### PR TITLE
fix flaky errors in trusty conda docker image

### DIFF
--- a/docker/common/install_base.sh
+++ b/docker/common/install_base.sh
@@ -3,6 +3,9 @@
 set -ex
 
 # Install common dependencies
+# cleanup again to avoid any sha mismatch
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 apt-get update
 apt-get install -y --no-install-recommends \
   curl \
@@ -27,6 +30,9 @@ apt-get install -y --no-install-recommends \
   software-properties-common \
   build-essential
 
+# cleanup again to avoid any sha mismatch
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 # setup gcc
 add-apt-repository ppa:ubuntu-toolchain-r/test
 apt-get update

--- a/docker/ubuntu-cuda-conda/Dockerfile
+++ b/docker/ubuntu-cuda-conda/Dockerfile
@@ -6,8 +6,6 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel-ubuntu${UBUNTU_VERS
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-
 # CUDA paths - we install cudnn ourselves (only Trusty) so we can match the version with
 # PyTorch conda install
 ARG CUDA_VERSION
@@ -22,6 +20,8 @@ ARG GCC_VERSION
 ARG CMAKE_VERSION
 ADD ./common/install_base.sh install_base.sh
 RUN bash ./install_base.sh && rm install_base.sh
+
+# Setup ccache env variables
 ENV PATH /usr/local/bin/ccache:$PATH
 ENV CUDA_NVCC_EXECUTABLE /usr/local/bin/nvcc
 ENV PATH /usr/local/cuda/bin:$PATH

--- a/docker/ubuntu-cuda/Dockerfile
+++ b/docker/ubuntu-cuda/Dockerfile
@@ -6,8 +6,6 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel-ubuntu${UBUNTU_VERS
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-
 # CUDA paths
 ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/targets/x86_64-linux/lib/stubs/:$LD_LIBRARY_PATH
 ENV PATH /usr/local/bin:/usr/local/cuda/bin:$PATH
@@ -17,6 +15,8 @@ ARG GCC_VERSION
 ARG CMAKE_VERSION
 ADD ./common/install_base.sh install_base.sh
 RUN bash ./install_base.sh && rm install_base.sh
+
+# Setup ccache env variables
 ENV PATH /usr/local/bin/ccache:$PATH
 ENV CUDA_NVCC_EXECUTABLE /usr/local/bin/nvcc
 ENV PATH /usr/local/cuda/bin:$PATH


### PR DESCRIPTION
I am noticing flaky errors in one image 
```
20:14:05 Fetched 21.4 MB in 28s (752 kB/s)
20:14:05 [91mW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/trusty-updates/universe/source/Sources  Hash Sum mismatch
20:14:05 
20:14:05 E: Some index files failed to download. They have been ignored, or old ones used instead.
```
trying to fix that. This seems to have solved the issue and docker image is now building fine https://ci.pytorch.org/jenkins/job/tensorcomp-docker/job/linux-trusty-gcc4.8-cuda8-cudnn7-py3-conda/13/console