### PR TITLE
.gitsubmodule paths and instructions for cloning should be https not ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 # Development branches, we modify those heavily
 [submodule "third-party/islpp"]
 	path = third-party/islpp
-	url = git@github.com:nicolasvasilache/isl.git
+	url = https://github.com/nicolasvasilache/isl.git
 	branch = ntv_dev
 [submodule "third-party/cub"]
 	path = third-party/cub
-        url = git@github.com:nicolasvasilache/cub.git
+        url = https://github.com/nicolasvasilache/cub.git
 	branch = nvrtc-cub
 [submodule "third-party/halide"]
 	path = third-party/halide
@@ -14,7 +14,7 @@
 # Mainstream branches, we don't modify those
 [submodule "third-party/caffe2"]
 	path = third-party/caffe2
-	url = git@github.com:caffe2/caffe2.git
+	url = https://github.com/caffe2/caffe2.git
 [submodule "third-party/gflags"]
 	path = third-party/gflags
 	url = https://github.com/gflags/gflags
@@ -23,7 +23,7 @@
 	url = https://github.com/google/glog.git
 [submodule "third-party/ATen"]
 	path = third-party/ATen
-	url = git@github.com:zdevito/aten.git
+	url = https://github.com/zdevito/aten.git
 [submodule "third-party/dlpack"]
 	path = third-party/dlpack
 	url = https://github.com/dmlc/dlpack.git

--- a/docs/source/installation_conda.rst
+++ b/docs/source/installation_conda.rst
@@ -176,7 +176,7 @@ Now, you need to install TC from source. For installing TC from source, checkout
 
 .. code-block:: bash
 
-    $ cd $HOME && git clone git@github.com:facebookresearch/TensorComprehensions.git --recursive
+    $ cd $HOME && git clone https://github.com/facebookresearch/TensorComprehensions.git --recursive
     $ cd TensorComprehensions
     $ git submodule update --init --recursive
     $ conda install -y pyyaml

--- a/docs/source/installation_conda_dep.rst
+++ b/docs/source/installation_conda_dep.rst
@@ -144,7 +144,7 @@ conda packages of TC dependencies and then build TC.
     $ source activate tc-build-conda
     $ conda install -y -c prigoyal tapir50 llvm isl-tc gflags glog
     $ conda install -y -c pytorch pytorch
-    $ cd $HOME && git clone git@github.com:facebookresearch/TensorComprehensions.git --recursive
+    $ cd $HOME && git clone https://github.com/facebookresearch/TensorComprehensions.git --recursive
     $ cd TensorComprehensions
     $ git submodule update --init --recursive
     $ BUILD_TYPE=Release INSTALL_PREFIX=$CONDA_PREFIX WITH_CAFFE2=OFF CLANG_PREFIX=$(llvm-config --prefix) ./build.sh --all

--- a/docs/source/installation_non_conda.rst
+++ b/docs/source/installation_non_conda.rst
@@ -154,7 +154,7 @@ TC from source, checkout the TensorComprehensions repo and run the following com
 
 .. code-block:: bash
 
-    $ cd $HOME && git clone git@github.com:facebookresearch/TensorComprehensions.git --recursive
+    $ cd $HOME && git clone https://github.com/facebookresearch/TensorComprehensions.git --recursive
     $ cd TensorComprehensions
     $ git submodule update --init --recursive
     $ export TC_DIR=$(pwd)


### PR DESCRIPTION
Running `git clone git@github.com:facebookresearch/TensorComprehensions.git --recursive` outputs

```
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Same output for submodules.

Using `https` to clone and link submodules circumvents this annoyance.