### PR TITLE
cmake: use HINTS instead of PATHS to prefer custom gflags and glog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,8 +215,8 @@ include(cmake/GetGitRevisionDescription.cmake)
 ################################################################################
 
 # gflags
-message("find_library(GFLAGS_LIBRARIES gflags")
-find_library(GFLAGS_LIBRARIES gflags PATHS ${CMAKE_INSTALL_PREFIX} PATH_SUFFIXES lib lib64)
+message("Looking for gflags...")
+find_library(GFLAGS_LIBRARIES gflags HINTS ${CMAKE_INSTALL_PREFIX} PATH_SUFFIXES lib lib64)
 message(STATUS "Found gflags: ${GFLAGS_LIBRARIES}")
 
 # glog
@@ -227,7 +227,7 @@ if (WITH_CAFFE2)
   add_definitions(-DCAFFE2_USE_GOOGLE_GLOG)
 endif()
 
-find_library(GLOG_LIBRARIES glog PATHS ${CMAKE_INSTALL_PREFIX} PATH_SUFFIXES lib lib64)
+find_library(GLOG_LIBRARIES glog HINTS ${CMAKE_INSTALL_PREFIX} PATH_SUFFIXES lib lib64)
 message(STATUS "Found glog: ${GLOG_LIBRARIES}")
 
 # Uncomment for debugging all the CMake variables


### PR DESCRIPTION
Root CMakeLists.txt was using PATHS in find_library call for gflags and
glog.  In this case, cmake looks in system paths _first_, before looking
at whatever is passed in PATHS, so it selects system versions of glog
and gflags.  HINTS are inspected _before_ system paths and our
installations of glog and gflags will be found, if installed, before the
system ones.