### PR TITLE
Make few things explicit - package distr and cuda() for tensors

### DIFF
--- a/docs/source/framework/pytorch_integration/autograd_with_tc.rst
+++ b/docs/source/framework/pytorch_integration/autograd_with_tc.rst
@@ -41,6 +41,13 @@ Examples
      out = convolution(I, W)
      out[0].sum().backward()
 
+.. note::
+
+    Please note the usage of :code:`.cuda()` i.e. tensor data is declared as the CUDA
+    type. Applying :code:`Variable` on the tensor data essentially allows the layer to be
+    part of computations graph and if :code:`Variable(torch.rand(), requires_grad=True).cuda()`
+    is done, then the grad will be available for the `Variable.cuda()` and not the actual `Variable/Tensor`.
+
 
 Specifying Mapping Options
 --------------------------

--- a/docs/source/framework/pytorch_integration/getting_started.rst
+++ b/docs/source/framework/pytorch_integration/getting_started.rst
@@ -28,8 +28,8 @@ to express their operations and bridge the gap between research and engineering.
 Installation
 ------------
 
-We provide :code:`conda` package for Tensor Comprehensions to quickly get started
-with using TC. Follow the steps below to install TC :code:`conda` package:
+We provide :code:`conda` package for Tensor Comprehensions (only :code:`linux-64` package)
+to quickly get started with using TC. Follow the steps below to install TC :code:`conda` package:
 
 **Step 1:** Setup Anaconda
 If you don't have Anaconda setup already, please follow the step :ref:`install_anaconda`.


### PR DESCRIPTION
1. make it explicit that conda package is linux-64, some people tried installing on osx-64
2. add a note about .cuda() placement. This is jankiness and suprising thing in pytorch but the next pytorch releases will have this corrected and better supported