### PR TITLE
[hotfix] Support min max bounds

### DIFF
--- a/test/test_tc_mapper_bugs.cc
+++ b/test/test_tc_mapper_bugs.cc
@@ -696,6 +696,27 @@ TEST(LayerNorm, ReferenceBelongsToTwoGroups) {
   atCompl.compile("layernorm", inputs, options);
 }
 
+// #124
+TEST(Halide2Isl, MinInUpperBound) {
+  at::Tensor mat1 = at::CUDA(at::kFloat).rand({1, 100, 184, 184});
+  at::Tensor mat1_pad = at::CUDA(at::kFloat).rand({1, 100, 186, 186});
+  at::Tensor mat2 = at::CUDA(at::kFloat).rand({3, 3});
+  std::vector<at::Tensor> inputs = {mat1, mat1_pad, mat2};
+
+  static constexpr auto TC = R"TC(
+    def graph2(float(N, C, H, W) I, float(N, C, R, T) J, float(KH, KW) W1) -> (O, Out) {
+        O(n, c, h, w) +=! J(n, c, h + kh, w + kw) * W1(kh, kw)
+        Out(i, j) +=! I(n, i, h, w) * O(n, j, h, w)
+    }
+  )TC";
+  auto options = tc::MappingOptions::makeNaiveMappingOptions();
+
+  tc::ATenCompilationUnit atCompl;
+  atCompl.define(TC);
+  EXPECT_THROW(
+      atCompl.compile("graph2", inputs, options), isl::exception_invalid);
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/test/test_tc_mapper_bugs.cc
+++ b/test/test_tc_mapper_bugs.cc
@@ -696,7 +696,6 @@ TEST(LayerNorm, ReferenceBelongsToTwoGroups) {
   atCompl.compile("layernorm", inputs, options);
 }
 
-// #124
 TEST(Halide2Isl, MinInUpperBound) {
   at::Tensor mat1 = at::CUDA(at::kFloat).rand({1, 100, 184, 184});
   at::Tensor mat1_pad = at::CUDA(at::kFloat).rand({1, 100, 186, 186});
@@ -713,8 +712,7 @@ TEST(Halide2Isl, MinInUpperBound) {
 
   tc::ATenCompilationUnit atCompl;
   atCompl.define(TC);
-  EXPECT_THROW(
-      atCompl.compile("graph2", inputs, options), isl::exception_invalid);
+  atCompl.compile("graph2", inputs, options);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Loop bounds inferred by Halide may involve min or max operations, which
are not convertible into affine functions.  For the sake of bound
computation, compute lists of affine functions by recursively
flattening arguments of nested min and max operations.  Use all
affine functions from a list to define loop bounds.  In particular,
allow min in upper bounds and max in lower bounds to exploit
```
  x < min(a, min(b, c)) <=> x < a and x < b and x < c,
  x > max(a, max(b, c)) <=> x > a and x > b and x > c
```
equivalences.  Do not allow other cases.

Closes #124 #125 