### PR TITLE
Log exception rather than just passing

### DIFF
--- a/tensor_comprehensions/tc_unit.py
+++ b/tensor_comprehensions/tc_unit.py
@@ -204,7 +204,8 @@ class TcAutotuner(object):
         try:
             best_options = self.autotuner.tune(cache_file, tc_name, inputs, options, [options])
             return best_options
-        except RuntimeError:
+        except Exception as e:
+            logger.error('Raised exception: {}'.format(e))
             return options
 
     def autotune(self, *inputs, **kwargs):


### PR DESCRIPTION
show the error message explicitly, one user had wrong TC but we were not displaying the error message. 