### PR TITLE
Bump isl for use of generated isl_id bindings

### DIFF
--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -227,9 +227,6 @@ struct Scop {
   }
 
   static bool isSyncId(isl::id id) {
-    if (!id.has_name()) {
-      return false;
-    }
     auto name = id.get_name();
     if (name.find(kSyncIdPrefix) != 0) {
       return false;

--- a/include/tc/external/detail/islpp.h
+++ b/include/tc/external/detail/islpp.h
@@ -259,9 +259,14 @@ struct UnionAsVector
 
 struct IslIdIslHash {
   size_t operator()(const isl::id& id) const {
-    return id.get_hash();
+    return isl_id_get_hash(id.get());
   }
 };
+
+inline bool operator==(const isl::id& id1, const isl::id& id2) {
+  // isl_id objects can be compared by pointer value.
+  return id1.get() == id2.get();
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Helper functions

--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -518,7 +518,6 @@ void Scop::reschedule(
 }
 
 const Halide::OutputImageParam& Scop::findArgument(isl::id id) const {
-  CHECK(id.has_name()) << "cannot lookup argument using nameless id";
   std::string name = id.get_name();
 
   for (const auto& i : halide.inputs) {


### PR DESCRIPTION
Calls to has_name can be removed because an isl::id is expected
to have been constructed by name.