### PR TITLE
Make the warning explicit that its a warning

### DIFF
--- a/include/tc/lang/error_report.h
+++ b/include/tc/lang/error_report.h
@@ -43,7 +43,7 @@ struct ErrorReport : public std::exception {
 };
 
 inline void warn(const ErrorReport& err) {
-  std::cerr << err.what();
+  std::cerr << "WARNING: " << err.what();
 }
 
 template <typename T>


### PR DESCRIPTION
it confused a user that this was error and they made some changes in TC that  broke it.