### PR TITLE
filter PLDI 2LUT tests temporarily from CI

### DIFF
--- a/.jenkins/run_test.sh
+++ b/.jenkins/run_test.sh
@@ -8,9 +8,12 @@ source /etc/lsb-release
 # condition: if 16.04 and conda, run only python tests
 # condition: if any and non-conda, run test.sh only
 
+# TODO: modify 2LUT tests from example_MLP_model and enable on CI
+
 if [[ "$DISTRIB_RELEASE" == 14.04 ]]; then
   echo "Running TC backend tests"
-  ./test.sh
+  FILTER_OUT=example_MLP_model ./test.sh
+  ./build/examples/example_MLP_model --gtest_filter=-*2LUT*
   if [[ $(conda --version | wc -c) -ne 0 ]]; then
     source activate tc-env
     echo "Running TC PyTorch tests"
@@ -25,6 +28,7 @@ if [[ "$DISTRIB_RELEASE" == 16.04 ]]; then
     ./test_python/run_test.sh
   else
     echo "Running TC backend tests"
-    ./test.sh
+    FILTER_OUT=example_MLP_model ./test.sh
+    ./build/examples/example_MLP_model --gtest_filter=-*2LUT*
   fi
 fi


### PR DESCRIPTION
2LUT tests in PLDI example/ are right now OOM. They are blocking the CI progress so I am blocking these 4 tests from running on CI for now temporarily.

1. 2LUT tests are also running somewhere so we are not removing testing some functionality
2. these tests require modification and the goal is to have CI functional for gpu and we can always enable these 4 tests later. 

This has been discussed over messenger and Albert has consented that if needed, we can disable for now. and like in 1) above, there are 2LUT tests  running as part of non-pldi tests on CI so we test functionality fully.