### PR TITLE
Add cilk runtime to docker images

### DIFF
--- a/docker/linux-trusty-gcc4.8-tapir5.0/Dockerfile
+++ b/docker/linux-trusty-gcc4.8-tapir5.0/Dockerfile
@@ -4,9 +4,11 @@ FROM tensorcomprehensions/linux-trusty:${BUILD_ID}
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
+RUN apt-get install -y --no-install-recommends vim
 
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update
+RUN apt-get install -y --no-install-recommends libcilkrts5
 RUN apt-get install -y --no-install-recommends gcc-4.8 g++-4.8
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
 RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50

--- a/docker/linux-xenial-gcc5-tapir5.0/Dockerfile
+++ b/docker/linux-xenial-gcc5-tapir5.0/Dockerfile
@@ -4,6 +4,7 @@ FROM tensorcomprehensions/linux-xenial:${BUILD_ID}
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
+RUN apt-get install -y --no-install-recommends vim
 
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update


### PR DESCRIPTION
1404 images didn't have cilk runtime and this was blocking @wsmoses PR. building and uploading new images now.