### PR TITLE
Cleanly handle SIGINT for autotuner and add layernorm test

### DIFF
--- a/include/tc/autotuner/genetic_tuning_harness.h
+++ b/include/tc/autotuner/genetic_tuning_harness.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <atomic>
+#include <csignal>
 #include <deque>
 #include <memory>
 #include <unordered_map>
@@ -30,6 +31,9 @@
 namespace tc {
 namespace autotune {
 namespace detail {
+
+extern volatile std::sig_atomic_t signal_;
+extern volatile std::sig_atomic_t killRequested_;
 
 class GeneticTunerHarness {
  public:

--- a/include/tc/library/dper_lut_concat.h
+++ b/include/tc/library/dper_lut_concat.h
@@ -20,7 +20,7 @@ namespace tc {
 constexpr static auto TC_DPER_LUT_CONCAT_NAME = "dper_lut_concat";
 
 constexpr static auto TC_DPER_LUT_CONCAT = R"TC(
-  def dper_lut_concat(float(B, M) I1, int(B, L1) I2, int(B, L2) I3, float(N, M) W1, float(N) B1, float(E1, D) LUT1, float(E2, D) LUT2) -> (O1, O2, O3) {
+  def dper_lut_concat(float(B, M) I1, int32(B, L1) I2, int32(B, L2) I3, float(N, M) W1, float(N) B1, float(E1, D) LUT1, float(E2, D) LUT2) -> (O1, O2, O3) {
     O1(b, n) +=! I1(b, m) * W1(n, m)
     O1(b, n) = O1(b, n) + B1(n)
     O2(i, j) +=! LUT1(I2(i, k), j)

--- a/src/autotuner/genetic_tuning_harness.cc
+++ b/src/autotuner/genetic_tuning_harness.cc
@@ -40,6 +40,9 @@ namespace tc {
 namespace autotune {
 namespace detail {
 
+volatile std::sig_atomic_t signal_ = 0;
+volatile std::sig_atomic_t killRequested_ = 0;
+
 GeneticTunerHarness::GeneticTunerHarness(
     size_t n,
     uint8_t crossoverRate,
@@ -98,7 +101,9 @@ GeneticTunerHarness::GeneticTunerHarness(
 
 void GeneticTunerHarness::run(size_t numGenerations) {
   for (size_t i = 0; i < numGenerations; ++i) {
-    runOneGeneration(i);
+    if (not killRequested_) {
+      runOneGeneration(i);
+    }
   }
 }
 

--- a/test/test_caffe2.cc
+++ b/test/test_caffe2.cc
@@ -671,7 +671,7 @@ TEST_F(Caffe2Test, DISABLED_TcGather) {
   Workspace w_test;
   init_ws(w_test);
   auto tc = R"TC(
-def fun(float(N) X, int(A,B) I) -> (Z) {
+def fun(float(N) X, int32(A,B) I) -> (Z) {
    Z(i,j) = X(I(i,j))
 }
 )TC";


### PR DESCRIPTION
bunch of backports - all in 1 PR to avoid bugging people to stamp things separately and there is time constraint

1. cleanly exit autotuner on SIGINT - rather than abort, throw the exception now
2. int -> int32 in few left out places
3. add a test for layernorm 

closes #55 