### PR TITLE
codegen_llvm.cc: clean up getTensorSize

### DIFF
--- a/src/core/polyhedral/codegen_llvm.cc
+++ b/src/core/polyhedral/codegen_llvm.cc
@@ -113,22 +113,12 @@ int64_t islIdToInt(isl::ast_expr e, isl::set context) {
 }
 
 int64_t getTensorSize(isl::set context, const Halide::Expr& e) {
-  if (context.get_space().is_params()) {
-    context = context.from_params();
-  }
   // isl will take care of substituting parameter values if they are known and
   // simplifying the expression.
-  auto pwAff =
-      isl::pw_aff(halide2isl::makeIslAffFromExpr(context.get_space(), e));
-  pwAff = pwAff.intersect_params(context);
-  isl::PA pwAffs(pwAff);
-  CHECK_EQ(pwAffs.size(), 1);
-  isl::map m(pwAffs[0].second);
-  auto r = m.range();
-  r = r.project_out(isl::dim_type::param, 0, r.n_dim());
-  CHECK(r.is_singleton());
-  auto p = r.sample_point();
-  return toSInt(p.get_coordinate_val(isl::dim_type::out, 0));
+  auto aff = halide2isl::makeIslAffFromExpr(context.get_space(), e);
+  auto p = context.sample_point();
+  CHECK(context.is_equal(p));
+  return toSInt(aff.eval(p));
 }
 
 std::vector<int64_t> getTensorSizesWithoutLeadingDim(


### PR DESCRIPTION
There were several issues with the original implementation:
- inconsistent context space (turned into non-parameter set and
  then passed as argument to intersect_params)
- the code assumed that there is at least one parameter
- partial projection of parameters
- spurious checks

The new implementation uses the newly introduced isl_pw_aff_eval
to simplify the evaluation and implements a proper check that
the parameters have a fixed value.
