### PR TITLE
Fix compilation issue: has virtual functions but non-virtual destructor

### DIFF
--- a/include/tc/lang/tree.h
+++ b/include/tc/lang/tree.h
@@ -89,6 +89,7 @@ struct Tree : std::enable_shared_from_this<Tree> {
     }
   }
   int kind_;
+  virtual ~Tree() {}
 };
 
 struct String : public Tree {


### PR DESCRIPTION
This diff is to fix the following compilation issues: 
Build failed: Command failed with exit code 1.
stderr: In file included from tc/tc/test/test_caffe2.cc:27:
In file included from tc/tc/test/test_harness.h:32:
In file included from tc/tc/include/tc/c2/tc_op.h:24:
In file included from tc/tc/include/tc/core/cuda/cuda_tc_executor.h:24:
In file included from tc/tc/include/tc/core/halide_utils.h:23:
In file included from tc/tc/include/tc/core/tc2halide.h:21:
tc/tc/include/tc/lang/tree.h:49:8: error: 'lang::Tree' has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor]
struct Tree : std::enable_shared_from_this<Tree> {
       ^
tc/tc/include/tc/lang/tree.h:94:8: error: 'lang::String' has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor]
struct String : public Tree {
       ^
tc/tc/include/tc/lang/tree.h:107:8: error: 'lang::Number' has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor]
struct Number : public Tree {
       ^
tc/tc/include/tc/lang/tree.h:120:8: error: 'lang::Bool' has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor]
struct Bool : public Tree {
       ^
tc/tc/include/tc/lang/tree.h:145:8: error: 'lang::Compound' has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor]
struct Compound : public Tree {
