### PR TITLE
Python support via pybind currently can only work in CUDA mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,8 +246,16 @@ message(STATUS "Found glog: ${GLOG_LIBRARIES}")
 # endforeach()
 
 add_subdirectory(src)
+
+# At the moment pybind is only supported in CUDA mode and compilation fails
+# for non-CUDA mode (CUDA_HOME and CUB_HOME undefined error).
+# Once the core CPU mapper is stabilized we can worry about pybind, deactivate
+# conditionally for now
+if (WITH_CUDA)
+  add_subdirectory(tensor_comprehensions/pybinds)
+endif()
+
 enable_testing()
-add_subdirectory(tensor_comprehensions/pybinds)
 add_subdirectory(test)
 
 if (WITH_CAFFE2 AND WITH_CUDA)


### PR DESCRIPTION
But at the moment compilation is still triggered in non-CUDA mode which results in errors.

This PR deactivates the problematic compilation conditionally.

```
WITH_CUDA=0 CLANG_PREFIX=$($HOME/clang+llvm-tapir5.0/bin/llvm-config --prefix) ./build.sh --all && ./test.sh
```
now compiles and runs properly