### PR TITLE
promotion to registers (aka private memory)

### DIFF
--- a/include/tc/core/polyhedral/memory_promotion.h
+++ b/include/tc/core/polyhedral/memory_promotion.h
@@ -179,9 +179,9 @@ inline std::ostream& operator<<(std::ostream& os, const TensorReference& tr) {
 inline std::ostream& operator<<(
     std::ostream& os,
     const TensorReferenceGroup& tg) {
-  os << " with footprint BB: " << tg.approximation << " ";
+  os << "Reference with footprint: " << tg.approximation << "\n";
   for (const auto& tr : tg.references) {
-    os << *tr << " ";
+    os << *tr << "\n";
   }
   return os;
 }

--- a/include/tc/core/polyhedral/memory_promotion_heuristic.h
+++ b/include/tc/core/polyhedral/memory_promotion_heuristic.h
@@ -26,6 +26,7 @@ using ThreadIdxxScheduleDepthState =
     std::vector<std::pair<isl::union_set, size_t>>;
 
 class MappedScop;
+class Scop;
 
 // In the given mapped scop "mscop",
 // promote to shared memory at "depth" until "sharedMemorySize" is used.
@@ -40,5 +41,10 @@ void promoteGreedilyAtDepth(
     std::size_t depth,
     std::size_t sharedMemorySize,
     bool unrollCopies);
+
+void promoteToRegistersBelowThreads(
+    Scop& scop,
+    const ThreadIdxxScheduleDepthState& threadIdxxScheduleDepthState,
+    std::size_t nRegisters);
 } // namespace polyhedral
 } // namespace tc

--- a/include/tc/core/polyhedral/schedule_transforms.h
+++ b/include/tc/core/polyhedral/schedule_transforms.h
@@ -284,13 +284,6 @@ isl::union_set activeDomainPoints(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node);
 
-// Get the set of statement identifiers whose domains have at least one active
-// point at the given node, i.e. the statements that were not filtered away on
-// the path from root to node.
-std::unordered_set<isl::id, isl::IslIdIslHash> activeStatements(
-    const detail::ScheduleTree* root,
-    const detail::ScheduleTree* node);
-
 ////////////////////////////////////////////////////////////////////////////////
 // Experimental
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -324,9 +324,8 @@ struct Scop {
     return promotedDecls_;
   }
 
