### PR TITLE
[RFC] Make all exception throwing happen from a single function

### DIFF
--- a/include/tc/core/utils/error.h
+++ b/include/tc/core/utils/error.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <string>
+
+namespace tc {
+template <typename ErrType>
+void reportError(const std::string& s) {
+  throw ErrType(s);
+}
+} // namespace tc


### PR DESCRIPTION
There is (will be) interest in using the polyhedral mapper standalone but without exceptions enabled. If am not mistaken currently all thrown exceptions are not caught and/or recovered from inside the mapper, they are essentially reporting errors. One non-intrusive way to hide exceptions and switch to, say, `std::abort` + message if the code is compiled with `-fno-exceptions`  is to use something like `reportError` of this commit. 

There's still the issue of isl bindings with and without exceptions. So this is obviously not a general solutions. Also there are `CHECK` macros throughout the code but maybe there's an easy solution like redefining `CHECK`. 

In addition, are we passing any exception throwing callbacks to isl? And how deep is the dependence on exceptions thrown by the isl bindings? In general do you think it is actually possible to replace throwing exceptions with `throw-if-exceptions-are-enabled-else-abort` or is it impossible without significant changes?