### PR TITLE
Use database's langs instead of hardcoded lang

### DIFF
--- a/test_python/layers/test_absolute.py
+++ b/test_python/layers/test_absolute.py
@@ -23,12 +23,8 @@ import unittest
 class TestAbsolute(unittest.TestCase):
 
     def test_absolute(self):
-        LANG = """
-        def abs(float(M, N) A) -> (O1) {
-          O1(m, n) = fabs(A(m, n))
-        }
-        """
-        absolute = tc.define(LANG, name="abs")
+
+        absolute = tc.define(tc.database['abs']['lang'], name="abs")
         A = -1 * torch.randn(3, 4).cuda()
         out = absolute(A, options=tc.Options("pointwise"))
 


### PR DESCRIPTION
Hi, I found codes in `test_python/layers` use hard-coded langs. I think it is better to use `database`'s langs to test if they are correct. Is there any reason you do not use `database`'s langs? If not, I can change rest of test codes.