### PR TITLE
fix typo in introduction.rst

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -24,12 +24,12 @@ Let's start with a simple example is a matrix vector product:
 .. code::
 
     def mv(float(R,C) A, float(C) x) -> (o) {
-      o(i) += A(i,j) * b(j)
+      o(i) += A(i,j) * x(j)
     }
 
 :code:`A` and :code:`x` are input tensors. :code:`o` is an output tensor.
-The statement :code:`o(i) += A(i,j)*b(j)` introduces two index variables :code:`i` and :code:`j`.
-Their range is inferred by their use indexing :code:`A` and :code:`b`. :code:`i = [0,R)`, :code:`j = [0,C)`.
+The statement :code:`o(i) += A(i,j)*x(j)` introduces two index variables :code:`i` and :code:`j`.
+Their range is inferred by their use indexing :code:`A` and :code:`x`. :code:`i = [0,R)`, :code:`j = [0,C)`.
 Because :code:`j` only appears on the right side,
 stores into :code:`o` will reduce over :code:`j` with the reduction specified for the loop.
 Reductions can occur across multiple variables, but they all share the same kind of associative reduction (e.g. :code:`+=`)
@@ -40,7 +40,7 @@ to maintain invariant (3). :code:`mv` computes the same thing as this C++ loop:
     for(int i = 0; i < R; i++) {
       o(i) = 0.0f;
       for(int j = 0; j < C; j++) {
-        o(i) += A(i,j) * b(j);
+        o(i) += A(i,j) * x(j);
       }
     }
 
@@ -57,7 +57,7 @@ Simple matrix-vector
 .. code::
 
     def mv(float(R,C) A, float(C) x) -> (o) {
-      o(i) += A(i,j) * b(j)
+      o(i) += A(i,j) * x(j)
     }
 
 Simple matrix-multiply


### PR DESCRIPTION
in Docs: Let’s start with a simple example is a matrix vector product:
def mv(float(R,C) A, float(C) x) -> (o) {
o(i) += A(i,j) * b(j)
}

should be:
o(i) += A(i,j) *x(j)