### PR TITLE
Specify the cilk runtime path during configuration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,7 @@ CMAKE_VERSION=${CMAKE_VERSION:="`which cmake3 || which cmake`"}
 CAFFE2_BUILD_CACHE=${CAFFE2_BUILD_CACHE:=${TC_DIR}/third-party/.caffe2_build_cache}
 HALIDE_BUILD_CACHE=${HALIDE_BUILD_CACHE:=${TC_DIR}/third-party/.halide_build_cache}
 INSTALL_PREFIX=${INSTALL_PREFIX:=${TC_DIR}/third-party-install/}
+CILK_PATH=
 CC=${CC:="`which gcc`"}
 CXX=${CXX:="`which g++`"}
 
@@ -345,6 +346,7 @@ function install_tc() {
         -DPROTOBUF_PROTOC_EXECUTABLE=${PROTOC} \
         -DCLANG_PREFIX=${CLANG_PREFIX} \
         -DCUDNN_ROOT_DIR=${CUDNN_ROOT_DIR} \
+        -DCILK_PATH=${CILK_PATH} \
         -DCMAKE_C_COMPILER=${CC} \
         -DCMAKE_CXX_COMPILER=${CXX} .. || exit 1
   fi

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(polyhedral)
+
 find_library(CUDA_NVRTC_LIBRARIES nvrtc
   PATHS ${CUDA_TOOLKIT_ROOT_DIR}
   PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs)
@@ -41,6 +43,7 @@ add_library(
   polyhedral/separation.cc
   polyhedral/tighten_launch_bounds.cc
   polyhedral/unroll.cc
+  ${CMAKE_CURRENT_BINARY_DIR}/polyhedral/libpaths.cc
 )
 
 target_include_directories(tc_core PUBLIC ${PROJECT_SOURCE_DIR}/include ${LLVM_INCLUDE_DIRS})

--- a/src/core/polyhedral/CMakeLists.txt
+++ b/src/core/polyhedral/CMakeLists.txt
@@ -1,5 +1,5 @@
-IF(DEFINED CILK_PATH)
-    message(STATUS "Using: "${CILK_PATH}) 
+IF(DEFINED CILK_PATH AND NOT ${CILK_PATH} STREQUAL "")
+    message(STATUS "Using: " ${CILK_PATH}) 
 ELSE()
     message(FATAL_ERROR "Please specify the full path to libcilkrts.so with -DCILK_PATH=...") 
 ENDIF()

--- a/src/core/polyhedral/CMakeLists.txt
+++ b/src/core/polyhedral/CMakeLists.txt
@@ -1,0 +1,8 @@
+IF(DEFINED CILK_PATH)
+    message(STATUS "Using: "${CILK_PATH}) 
+ELSE()
+    message(FATAL_ERROR "Please specify the full path to libcilkrts.so with -DCILK_PATH=...") 
+ENDIF()
+
+SET(CILK_PATH ${CILK_PATH})
+configure_file(libpaths.cc.in libpaths.cc)

--- a/src/core/polyhedral/libpaths.cc.in
+++ b/src/core/polyhedral/libpaths.cc.in
@@ -1,0 +1,1 @@
+const char* libcilkPath = "@CILK_PATH@";


### PR DESCRIPTION
Addresses #49 

It is not a _proper_ solution since:
- the path has to be specified manually
- I do not know a good default for `build.sh`
- most importantly, pre-built binaries depend on `libcilkrts.so` residing on a fixed path