### PR TITLE
Avoid reconstructing HalideComponents from TC lang

### DIFF
--- a/src/core/tc_executor.cc
+++ b/src/core/tc_executor.cc
@@ -287,7 +287,7 @@ std::vector<int> narrowParamsVector(const std::vector<long>& params) {
 void TcExecutor::compileWithTcMapper() {
   // A bit chicken-and-eggy, need scop from TC to have the space to build the
   // context to specialize the scop..
-  auto scopTmp = polyhedral::Scop::makeScop(ctx_, tcTree_);
+  auto scopTmp = polyhedral::Scop::makeScop(ctx_, halideComponents_);
   auto globalParameterContext =
       scopTmp->makeContextFromInputs(extractRawPtrs(execInfo_.inputsInfo));
   scopTmp = polyhedral::Scop::makeSpecializedScop(


### PR DESCRIPTION
TcExecutor creates and holds an instance of HalideComponents in
constructor.  At the same time, in "compile" call, it passes unparsed TC
string to makeScop.  The latter creates a new instance of
HalideComponents internally, which leads to inference warnings being
emitted twice.  Use makeScop overload that takes HalideComponents
instead to avoid double parsing and analysis.