### PR TITLE
[Hotfix] Temporarily make dump-cuda flag dump to cout

### DIFF
--- a/src/core/tc_executor.cc
+++ b/src/core/tc_executor.cc
@@ -302,7 +302,9 @@ void TcExecutor::compileWithTcMapper() {
   // that.
   std::tie(execInfo_.cudaSource, execInfo_.grid, execInfo_.block) =
       mappedScop->codegen(execInfo_.kernelSpecializedName);
-  LOG_IF(INFO, FLAGS_dump_cuda) << "generatedCuda: " << execInfo_.cudaSource;
+  if (FLAGS_dump_cuda) {
+    std::cout << "generatedCuda: " << execInfo_.cudaSource << std::endl;
+  }
 }
 
 Duration TcExecutor::run(


### PR DESCRIPTION
this changeset somehow was missed when I moved the pytorch integration code to this repo.

using env GLOG_logtostderr is also fine however people often run things in python interpreter where setting this env variable is not friendly, or is an extra non-convenient step.

making this change and will refresh things. users complained in the slack channel about it.