-  const std::
-      unordered_map<isl::id, std::vector<PromotionInfo>, isl::IslIdIslHash>&
-      activePromotions() const {
+  const std::vector<std::pair<isl::union_set, PromotionInfo>>&
+  activePromotions() const {
     return activePromotions_;
   }
 
@@ -377,7 +376,6 @@ struct Scop {
       isl::id tensorId,
       std::unique_ptr<TensorReferenceGroup>&& gr,
       detail::ScheduleTree* tree,
-      const std::unordered_set<isl::id, isl::IslIdIslHash>& activeStmts,
       isl::union_map schedule,
       bool forceLastExtentOdd = false);
 
@@ -468,9 +466,10 @@ struct Scop {
   std::unordered_map<isl::id, size_t, isl::IslIdIslHash> groupCounts_;
   // groupId -> (tensorId, groupSizes)
   std::unordered_map<isl::id, PromotedDecl, isl::IslIdIslHash> promotedDecls_;
-  // stmtId -> (group, partial schedule, groupId)
-  std::unordered_map<isl::id, std::vector<PromotionInfo>, isl::IslIdIslHash>
-      activePromotions_;
+  // (domain, group, partial schedule, groupId)
+  // Note that domain is a non-unique key, i.e. multiple groups can be listed
+  // for the same domain, or for partially intersecting domains.
+  std::vector<std::pair<isl::union_set, PromotionInfo>> activePromotions_;
 };
 
 std::ostream& operator<<(std::ostream& os, const Scop&);

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -306,8 +306,11 @@ struct Scop {
   void promoteEverythingAt(std::vector<size_t> pos);
 
   struct PromotedDecl {
+    enum class Kind { SharedMem, Register };
+
     isl::id tensorId;
     std::vector<size_t> sizes;
+    Kind kind;
   };
 
   struct PromotionInfo {
@@ -356,7 +359,8 @@ struct Scop {
   // Assumes such argument exists.
   const Halide::OutputImageParam& findArgument(isl::id id) const;
 
-  // Promote a tensor reference group to shared memory, inserting the copy
+  // Promote a tensor reference group to a storage of a given "kind",
+  // inserting the copy
   // statements below the given node.  Inserts an Extension node below the give
   // node, unless there is already another Extension node which introduces
   // copies.  The Extension node has a unique Sequence child, whose children
@@ -368,7 +372,8 @@ struct Scop {
   // If "forceLastExtentOdd" is set, the last extent in the declaration is
   // incremented if it is even.  This serves as a simple heuristic to reduce
   // shared memory bank conflicts.
-  void promoteGroupToShared(
+  void promoteGroup(
+      PromotedDecl::Kind kind,
       isl::id tensorId,
       std::unique_ptr<TensorReferenceGroup>&& gr,
       detail::ScheduleTree* tree,

--- a/include/tc/external/detail/islpp.h
+++ b/include/tc/external/detail/islpp.h
@@ -268,6 +268,10 @@ inline bool operator==(const isl::id& id1, const isl::id& id2) {
   return id1.get() == id2.get();
 }
 
+inline bool operator!=(const isl::id& id1, const isl::id& id2) {
+  return id1.get() != id2.get();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Helper functions
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/tc/external/detail/islpp.h
+++ b/include/tc/external/detail/islpp.h
@@ -403,6 +403,21 @@ auto end(L& list) -> ListIter<decltype(list.get(0)), L> {
 using detail::begin;
 using detail::end;
 
+template <typename T>
+isl::val getParamValIfFixed(T t, int pos) {
+  auto val = isl::val::nan(t.get_ctx());
+  for (auto set : isl::UnionAsVector<T>(t)) {
+    auto currentVal = set.plain_get_val_if_fixed(isl::dim_type::param, pos);
+    if (currentVal.is_nan()) {
+      return currentVal;
+    }
+    if (!val.is_nan() && val != currentVal) {
+      return isl::val::nan(t.get_ctx());
+    }
+    val = currentVal;
+  }
+  return val;
+}
 } // namespace isl
 
 namespace isl {

--- a/src/core/polyhedral/codegen_cuda.cc
+++ b/src/core/polyhedral/codegen_cuda.cc
@@ -707,7 +707,10 @@ void emitPromotedArrayViewsHalide(stringstream& ss, const Scop& scop) {
         t = i.type();
       }
     }
-    ss << "__shared__ " << t << " " << viewName;
+    if (p.second.kind == Scop::PromotedDecl::Kind::SharedMem) {
+      ss << "__shared__ ";
+    }
+    ss << t << " " << viewName;
     for (auto s : p.second.sizes) {
       ss << "[" << s << "]";
     }

--- a/src/core/polyhedral/mapped_scop.cc
+++ b/src/core/polyhedral/mapped_scop.cc
@@ -176,8 +176,11 @@ void fixThreadsBelowFilter(
 
   for (size_t i = begin; i < end; ++i) {
     if (mapping::ThreadId::makeId(i) == mapping::ThreadId::x()) {
+      // Mapping happend below filterTree, so we need points active for its
+      // children.  After insertion, filterTree is guaranteed to have at least
+      // one child.
       mscop.threadIdxxScheduleDepthState.emplace_back(std::make_pair(
-          activeDomainPoints(mscop.schedule(), filterTree),
+          activeDomainPoints(mscop.schedule(), filterTree->child({0})),
           filterTree->scheduleDepth(mscop.schedule())));
     }
   }

--- a/src/core/polyhedral/mapped_scop.cc
+++ b/src/core/polyhedral/mapped_scop.cc
@@ -689,10 +689,16 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
     }
   }
 
-  // 8. Insert mapping context
+  // 8. Promote to registers below the loops mapped to threads.
+  if (options.proto.use_private_memory()) {
+    promoteToRegistersBelowThreads(
+        mappedScop->scop(), mappedScop->threadIdxxScheduleDepthState, -1ull);
+  }
+
+  // 9. Insert mapping context
   mappedScop->insertMappingContext();
 
-  // 9. Optionally insert reduction synchronizations
+  // 10. Optionally insert reduction synchronizations
   for (auto bandUpdate : mappedScop->reductionBandUpdates_) {
     for (auto updateId : bandUpdate.second.ids) {
       scop->insertReductionSync1D(

--- a/src/core/polyhedral/memory_promotion.cc
+++ b/src/core/polyhedral/memory_promotion.cc
@@ -321,13 +321,21 @@ void addSingletonReferenceGroups(
   // access relations have a shape :: [D -> ref] -> O
   // use currying to isolate the D part before intersecting with the domain
   // Compute initial groups with single reference per group.
+  std::unordered_set<isl::id, isl::IslIdIslHash> unapproximatable;
   for (auto a : isl::UnionAsVector<isl::union_map>(accesses)) {
     if (isl::union_map(a.curry()).intersect_domain(domain).is_empty()) {
       continue;
     }
 
     auto tensorId = a.get_tuple_id(isl::dim_type::out);
-    addSingletonReferenceGroup(tensorGroups, tensorId, schedule, a, type);
+    if (unapproximatable.count(tensorId) != 0) {
+      continue;
+    }
+    try {
+      addSingletonReferenceGroup(tensorGroups, tensorId, schedule, a, type);
+    } catch (const promotion::GroupingError& err) {
+      unapproximatable.insert(tensorId);
+    }
   }
 }
 } // namespace

--- a/src/core/polyhedral/memory_promotion.cc
+++ b/src/core/polyhedral/memory_promotion.cc
@@ -321,8 +321,11 @@ void addSingletonReferenceGroups(
   // access relations have a shape :: [D -> ref] -> O
   // use currying to isolate the D part before intersecting with the domain
   // Compute initial groups with single reference per group.
-  accesses = accesses.curry().intersect_domain(domain).uncurry();
   for (auto a : isl::UnionAsVector<isl::union_map>(accesses)) {
+    if (isl::union_map(a.curry()).intersect_domain(domain).is_empty()) {
+      continue;
+    }
+
     auto tensorId = a.get_tuple_id(isl::dim_type::out);
     addSingletonReferenceGroup(tensorGroups, tensorId, schedule, a, type);
   }

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -530,7 +530,8 @@ void promoteToSharedGreedy(
           continue;
         }
 
-        scop.promoteGroupToShared(
+        scop.promoteGroup(
+            Scop::PromotedDecl::Kind::SharedMem,
             tensorId,
             std::move(group),
             bandNode,

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -617,7 +617,6 @@ void promoteToRegistersBelowThreads(
       // per-thread-group access relations.
       auto points = activeDomainPoints(root, band);
       auto partialSched = partialSchedule(root, band);
-      auto activeStmts = activeStatements(root, band);
 
       size_t nMappedThreads = 0;
       for (int j = 0; j < points.dim(isl::dim_type::param); ++j) {
@@ -666,7 +665,6 @@ void promoteToRegistersBelowThreads(
               tensorId,
               std::move(group),
               band,
-              activeStmts,
               partialSched);
         }
       }

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -558,23 +558,6 @@ void promoteGreedilyAtDepth(
   mapCopiesToThreads(mscop, unrollCopies);
 }
 
-namespace {
-isl::val getParamValIfFixed(isl::union_set uset, int pos) {
-  auto val = isl::val::nan(uset.get_ctx());
-  for (auto set : isl::UnionAsVector<isl::union_set>(uset)) {
-    auto currentVal = set.plain_get_val_if_fixed(isl::dim_type::param, pos);
-    if (currentVal.is_nan()) {
-      return currentVal;
-    }
-    if (!val.is_nan() && val != currentVal) {
-      return isl::val::nan(uset.get_ctx());
-    }
-    val = currentVal;
-  }
-  return val;
-}
-} // namespace
-
 // Assuming the mapping to threads happens in inverse order, i.e. the innermost
 // loop is mapped to thread x, promote below that depth.
 void promoteToRegistersBelowThreads(
@@ -625,7 +608,7 @@ void promoteToRegistersBelowThreads(
           if (id != mapping::ThreadId::makeId(i)) {
             continue;
           }
-          if (getParamValIfFixed(points, j) ==
+          if (isl::getParamValIfFixed(points, j) ==
               isl::val::zero(points.get_ctx())) {
             continue;
           }

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -300,9 +300,7 @@ bool isCoalesced(
       auto partialSchedule = isl::map::from_union_map(partialScheduleUMap);
       auto scheduleToNextX = makeNextElementMap(
           partialSchedule.get_space().range(), threadIdxxDepth);
-      auto scheduledAccess = isl::map(access)
-                                 .gist_domain(access.domain())
-                                 .apply_domain(partialSchedule);
+      auto scheduledAccess = isl::map(access).apply_domain(partialSchedule);
       auto accessedByAdjacentX = scheduleToNextX.apply_domain(scheduledAccess)
                                      .apply_range(scheduledAccess);
 
@@ -349,9 +347,7 @@ bool isPromotableToRegisterBelowThreads(
                    threadIdxxScheduleDepthState,
                    originalAccesses.domain().intersect(activePoints));
 
-  auto scheduledAccesses =
-      originalAccesses.gist_domain(originalAccesses.domain())
-          .apply_domain(schedule);
+  auto scheduledAccesses = originalAccesses.apply_domain(schedule);
 
   // Scheduled accesses contain maps from schedule dimensions to tensor
   // subscripts.  Compute the relation that between the schedule dimensions
@@ -460,7 +456,6 @@ void promoteToSharedGreedy(
   size_t remainingMemory = maxMemory;
   for (auto bandNode : bands) {
     auto groupMap = TensorReferenceGroup::accessedBySubtree(bandNode, scop);
-    auto activeStmts = activeStatements(root, bandNode);
     auto partialSched = partialSchedule(root, bandNode);
     auto activePoints = activeDomainPoints(root, bandNode);
 
@@ -535,7 +530,6 @@ void promoteToSharedGreedy(
             tensorId,
             std::move(group),
             bandNode,
-            activeStmts,
             partialSched,
             true);
         remainingMemory -= memoryRequirement;

--- a/src/core/polyhedral/schedule_isl_conversion.cc
+++ b/src/core/polyhedral/schedule_isl_conversion.cc
@@ -156,12 +156,12 @@ isl::schedule_node insertExtension(
     }
     node = node.ancestor(node.get_tree_depth() - depth0);
   }
-  for (auto i = corePos[0]; i >= 1; --i) {
-    auto graft = graftFromFilterSubtree(child->child({i - 1}), extension);
+  for (size_t i = 0; i < corePos[0]; ++i) {
+    auto graft = graftFromFilterSubtree(child->child({i}), extension);
     node = node.graft_before(graft);
   }
-  for (auto i = corePos.back() + 1; i < child->numChildren(); ++i) {
-    auto graft = graftFromFilterSubtree(child->child({i}), extension);
+  for (auto i = child->numChildren(); i > corePos.back() + 1; --i) {
+    auto graft = graftFromFilterSubtree(child->child({i - 1}), extension);
     node = node.graft_after(graft);
   }
   node = node.ancestor(node.get_tree_depth() - depth0);

--- a/src/core/polyhedral/schedule_transforms.cc
+++ b/src/core/polyhedral/schedule_transforms.cc
@@ -135,17 +135,6 @@ isl::union_set activeDomainPoints(
   return domain;
 }
 
-std::unordered_set<isl::id, isl::IslIdIslHash> activeStatements(
-    const ScheduleTree* root,
-    const ScheduleTree* tree) {
-  std::unordered_set<isl::id, isl::IslIdIslHash> ids;
-  auto domain = activeDomainPoints(root, tree).universe();
-  for (auto d : isl::UnionAsVector<isl::union_set>(domain)) {
-    ids.insert(d.get_tuple_id());
-  }
-  return ids;
-}
-
 vector<ScheduleTree*> collectScheduleTreesPath(
     std::function<ScheduleTree*(ScheduleTree*)> next,
     ScheduleTree* start) {

--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -187,6 +187,22 @@ void Scop::promoteGroup(
     const std::unordered_set<isl::id, isl::IslIdIslHash>& activeStmts,
     isl::union_map schedule,
     bool forceLastExtentOdd) {
+  for (const auto& id : activeStmts) {
+    for (const auto& prom : activePromotions_[id]) {
+      if (promotedDecls_.count(prom.groupId) != 0 &&
+          promotedDecls_[prom.groupId].tensorId == tensorId) {
+        // FIXME: allow double promotion if copies are inserted properly,
+        // in particular if the new promotion is strictly smaller in scope
+        // and size than the existing ones (otherwise we would need to find
+        // the all the existing ones and change their copy relations).
+        std::cerr << "FIXME: not promoting because another promotion of tensor "
+                  << promotedDecls_[prom.groupId].tensorId << " is active in "
+                  << id << std::endl;
+        return;
+      }
+    }
+  }
+
   auto groupId = nextGroupIdForTensor(tensorId);
   insertCopiesUnder(*this, tree, *gr, tensorId, groupId);
   auto sizes = gr->approximationSizes();

--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -188,19 +188,19 @@ void Scop::promoteGroup(
     bool forceLastExtentOdd) {
   auto activePoints = activeDomainPoints(scheduleRoot(), tree);
 
-  for (const auto& id : activeStmts) {
-    for (const auto& prom : activePromotions_[id]) {
-      if (promotedDecls_.count(prom.groupId) != 0 &&
-          promotedDecls_[prom.groupId].tensorId == tensorId) {
-        // FIXME: allow double promotion if copies are inserted properly,
-        // in particular if the new promotion is strictly smaller in scope
-        // and size than the existing ones (otherwise we would need to find
-        // the all the existing ones and change their copy relations).
-        std::cerr << "FIXME: not promoting because another promotion of tensor "
-                  << promotedDecls_[prom.groupId].tensorId << " is active in "
-                  << id << std::endl;
-        return;
-      }
+  for (const auto& kvp : activePromotions_) {
+    if (kvp.first.intersect(activePoints).is_empty()) {
+      continue;
+    }
+
+    auto groupId = kvp.second.groupId;
+    if (promotedDecls_.count(groupId) != 0 &&
+        promotedDecls_[groupId].tensorId == tensorId) {
+      // FIXME: allow double promotion if copies are inserted properly,
+      // in particular if the new promotion is strictly smaller in scope
+      // and size than the existing ones (otherwise we would need to find
+      // the all the existing ones and change their copy relations).
+      return;
     }
   }
 

--- a/test/test_mapper_memory_promotion.cc
+++ b/test/test_mapper_memory_promotion.cc
@@ -459,7 +459,7 @@ class MatMulBias : public TestMapper {
  public:
   std::string emitCode(
       const std::unordered_map<std::string, size_t>& parameters,
-      const std::vector<size_t>& tileSizes) {
+      const MappingOptions& mappingOptions) {
     std::string tc = R"TC(
 def fun(float(N,K) A, float(K,M) B, float(N,M) C) -> (O) {
   O(i,j) +=! A(i,k) * B(k,j)
@@ -467,17 +467,59 @@ def fun(float(N,K) A, float(K,M) B, float(N,M) C) -> (O) {
 }
 )TC";
 
-    auto mappingOptions = MappingOptions::makeNaiveMappingOptions()
-                              .tile(tileSizes)
-                              .useSharedMemory(false)
-                              .usePrivateMemory(true);
     auto mscop = makeMappedScop(tc, mappingOptions, parameters);
     return std::get<0>(mscop->codegen("fun"));
   }
 };
 
 TEST_F(MatMulBias, RegisterPromotion) {
-  emitCode({{"N", 42}, {"M", 56}, {"K", 37}}, {32, 32, 32});
+  auto mappingOptions = MappingOptions::makeNaiveMappingOptions()
+                            .tile({32, 32, 32})
+                            .useSharedMemory(false)
+                            .usePrivateMemory(true);
+
+  auto code = emitCode({{"N", 42}, {"M", 56}, {"K", 37}}, mappingOptions);
+  auto declPos = code.find("float32 _O_0");
+  auto copyToPos =
+      code.find("_O_0[0][0] = O[32*b0 + c3][t0 + 32*b1]", declPos + 1);
+  auto copyFromPos =
+      code.find("O[32*b0 + c3][t0 + 32*b1] = _O_0[0][0]", copyToPos + 1);
+
+  auto originalAccPos = code.find("O[32*b0 + c3][t0 + 32*b1]", copyToPos + 1);
+  auto cDeclPos = code.find("float32 _C_0");
+  auto aDeclPos = code.find("float32 _A_0");
+
+  EXPECT_TRUE(declPos != std::string::npos) << "no declaration of the register";
+  EXPECT_TRUE(copyToPos != std::string::npos) << "expected copy to register";
+  EXPECT_TRUE(copyFromPos != std::string::npos)
+      << "expected copy from register";
+
+  EXPECT_NE(originalAccPos, copyFromPos)
+      << "global array reference is used in main computation";
+  EXPECT_TRUE(cDeclPos == std::string::npos)
+      << "tensor C promoted to register but has no reuse";
+  EXPECT_TRUE(aDeclPos == std::string::npos)
+      << "tensor A promoted to register but has elements accessed by multiple threads";
+}
+
+TEST_F(MatMulBias, RegisterPromotionSharedPreference) {
+  auto mappingOptions = MappingOptions::makeNaiveMappingOptions()
+                            .tile({32, 32, 32})
+                            .maxSharedMemory(32768)
+                            .useSharedMemory(true)
+                            .usePrivateMemory(true);
+
+  auto code = emitCode({{"N", 42}, {"M", 56}, {"K", 37}}, mappingOptions);
+  auto declPos = code.find("float32 _O_0[1][1]");
+  auto cDeclPos = code.find("float32 _C_0[1][1]");
+  auto aDeclPos = code.find("float32 _A_0[1][1]");
+
+  EXPECT_TRUE(declPos == std::string::npos)
+      << "not expected promotion to register because promoted to shared";
+  EXPECT_TRUE(cDeclPos == std::string::npos)
+      << "tensor C promoted to register but has no reuse";
+  EXPECT_TRUE(aDeclPos == std::string::npos)
+      << "tensor A promoted to register but has elements accessed by multiple threads";
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Assuming mapping to threads starts from the innermost coincident
schedule dimension and from the thread x, promote to registers in each
subtree below the band member mapped to thread x.  Split bands if
necessary to ensure that this member is the last one in the band.
For each such band, collect references to tensors accessed below it.
Group together the references that have overlapping footprints and at
least one of them is a write to ensure the most recent value is read.
For each group, consider promotion to registers if the footprint
contains only one element (hence promotable to a register) and if each
element is accessed by at most one thread (registers are private to
threads).  Do not promote to registers if these references were already
promoted to shared memory as this would require either copying from
shraed memory to registers, or demoting from shared memory first.
Do not insert synchroniztaions around these copies as no two threads are
accessing the same value.  The compiler could load from memory to a
register anyway for most arithmetic operations.