### PR TITLE
Implement where clause variables and exists

### DIFF
--- a/include/tc/core/libraries.h
+++ b/include/tc/core/libraries.h
@@ -140,6 +140,7 @@ constexpr auto boundsAsTemplate = R"C(
 template<typename T> inline __device__ T floord(T n, T d) {
   return n < 0 ? - (-n + d - 1)/d : n / d;
 }
+#define if_then_else(cond,a,b) (cond) ? (a) : (b);
 )C";
 } // namespace cpp
 

--- a/include/tc/lang/lexer.h
+++ b/include/tc/lang/lexer.h
@@ -77,9 +77,15 @@ namespace lang {
   _(TK_UINT64, "uint64", "uint64")               \
   _(TK_BOOL, "bool", "bool")                     \
   _(TK_CAST, "cast", "")                         \
-  _(TK_IN, "in", "in")
+  _(TK_IN, "in", "in")                           \
+  _(TK_GE, "ge", ">=")                           \
+  _(TK_LE, "le", "<=")                           \
+  _(TK_EQ, "eq", "==")                           \
+  _(TK_NE, "neq", "!=")                          \
+  _(TK_AND, "and", "&&")                         \
+  _(TK_OR, "or", "||")
 
-static const char* valid_single_char_tokens = "+-*/()[]?:,={}>";
+static const char* valid_single_char_tokens = "+-*/()[]?:,={}><!";
 
 enum TokenKind {
   // we use characters to represent themselves so skip all valid characters
@@ -121,11 +127,14 @@ struct SharedParserData {
     // listed in increasing order of precedence
     std::vector<std::vector<int>> binary_ops = {
         {'?'},
+        {TK_OR},
+        {TK_AND},
+        {'>', '<', TK_LE, TK_GE, TK_EQ, TK_NE},
         {'+', '-'},
         {'*', '/'},
     };
     std::vector<std::vector<int>> unary_ops = {
-        {'-'},
+        {'-', '!'},
     };
 
     std::stringstream ss;

--- a/include/tc/lang/lexer.h
+++ b/include/tc/lang/lexer.h
@@ -83,7 +83,9 @@ namespace lang {
   _(TK_EQ, "eq", "==")                           \
   _(TK_NE, "neq", "!=")                          \
   _(TK_AND, "and", "&&")                         \
-  _(TK_OR, "or", "||")
+  _(TK_OR, "or", "||")                           \
+  _(TK_LET, "let", "")                           \
+  _(TK_EXISTS, "exists", "exists")
 
 static const char* valid_single_char_tokens = "+-*/()[]?:,={}><!";
 
@@ -380,9 +382,20 @@ struct Lexer {
     next();
     return true;
   }
+  Token lookahead() {
+    if (!lookahead_) {
+      lookahead_.reset(new Token(lex()));
+    }
+    return *lookahead_;
+  }
   Token next() {
     auto r = cur_;
-    cur_ = lex();
+    if (lookahead_) {
+      cur_ = *lookahead_;
+      lookahead_.reset();
+    } else {
+      cur_ = lex();
+    }
     return r;
   }
   void reportError(const std::string& what, const Token& t);
@@ -416,6 +429,7 @@ struct Lexer {
   }
   size_t pos;
   Token cur_;
+  std::unique_ptr<Token> lookahead_;
   SharedParserData& shared;
 };
 } // namespace lang

--- a/include/tc/lang/parser.h
+++ b/include/tc/lang/parser.h
@@ -149,6 +149,24 @@ struct Parser {
     auto r = parseExp();
     return RangeConstraint::create(id->range(), id, l, r);
   }
+  TreeRef parseLetBinding() {
+    auto ident = parseIdent();
+    L.expect('=');
+    auto exp = parseExp();
+    return Let::create(ident->range(), ident, exp);
+  }
+  TreeRef parseWhereClause() {
+    auto lookahead = L.lookahead();
+    if (lookahead.kind == '=') {
+      return parseLetBinding();
+    } else if (lookahead.kind == TK_IN) {
+      return parseRangeConstraint();
+    } else {
+      auto exp = parseExp();
+      L.expect(TK_EXISTS);
+      return Exists::create(exp->range(), {exp});
+    }
+  }
   TreeRef parseParam() {
     if (L.cur().kind == TK_IDENT) {
       auto ident = parseIdent();
@@ -159,10 +177,9 @@ struct Parser {
     auto ident = parseIdent();
     return Param::create(typ->range(), ident, typ);
   }
-  TreeRef parseRangeConstraints() {
+  TreeRef parseWhereClauses() {
     if (L.nextIf(TK_WHERE)) {
-      return parseNonEmptyList(
-          ',', [&](int i) { return parseRangeConstraint(); });
+      return parseNonEmptyList(',', [&](int i) { return parseWhereClause(); });
     }
     return List::create(L.cur().range, {});
   }
@@ -200,7 +217,7 @@ struct Parser {
     auto assign = parseAssignment();
     auto rhs = parseExp();
     TreeRef equivalent_statement = parseEquivalent();
-    TreeRef range_statements = parseRangeConstraints();
+    TreeRef range_statements = parseWhereClauses();
     TreeRef empty_reduction_variables = c(TK_LIST, ident->range(), {});
     return Comprehension::create(
         ident->range(),

--- a/include/tc/lang/sema.h
+++ b/include/tc/lang/sema.h
@@ -204,6 +204,17 @@ struct Sema {
     expectBool(exp, typeOfExpr(exp)->kind());
     return exp;
   }
+  TreeRef lookupVarOrCreateIndex(Ident ident) {
+    TreeRef type = lookup(ident, false);
+    if (!type) {
+      // variable exp is not defined, so a reduction variable is created
+      // a reduction variable index i
+      type = indexType(ident);
+      insert(index_env, ident, type, true);
+      reduction_variables.push_back(ident);
+    }
+    return type;
+  }
   TreeRef checkExp(TreeRef exp, bool allow_access) {
     switch (exp->kind()) {
       case TK_APPLY: {
@@ -250,14 +261,7 @@ struct Sema {
       } break;
       case TK_IDENT: {
         auto ident = Ident(exp);
-        TreeRef type = lookup(ident, false);
-        if (!type) {
-          // variable exp is not defined, so a reduction variable is created
-          // a reduction variable index i
-          type = indexType(exp);
-          insert(index_env, ident, type, true);
-          reduction_variables.push_back(exp);
-        }
+        auto type = lookupVarOrCreateIndex(ident);
         if (type->kind() == TK_TENSOR_TYPE) {
           auto tt = TensorType(type);
           if (tt.dims().size() != 0) {
@@ -397,6 +401,33 @@ struct Sema {
     }
     return List::create(list->range(), std::move(r));
   }
+  TreeRef checkRangeConstraint(RangeConstraint rc) {
+    // RCs are checked _before_ the rhs of the TC, so
+    // it is possible the index is not in the environment yet
+    // calling lookupOrCreate ensures it exists
+    lookupVarOrCreateIndex(rc.ident());
+    // calling looking directly in the index_env ensures that
+    // we are actually constraining an index and not some other variable
+    lookup(index_env, rc.ident(), true);
+    auto s = expectIntegral(checkExp(rc.start(), false));
+    auto e = expectIntegral(checkExp(rc.end(), false));
+    return RangeConstraint::create(rc.range(), rc.ident(), s, e);
+  }
+  TreeRef checkLet(Let l) {
+    auto rhs = checkExp(l.rhs(), true);
+    insert(let_env, l.name(), typeOfExpr(rhs), true);
+    return Let::create(l.range(), l.name(), rhs);
+  }
+  TreeRef checkWhereClause(TreeRef ref) {
+    if (ref->kind() == TK_LET) {
+      return checkLet(Let(ref));
+    } else if (ref->kind() == TK_EXISTS) {
+      auto exp = checkExp(Exists(ref).exp(), true);
+      return Exists::create(ref->range(), exp);
+    } else {
+      return checkRangeConstraint(RangeConstraint(ref));
+    }
+  }
   TreeRef checkStmt(TreeRef stmt_) {
     auto stmt = Comprehension(stmt_);
 
@@ -416,6 +447,11 @@ struct Sema {
           Ident::create(stmt.range(), name + "." + std::to_string(i));
       output_indices.push_back(new_var);
     }
+
+    // where clauses are checked _before_ the rhs because they
+    // introduce let bindings that are in scope for the rhs
+    auto where_clauses_ = stmt.whereClauses().map(
+        [&](const TreeRef& rc) { return checkWhereClause(rc); });
 
     TreeRef rhs_ = checkExp(stmt.rhs(), true);
     TreeRef scalar_type = typeOfExpr(rhs_);
@@ -451,14 +487,6 @@ struct Sema {
     // if we redefined an input, it is no longer valid for range expressions
     live_input_names.erase(stmt.ident().name());
 
-    auto range_constraints =
-        stmt.rangeConstraints().map([&](const RangeConstraint& rc) {
-          lookup(index_env, rc.ident(), true);
-          auto s = expectIntegral(checkExp(rc.start(), false));
-          auto e = expectIntegral(checkExp(rc.end(), false));
-          return RangeConstraint::create(rc.range(), rc.ident(), s, e);
-        });
-
     auto equivalent_statement_ =
         stmt.equivalent().map([&](const Equivalent& eq) {
           auto indices_ = eq.accesses().map(
@@ -489,10 +517,13 @@ struct Sema {
         stmt.indices(),
         stmt.assignment(),
         rhs_,
-        range_constraints,
+        where_clauses_,
         equivalent_statement_,
         reduction_variable_list);
+    // clear the per-statement environments to get ready for the next statement
     index_env.clear();
+    let_env.clear();
+
     return result;
   }
   bool isNotInplace(const TreeRef& assignment) {
@@ -539,6 +570,8 @@ struct Sema {
   TreeRef lookup(const Ident& ident, bool required) {
     TreeRef v = lookup(index_env, ident, false);
     if (!v)
+      v = lookup(let_env, ident, false);
+    if (!v)
       v = lookup(env, ident, required);
     return v;
   }
@@ -560,6 +593,7 @@ struct Sema {
 
   std::vector<TreeRef> reduction_variables; // per-statement
   Env index_env; // per-statement
+  Env let_env; // per-statement, used for where i = <exp>
 
   Env env; // name -> type
   Env annotated_output_types; // name -> type, for all annotated returns types

--- a/include/tc/lang/tree.h
+++ b/include/tc/lang/tree.h
@@ -75,34 +75,19 @@ struct Tree : std::enable_shared_from_this<Tree> {
   virtual TreeRef map(std::function<TreeRef(TreeRef)> fn) {
     return shared_from_this();
   }
-  template <typename... Args>
-  void match(int k, Args&... args) {
-    matchD(k, "unknown", 0, args...);
+  void expect(int k) {
+    expect(k, trees().size());
   }
-  template <typename... Args>
-  void matchD(int k, const char* filename, int lineno, Args&... args) {
-    if (kind() != k) {
+  void expect(int k, int numsubtrees) {
+    if (kind() != k || trees().size() != numsubtrees) {
       std::stringstream ss;
-      ss << filename << ":" << lineno << ": expecting kind '" << kindToString(k)
-         << "' but found '" << kind() << "'\n";
+      ss << "expected kind '" << kindToString(k) << "' with " << numsubtrees
+         << " subtrees but found '" << kindToString(kind()) << "' with "
+         << trees().size() << " subtrees.\n";
       range().highlight(ss);
       throw std::runtime_error(ss.str());
     }
-    std::initializer_list<TreeRef*> vars = {&args...};
-    if (vars.size() > trees().size()) {
-      std::stringstream ss;
-      ss << filename << ":" << lineno << ": trying to match " << vars.size()
-         << " variables against " << trees().size() << " values in list.\n";
-      range().highlight(ss);
-      throw std::runtime_error(ss.str());
-    }
-    size_t i = 0;
-    for (TreeRef* v : vars) {
-      *v = trees()[i++];
-    }
   }
-
- private:
   int kind_;
 };
 

--- a/src/core/tc2halide.cc
+++ b/src/core/tc2halide.cc
@@ -162,6 +162,24 @@ Expr translateExpr(
           {cond, true_val, false_val},
           Call::Intrinsic);
     }
+    case lang::TK_EQ:
+      return t(0) == t(1);
+    case lang::TK_NE:
+      return t(0) != t(1);
+    case lang::TK_LE:
+      return t(0) <= t(1);
+    case lang::TK_GE:
+      return t(0) >= t(1);
+    case '<':
+      return t(0) < t(1);
+    case '>':
+      return t(0) > t(1);
+    case '!':
+      return !t(0);
+    case lang::TK_AND:
+      return t(0) && t(1);
+    case lang::TK_OR:
+      return t(0) || t(1);
     case lang::TK_BUILT_IN: {
       auto b = lang::BuiltIn(expr);
       vector<Expr> exprs;

--- a/test/test_corner_cases.cc
+++ b/test/test_corner_cases.cc
@@ -175,6 +175,46 @@ TEST(FailTest, DISABLED_E14) {
       {I(10)});
 }
 
+TEST(FailTest, E15){
+#define GEN_COMPARATOR(op)                                       \
+  {                                                              \
+    auto a = F();                                                \
+    auto b = F();                                                \
+    auto c = F(1);                                               \
+    Succeed(                                                     \
+        "def f(float a, float b) -> (c) { c(i) = float(a " #op   \
+        " b) where i in 0:1 }",                                  \
+        {a, b},                                                  \
+        {c});                                                    \
+    auto r = at::Scalar(a).toFloat() op at::Scalar(b).toFloat(); \
+    CHECK_EQ(r, at::Scalar(c[0]).toFloat());                     \
+  }
+
+    GEN_COMPARATOR(<=) GEN_COMPARATOR(>=) GEN_COMPARATOR(==) GEN_COMPARATOR(!=)
+        GEN_COMPARATOR(<) GEN_COMPARATOR(>)
+
+}
+
+TEST(FailTest, E16) {
+#define GEN_BOOLS(op)                                                         \
+  {                                                                           \
+    auto a = F();                                                             \
+    auto b = F();                                                             \
+    auto c = F(1);                                                            \
+    Succeed(                                                                  \
+        "def f(float a, float b) -> (c) { c(i) = float(!(a < .5) " #op        \
+        " b > .5) where i in 0:1 }",                                          \
+        {a, b},                                                               \
+        {c});                                                                 \
+    auto r = !(at::Scalar(a).toFloat() < .5) op at::Scalar(b).toFloat() > .5; \
+    ;                                                                         \
+    CHECK_EQ(r, at::Scalar(c[0]).toFloat());                                  \
+  }
+
+  GEN_BOOLS(||)
+  GEN_BOOLS(&&)
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/test/test_corner_cases.cc
+++ b/test/test_corner_cases.cc
@@ -195,7 +195,7 @@ TEST(FailTest, E15){
 
 }
 
-TEST(FailTest, E16) {
+TEST(FailTest, E16){
 #define GEN_BOOLS(op)                                                         \
   {                                                                           \
     auto a = F();                                                             \
@@ -211,8 +211,28 @@ TEST(FailTest, E16) {
     CHECK_EQ(r, at::Scalar(c[0]).toFloat());                                  \
   }
 
-  GEN_BOOLS(||)
-  GEN_BOOLS(&&)
+    GEN_BOOLS(||) GEN_BOOLS(&&)}
+
+TEST(FailTest, E17) {
+  auto r = F(1);
+  Succeed(
+      "def f(float(1) a) -> (b) { b(i) = 4.0 where a(i) exists }", {F(1)}, {r});
+  CHECK_EQ(at::Scalar(r[0]).toFloat(), 4);
+}
+
+TEST(FailTest, E18) {
+  auto a = F(1);
+  auto r = F(1);
+  Succeed(
+      "def f(float(1) a) -> (b) { b(i) = 2*foo where foo = a(i) }", {a}, {r});
+  CHECK_EQ(at::Scalar(r[0]).toFloat(), at::Scalar(a[0]).toFloat() * 2);
+}
+TEST(FailTest, E19) {
+  Fail(
+      "undefined variable",
+      "def f(float(1) a) -> (b) { b(i) = 2*foo where foo = a(i), foo in 1:2 }",
+      {F(1)},
+      {F(1)});
 }
 
 int main(int argc, char** argv) {

--- a/test/test_execution_engine.cc
+++ b/test/test_execution_engine.cc
@@ -45,7 +45,7 @@ struct ATenCompilationUnitTest : public ::testing::Test {
   }
 };
 
-TEST_F(ATenCompilationUnitTest, DISABLED_Concat) {
+TEST_F(ATenCompilationUnitTest, Concat) {
   at::Tensor a = at::CUDA(at::kFloat).rand({32, 16});
   at::Tensor b = at::CUDA(at::kFloat).rand({32, 16});
   std::vector<at::Tensor> inputs = {a, b};
@@ -53,7 +53,7 @@ TEST_F(ATenCompilationUnitTest, DISABLED_Concat) {
 
   Check(
       R"(
-      def concat(float(M, N) A, float(M, N) B) -> (O1, O2) {
+      def concat(float(M, N) A, float(M, N) B) -> (O1) {
         O1(n, i, m) = i == 0 ? A(m, n) : B(m, n) where i in 0:2
       }
     )",

--- a/test/test_lang.cc
+++ b/test/test_lang.cc
@@ -200,9 +200,8 @@ int main(int argc, char** argv) {
     std::stringstream ss;
     bar->range().highlight(ss);
     assertEqual("lexer2.expected", ss.str());
-    TreeRef sss;
-    s->matchD(TK_CONST, "file.h", 3, sss);
-    assert(sss->stringValue() == "min");
+    s->expect(TK_CONST, 1);
+    ASSERT(s->tree(0)->stringValue() == "min");
   }
   {
     std::string stuff = "-3+4*5+7-a";


### PR DESCRIPTION
This adds two things to where clauses:

Exists clauses are looked at in range inference but are not actually
evaluated. This allows you make things that are similarly sized to
another tensor (and will work well with the pad() operator once we
finish it):

  a(i) = 0
  where b(i) exists

Let clauses allow you to declare temporary variables whose scope
is only for the local comprehensions:

  a(i) = foo + foo*foo
  where foo = b(i)

This commit also includes a simplification of TreeView objects that
I back ported from pytorch that makes adding new tree views less
verbose.

This PR also includes the backported changes to add comparison ops, because they edit similar code and would cause merge problems if done separately.