### PR TITLE
Fix extractAccess to process each IRNode once

### DIFF
--- a/src/core/halide2isl.cc
+++ b/src/core/halide2isl.cc
@@ -185,11 +185,11 @@ isl::map extractAccess(
 
 std::pair<isl::union_map, isl::union_map>
 extractAccesses(isl::set domain, const Stmt& s, AccessMap* accesses) {
-  class FindAccesses : public IRVisitor {
-    using IRVisitor::visit;
+  class FindAccesses : public IRGraphVisitor {
+    using IRGraphVisitor::visit;
 
     void visit(const Call* op) override {
-      IRVisitor::visit(op);
+      IRGraphVisitor::visit(op);
       if (op->call_type == Call::Halide || op->call_type == Call::Image) {
         reads = reads.unite(
             extractAccess(domain, op, op->name, op->args, accesses));
@@ -197,7 +197,7 @@ extractAccesses(isl::set domain, const Stmt& s, AccessMap* accesses) {
     }
 
     void visit(const Provide* op) override {
-      IRVisitor::visit(op);
+      IRGraphVisitor::visit(op);
       writes =
           writes.unite(extractAccess(domain, op, op->name, op->args, accesses));
     }

--- a/test/test_tc_mapper_bugs.cc
+++ b/test/test_tc_mapper_bugs.cc
@@ -658,6 +658,43 @@ TEST_F(TMM_128_1024_1024, Tightening) {
   Check(options);
 }
 
+TEST(LayerNorm, BugReferenceBelongsToTwoGroups) {
+  at::Tensor mat1 = at::CUDA(at::kFloat).rand({7, 32, 64});
+  std::vector<at::Tensor> inputs = {mat1};
+  std::vector<at::Tensor> outputs;
+
+  static constexpr auto TC = R"TC(
+    def layernorm(float(T, B, C) I) -> (O, mean, centered, var) {
+       mean(t, b) +=! I(t, b, c) / C
+       centered(t, b, c) = I(t, b, c) - mean(t, b)
+       var(t, b) +=! centered(t, b, c) * centered(t, b, c)
+       var(t, b) = (var(t, b)) / C
+       O(t, b, c) = centered(t, b, c) / rsqrt(var(t, b))
+    }
+  )TC";
+  auto options = tc::MappingOptions::makeNaiveMappingOptions()
+                     .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
+                     .outerScheduleAllowSkewing(false)
+                     .outerSchedulePositiveOrthant(true)
+                     .intraTileScheduleFusionStrategy(
+                         tc::FusionStrategy::Preserve3Coincident)
+                     .intraTileScheduleAllowSkewing(false)
+                     .intraTileSchedulePositiveOrthant(true)
+                     .tile(4, 16)
+                     .mapToThreads(64)
+                     .mapToBlocks(128, 32, 4)
+                     .unroll(2)
+                     .tileImperfectlyNested(false)
+                     .useSharedMemory(true)
+                     .usePrivateMemory(true)
+                     .unrollCopyShared(false)
+                     .matchLibraryCalls(false);
+
+  tc::ATenCompilationUnit atCompl;
+  atCompl.define(TC);
+  EXPECT_DEATH(atCompl.compile("layernorm", inputs, options));
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/test/test_tc_mapper_bugs.cc
+++ b/test/test_tc_mapper_bugs.cc
@@ -658,7 +658,7 @@ TEST_F(TMM_128_1024_1024, Tightening) {
   Check(options);
 }
 
-TEST(LayerNorm, BugReferenceBelongsToTwoGroups) {
+TEST(LayerNorm, ReferenceBelongsToTwoGroups) {
   at::Tensor mat1 = at::CUDA(at::kFloat).rand({7, 32, 64});
   std::vector<at::Tensor> inputs = {mat1};
   std::vector<at::Tensor> outputs;
@@ -692,7 +692,8 @@ TEST(LayerNorm, BugReferenceBelongsToTwoGroups) {
 
   tc::ATenCompilationUnit atCompl;
   atCompl.define(TC);
-  EXPECT_DEATH(atCompl.compile("layernorm", inputs, options));
+  // Expecting this to compile without dying.
+  atCompl.compile("layernorm", inputs, options);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
extractAccess introduces reference identifiers with sequential numbers
in the domain of the access relation it constructs.  The reference
idetifiers are stored in a map halide::IRNode->isl::id.  Assuming that
each IRNode is visited once by extractAccess, the sequential numbers are
obtained by querying the size of the map.  However, some IRNodes may be
visited more than once, for example, with let statement substitution.
Make FindAccesses visitor class, which class extractAccess on IRNodes,
inherit IRGraphVisitor instead of IRVisitor to ensure each IRNode is
visited once.

This fixes the problem that appeared in memory promotion when the same
reference identifier was attached to different tensor names.