### PR TITLE
Fix compilation issue: prevents copy elision

### DIFF
--- a/test/test_harness.h
+++ b/test/test_harness.h
@@ -393,7 +393,7 @@ struct TestHarness {
       test->Check();
     }
 
-    return std::move(test);
+    return test;
   }
 
   static void RunGradient(Workspace& w, const OperatorDef& def) {


### PR DESCRIPTION
This diff is to fix: 
tc/tc/test/test_harness.h:396:12: error: moving a local object in a return statement prevents copy elision [-Werror,-Wpessimizing-move]
    return std::move(test);
