### PR TITLE
do not emit semicolon after if_then_else macro

### DIFF
--- a/include/tc/core/libraries.h
+++ b/include/tc/core/libraries.h
@@ -144,7 +144,7 @@ constexpr auto boundsAsTemplate = R"C(
 template<typename T> inline __device__ T floord(T n, T d) {
   return n < 0 ? - (-n + d - 1)/d : n / d;
 }
-#define if_then_else(cond,a,b) (cond) ? (a) : (b);
+#define if_then_else(cond,a,b) ((cond) ? (a) : (b))
 )C";
 } // namespace cpp
 


### PR DESCRIPTION
This macro can be used inside a larger expression and the semicolon
would appear before the end of statement.  Generally, it's a bad idea to
have semicolons in macros.

Closes #144 