### PR TITLE
Allow Jenkins to write to root conda env

### DIFF
--- a/docker/common/add_jenkins_user.sh
+++ b/docker/common/add_jenkins_user.sh
@@ -18,5 +18,11 @@ chown jenkins:jenkins /var/lib/jenkins/.ccache
 # Allow writing to /usr/local (for make install)
 chown jenkins:jenkins /usr/local
 
+# Allow writing to conda root env
+if [[ "$BUILD_ENVIRONMENT" == *-conda* ]]; then
+  echo "Chowning Conda"
+  chown jenkins:jenkins /opt/conda
+fi
+
 # Allow sudo
 echo 'jenkins ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jenkins

--- a/docker/ubuntu-cuda-conda/Dockerfile
+++ b/docker/ubuntu-cuda-conda/Dockerfile
@@ -35,6 +35,7 @@ RUN bash ./install_protobuf.sh && rm install_protobuf.sh
 ARG JENKINS
 ARG JENKINS_UID
 ARG JENKINS_GID
+ARG BUILD_ENVIRONMENT
 ADD ./common/add_jenkins_user.sh add_jenkins_user.sh
 RUN if [ -n "${JENKINS}" ]; then bash ./add_jenkins_user.sh ${JENKINS_UID} ${JENKINS_GID}; fi
 RUN rm add_jenkins_user.sh


### PR DESCRIPTION
jenkins doesn't have permissions in docker images to write to root conda env. correcting that.