### PR TITLE
Fix compilation issue: braces around scalar initializer

### DIFF
--- a/include/tc/c2/copy_op.h
+++ b/include/tc/c2/copy_op.h
@@ -47,7 +47,7 @@ class TcCopyOp : public TcOp<T, Context, Engine> {
                                 .tile({4, 8, 8})
                                 .mapToThreads({32, 4, 4})
                                 .mapToBlocks({100, 100, 100})
-                                .unroll({128});
+                                .unroll(128);
     this->gradMappingOptions_ =
         tc::MappingOptions::makePointwiseMappingOptions();
   }

--- a/test/test_basic.cc
+++ b/test/test_basic.cc
@@ -87,7 +87,7 @@ TEST(Math, Median) {
   std::vector<int> v0{};
   EXPECT_THROW(tc::median(v0), std::out_of_range);
 
-  std::vector<int> v1{{1}};
+  std::vector<int> v1({1});
   EXPECT_EQ(tc::median(v1), 1);
 
   std::vector<int> v2{{1, 3}};


### PR DESCRIPTION
This diff is to fix the following two compilation issues: 

tc/tc/include/tc/c2/copy_op.h:50:41: error: braces around scalar initializer [-Werror,-Wbraced-scalar-init]
                                .unroll({128});

tc/tc/test/test_basic.cc:90:23: error: braces around scalar initializer [-Werror,-Wbraced-scalar-init]
  std::vector<int> v1{{1}};
