### PR TITLE
[wip] Register promotion improvements

### DIFF
--- a/include/tc/core/polyhedral/memory_promotion.h
+++ b/include/tc/core/polyhedral/memory_promotion.h
@@ -179,9 +179,9 @@ inline std::ostream& operator<<(std::ostream& os, const TensorReference& tr) {
 inline std::ostream& operator<<(
     std::ostream& os,
     const TensorReferenceGroup& tg) {
-  os << " with footprint BB: " << tg.approximation << " ";
+  os << "Reference with footprint: " << tg.approximation << "\n";
   for (const auto& tr : tg.references) {
-    os << *tr << " ";
+    os << *tr << "\n";
   }
   return os;
 }

--- a/include/tc/core/polyhedral/memory_promotion_heuristic.h
+++ b/include/tc/core/polyhedral/memory_promotion_heuristic.h
@@ -26,6 +26,7 @@ using ThreadIdxxScheduleDepthState =
     std::vector<std::pair<isl::union_set, size_t>>;
 
 class MappedScop;
+class Scop;
 
 // In the given mapped scop "mscop",
 // promote to shared memory at "depth" until "sharedMemorySize" is used.
@@ -40,5 +41,10 @@ void promoteGreedilyAtDepth(
     std::size_t depth,
     std::size_t sharedMemorySize,
     bool unrollCopies);
+
+void promoteToRegistersBelowThreads(
+    Scop& scop,
+    const ThreadIdxxScheduleDepthState& threadIdxxScheduleDepthState,
+    std::size_t nRegisters);
 } // namespace polyhedral
 } // namespace tc

--- a/include/tc/core/polyhedral/schedule_transforms.h
+++ b/include/tc/core/polyhedral/schedule_transforms.h
@@ -284,13 +284,6 @@ isl::union_set activeDomainPoints(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node);
 
-// Get the set of statement identifiers whose domains have at least one active
-// point at the given node, i.e. the statements that were not filtered away on
-// the path from root to node.
-std::unordered_set<isl::id, isl::IslIdIslHash> activeStatements(
-    const detail::ScheduleTree* root,
-    const detail::ScheduleTree* node);
-
 ////////////////////////////////////////////////////////////////////////////////
 // Experimental
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -324,9 +324,8 @@ struct Scop {
     return promotedDecls_;
   }
 
-  const std::
-      unordered_map<isl::id, std::vector<PromotionInfo>, isl::IslIdIslHash>&
-      activePromotions() const {
+  const std::vector<std::pair<isl::union_set, PromotionInfo>>&
+  activePromotions() const {
     return activePromotions_;
   }
 
@@ -377,7 +376,6 @@ struct Scop {
       isl::id tensorId,
       std::unique_ptr<TensorReferenceGroup>&& gr,
       detail::ScheduleTree* tree,
-      const std::unordered_set<isl::id, isl::IslIdIslHash>& activeStmts,
       isl::union_map schedule,
       bool forceLastExtentOdd = false);
 
@@ -468,9 +466,10 @@ struct Scop {
   std::unordered_map<isl::id, size_t, isl::IslIdIslHash> groupCounts_;
   // groupId -> (tensorId, groupSizes)
   std::unordered_map<isl::id, PromotedDecl, isl::IslIdIslHash> promotedDecls_;
-  // stmtId -> (group, partial schedule, groupId)
-  std::unordered_map<isl::id, std::vector<PromotionInfo>, isl::IslIdIslHash>
-      activePromotions_;
+  // (domain, group, partial schedule, groupId)
+  // Note that domain is a non-unique key, i.e. multiple groups can be listed
+  // for the same domain, or for partially intersecting domains.
+  std::vector<std::pair<isl::union_set, PromotionInfo>> activePromotions_;
 };
 
 std::ostream& operator<<(std::ostream& os, const Scop&);

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -383,6 +383,8 @@ struct Scop {
       isl::union_map schedule,
       bool forceLastExtentOdd = false);
 
+  void demoteGroup(isl::id groupId);
+
   // Given a tree node under which the promotion copy statements were
   // introduced, insert syncthread statements before and after the copies.
   // The tree should match the structure:

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -306,8 +306,11 @@ struct Scop {
   void promoteEverythingAt(std::vector<size_t> pos);
 
   struct PromotedDecl {
+    enum class Kind { SharedMem, Register };
+
     isl::id tensorId;
     std::vector<size_t> sizes;
+    Kind kind;
   };
 
   struct PromotionInfo {
@@ -356,7 +359,8 @@ struct Scop {
   // Assumes such argument exists.
   const Halide::OutputImageParam& findArgument(isl::id id) const;
 
-  // Promote a tensor reference group to shared memory, inserting the copy
+  // Promote a tensor reference group to a storage of a given "kind",
+  // inserting the copy
   // statements below the given node.  Inserts an Extension node below the give
   // node, unless there is already another Extension node which introduces
   // copies.  The Extension node has a unique Sequence child, whose children
@@ -368,7 +372,8 @@ struct Scop {
   // If "forceLastExtentOdd" is set, the last extent in the declaration is
   // incremented if it is even.  This serves as a simple heuristic to reduce
   // shared memory bank conflicts.
-  void promoteGroupToShared(
+  void promoteGroup(
+      PromotedDecl::Kind kind,
       isl::id tensorId,
       std::unique_ptr<TensorReferenceGroup>&& gr,
       detail::ScheduleTree* tree,

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -329,6 +329,10 @@ struct Scop {
     return activePromotions_;
   }
 
+  std::vector<std::pair<isl::union_set, Scop::PromotionInfo>> activePromotions(
+      isl::union_set activePoints,
+      isl::id tensorId);
+
   detail::ScheduleTree* scheduleRoot() {
     return scheduleTreeUPtr.get();
   }

--- a/include/tc/external/detail/islpp.h
+++ b/include/tc/external/detail/islpp.h
@@ -268,6 +268,10 @@ inline bool operator==(const isl::id& id1, const isl::id& id2) {
   return id1.get() == id2.get();
 }
 
+inline bool operator!=(const isl::id& id1, const isl::id& id2) {
+  return id1.get() != id2.get();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Helper functions
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/core/polyhedral/codegen_cuda.cc
+++ b/src/core/polyhedral/codegen_cuda.cc
@@ -817,7 +817,10 @@ void emitPromotedArrayViewsHalide(stringstream& ss, const Scop& scop) {
         t = i.type();
       }
     }
-    ss << "__shared__ " << t << " " << viewName;
+    if (p.second.kind == Scop::PromotedDecl::Kind::SharedMem) {
+      ss << "__shared__ ";
+    }
+    ss << t << " " << viewName;
     for (auto s : p.second.sizes) {
       ss << "[" << s << "]";
     }

--- a/src/core/polyhedral/mapped_scop.cc
+++ b/src/core/polyhedral/mapped_scop.cc
@@ -685,10 +685,16 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
     }
   }
 
-  // 8. Insert mapping context
+  // 8. Promote to registers below the loops mapped to threads.
+  if (options.proto.use_private_memory()) {
+    promoteToRegistersBelowThreads(
+        mappedScop->scop(), mappedScop->threadIdxxScheduleDepthState, -1ull);
+  }
+
+  // 9. Insert mapping context
   mappedScop->insertMappingContext();
 
-  // 9. Optionally insert reduction synchronizations
+  // 10. Optionally insert reduction synchronizations
   for (auto bandUpdate : mappedScop->reductionBandUpdates_) {
     for (auto updateId : bandUpdate.second.ids) {
       scop->insertReductionSync1D(

--- a/src/core/polyhedral/memory_promotion.cc
+++ b/src/core/polyhedral/memory_promotion.cc
@@ -321,13 +321,21 @@ void addSingletonReferenceGroups(
   // access relations have a shape :: [D -> ref] -> O
   // use currying to isolate the D part before intersecting with the domain
   // Compute initial groups with single reference per group.
+  std::unordered_set<isl::id, isl::IslIdIslHash> unapproximatable;
   for (auto a : isl::UnionAsVector<isl::union_map>(accesses)) {
     if (isl::union_map(a.curry()).intersect_domain(domain).is_empty()) {
       continue;
     }
 
     auto tensorId = a.get_tuple_id(isl::dim_type::out);
-    addSingletonReferenceGroup(tensorGroups, tensorId, schedule, a, type);
+    if (unapproximatable.count(tensorId) != 0) {
+      continue;
+    }
+    try {
+      addSingletonReferenceGroup(tensorGroups, tensorId, schedule, a, type);
+    } catch (const promotion::GroupingError& err) {
+      unapproximatable.insert(tensorId);
+    }
   }
 }
 } // namespace

--- a/src/core/polyhedral/memory_promotion.cc
+++ b/src/core/polyhedral/memory_promotion.cc
@@ -321,8 +321,11 @@ void addSingletonReferenceGroups(
   // access relations have a shape :: [D -> ref] -> O
   // use currying to isolate the D part before intersecting with the domain
   // Compute initial groups with single reference per group.
-  accesses = accesses.curry().intersect_domain(domain).uncurry();
   for (auto a : isl::UnionAsVector<isl::union_map>(accesses)) {
+    if (isl::union_map(a.curry()).intersect_domain(domain).is_empty()) {
+      continue;
+    }
+
     auto tensorId = a.get_tuple_id(isl::dim_type::out);
     addSingletonReferenceGroup(tensorGroups, tensorId, schedule, a, type);
   }

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -559,6 +559,13 @@ isl::val getParamValIfFixed(isl::union_set uset, int pos) {
   }
   return val;
 }
+
+template <typename T>
+T projectOutNamedParam(T t, isl::id paramId) {
+  auto space = t.get_space();
+  int pos = space.find_dim_by_id(isl::dim_type::param, paramId);
+  return (pos == -1) ? t : t.project_out(isl::dim_type::param, pos, 1);
+}
 } // namespace
 
 void promoteToRegistersBelowThreads(
@@ -621,6 +628,21 @@ void promoteToRegistersBelowThreads(
         }
       }
 
+      // Compute the set of active points without constraints introduced by
+      // thread mapping.
+      auto mappingTree = band;
+      while (mappingTree &&
+             !mappingTree->elemAs<ScheduleTreeElemMappingFilter>()) {
+        mappingTree = mappingTree->ancestor(scop.scheduleRoot(), 1);
+      }
+      CHECK(mappingTree);
+      auto mappingElem = mappingTree->elemAs<ScheduleTreeElemMappingFilter>();
+      auto pointsNoThreadMapping = points.gist(mappingElem->filter_);
+      for (size_t j = 0; j < mapping::ThreadId::kMaxDim; ++j) {
+        pointsNoThreadMapping = projectOutNamedParam(
+            pointsNoThreadMapping, mapping::ThreadId::makeId(j));
+      }
+
       auto groupMap = TensorReferenceGroup::accessedBySubtree(band, scop);
       for (auto& tensorGroups : groupMap) {
         auto tensorId = tensorGroups.first;
@@ -646,9 +668,19 @@ void promoteToRegistersBelowThreads(
           if (!hasReuse(*group, fullSched, depth)) {
             continue;
           }
-          // TODO: if something is already in shared, but reuse it within one
-          // thread only, there is no point in keeping it in shared _if_ it
-          // gets promoted into a register.
+
+          // If a group of references was promoted into shared memory, but it
+          // could be also promoted to registers while covering exactly the
+          // same statement instances accessing it, demote it from shared
+          // memory first.
+          auto outerScopePromotions = scop.activePromotions(points, tensorId);
+          if (outerScopePromotions.size() == 1 &&
+              outerScopePromotions[0]
+                  .first.subtract(pointsNoThreadMapping)
+                  .is_empty()) {
+            scop.demoteGroup(outerScopePromotions[0].second.groupId);
+          }
+
           scop.promoteGroup(
               Scop::PromotedDecl::Kind::Register,
               tensorId,

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -604,7 +604,6 @@ void promoteToRegistersBelowThreads(
       // per-thread-group access relations.
       auto points = activeDomainPoints(root, band);
       auto partialSched = partialSchedule(root, band);
-      auto activeStmts = activeStatements(root, band);
 
       size_t nMappedThreads = 0;
       for (int j = 0; j < points.dim(isl::dim_type::param); ++j) {
@@ -655,7 +654,6 @@ void promoteToRegistersBelowThreads(
               tensorId,
               std::move(group),
               band,
-              activeStmts,
               partialSched);
         }
       }

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -315,6 +315,48 @@ bool isCoalesced(
   return true;
 }
 
+bool isPromotableToRegisterBelowThreads(
+    const ThreadIdxxScheduleDepthState& threadIdxxScheduleDepthState,
+    const TensorReferenceGroup& group,
+    isl::union_map schedule,
+    size_t nThreads,
+    isl::union_set activePoints) {
+  auto originalAccesses = group.originalAccesses();
+
+  // Return early if more than one element needs to be stored in registers.
+  // TODO: support arrays in registers if they are only accessed with constant
+  // subscripts, e.g. if the inner loops are fully unrolled.
+  auto sizes = group.approximationSizes();
+  auto nElements =
+      std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<size_t>());
+  if (nElements != 1) {
+    return false;
+  }
+
+  // Since this function is only supposed to be called on groups seen _below_
+  // thread mapping, all refs in the group must all have the same thread-x
+  // depth.
+  auto depth = computeThreadIdxxScheduleDepth(
+                   threadIdxxScheduleDepthState,
+                   originalAccesses.domain().intersect(activePoints)) +
+      1;
+
+  auto scheduledAccesses =
+      originalAccesses.gist_domain(originalAccesses.domain())
+          .apply_domain(schedule);
+
+  for (auto sa : isl::UnionAsVector<isl::union_map>(scheduledAccesses)) {
+    sa = sa.project_out(
+        isl::dim_type::in, depth, sa.dim(isl::dim_type::in) - depth);
+    sa = fixOuterInputDimsAsParameters(sa, depth - nThreads);
+    if (!sa.is_injective()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 /*
  * Starting from the root, find bands where depth is reached.  Using
  * DFSPreorder to make sure order is specified and consistent for tests.
@@ -501,6 +543,115 @@ void promoteGreedilyAtDepth(
 
   // 2. Map copies to shared, state by copy
   mapCopiesToThreads(mscop, unrollCopies);
+}
+
+namespace {
+isl::val getParamValIfFixed(isl::union_set uset, int pos) {
+  auto val = isl::val::nan(uset.get_ctx());
+  for (auto set : isl::UnionAsVector<isl::union_set>(uset)) {
+    auto currentVal = set.plain_get_val_if_fixed(isl::dim_type::param, pos);
+    if (currentVal.is_nan()) {
+      return currentVal;
+    }
+    if (!val.is_nan() && val != currentVal) {
+      return isl::val::nan(uset.get_ctx());
+    }
+    val = currentVal;
+  }
+  return val;
+}
+} // namespace
+
+void promoteToRegistersBelowThreads(
+    Scop& scop,
+    const ThreadIdxxScheduleDepthState& threadIdxxScheduleDepthState,
+    size_t nRegisters) {
+  using namespace tc::polyhedral::detail;
+
+  // Assuming the mapping happens to threads happens in inverse order, i.e.
+  // the innermost loop is mapped to thread x, promote below that depth.
+
+  auto root = scop.scheduleRoot();
+
+  auto fullSched = fullSchedule(root);
+  for (const auto& kvp : threadIdxxScheduleDepthState) {
+    auto depth = kvp.second + 1;
+    auto subdomain = kvp.first;
+
+    // Collect all bands where a member is located at the given depth.
+    auto bands = bandsContainingScheduleDepth(root, depth);
+    // We may have no band members mapped to thread x in case when we
+    // force-mapped everything to one thread.
+    if (bands.size() == 0) {
+      continue;
+    }
+
+    // Keep only those bands for which the this depth was recorded.
+    std::function<bool(ScheduleTree*)> keepActive =
+        [root, subdomain](const ScheduleTree* tree) {
+          isl::union_set active = activeDomainPoints(root, tree);
+          return !active.intersect(subdomain).is_empty();
+        };
+    bands = functional::Filter(keepActive, bands);
+
+    // Make sure the band ends at thread x depth so we can promote below it.
+    bands = bandsSplitAfterDepth(bands, root, depth);
+
+    for (auto band : bands) {
+      // Find out how many threads are actually mapped.  Active domain points
+      // will involve all mapping parameters when we take them below the
+      // mapping.  Skip mapping parameters obviously mapped to 0, because they
+      // do not correspond to band members that should be fixed to obtain
+      // per-thread-group access relations.
+      auto points = activeDomainPoints(root, band);
+      size_t nMappedThreads = 0;
+      for (int j = 0; j < points.dim(isl::dim_type::param); ++j) {
+        auto id = points.get_space().get_dim_id(isl::dim_type::param, j);
+        for (size_t i = 0; i < mapping::ThreadId::kMaxDim; ++i) {
+          if (not(id == mapping::ThreadId::makeId(i))) {
+            continue;
+          }
+          if (getParamValIfFixed(points, j) ==
+              isl::val::zero(points.get_ctx())) {
+            continue;
+          }
+          ++nMappedThreads;
+          break;
+        }
+      }
+
+      auto groupMap = TensorReferenceGroup::accessedBySubtree(band, scop);
+      for (const auto& tensorGroups : groupMap) {
+        auto tensorId = tensorGroups.first;
+
+        // TODO: sorting of groups and counting the number of promoted elements
+        // TODO: check if nvrtc is smart enough to reuse a register for
+        // variables in disjoint scopes or do we need to reuse the variable?
+
+        for (const auto& group : tensorGroups.second) {
+          auto sizes = group->approximationSizes();
+          // No point in promoting a scalar that will go to a register anyway.
+          if (sizes.size() == 0) {
+            continue;
+          }
+          if (!isPromotableToRegisterBelowThreads(
+                  threadIdxxScheduleDepthState,
+                  *group,
+                  fullSched,
+                  nMappedThreads,
+                  points)) {
+            continue;
+          }
+          if (!hasReuse(*group, fullSched, depth)) {
+            continue;
+          }
+          // TODO: if something is already in shared, but reuse it within one
+          // thread only, there is no point in keeping it in shared _if_ it
+          // gets promoted into a register.
+        }
+      }
+    }
+  }
 }
 
 } // namespace polyhedral

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -605,6 +605,9 @@ void promoteToRegistersBelowThreads(
       // do not correspond to band members that should be fixed to obtain
       // per-thread-group access relations.
       auto points = activeDomainPoints(root, band);
+      auto partialSched = partialSchedule(root, band);
+      auto activeStmts = activeStatements(root, band);
+
       size_t nMappedThreads = 0;
       for (int j = 0; j < points.dim(isl::dim_type::param); ++j) {
         auto id = points.get_space().get_dim_id(isl::dim_type::param, j);
@@ -622,14 +625,14 @@ void promoteToRegistersBelowThreads(
       }
 
       auto groupMap = TensorReferenceGroup::accessedBySubtree(band, scop);
-      for (const auto& tensorGroups : groupMap) {
+      for (auto& tensorGroups : groupMap) {
         auto tensorId = tensorGroups.first;
 
         // TODO: sorting of groups and counting the number of promoted elements
         // TODO: check if nvrtc is smart enough to reuse a register for
         // variables in disjoint scopes or do we need to reuse the variable?
 
-        for (const auto& group : tensorGroups.second) {
+        for (auto& group : tensorGroups.second) {
           auto sizes = group->approximationSizes();
           // No point in promoting a scalar that will go to a register anyway.
           if (sizes.size() == 0) {
@@ -649,6 +652,13 @@ void promoteToRegistersBelowThreads(
           // TODO: if something is already in shared, but reuse it within one
           // thread only, there is no point in keeping it in shared _if_ it
           // gets promoted into a register.
+          scop.promoteGroup(
+              Scop::PromotedDecl::Kind::Register,
+              tensorId,
+              std::move(group),
+              band,
+              activeStmts,
+              partialSched);
         }
       }
     }

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -442,7 +442,6 @@ void promoteToSharedGreedy(
   size_t remainingMemory = maxMemory;
   for (auto bandNode : bands) {
     auto groupMap = TensorReferenceGroup::accessedBySubtree(bandNode, scop);
-    auto activeStmts = activeStatements(root, bandNode);
     auto partialSched = partialSchedule(root, bandNode);
     auto activePoints = activeDomainPoints(root, bandNode);
 
@@ -517,7 +516,6 @@ void promoteToSharedGreedy(
             tensorId,
             std::move(group),
             bandNode,
-            activeStmts,
             partialSched,
             true);
         remainingMemory -= memoryRequirement;

--- a/src/core/polyhedral/memory_promotion_heuristic.cc
+++ b/src/core/polyhedral/memory_promotion_heuristic.cc
@@ -512,7 +512,8 @@ void promoteToSharedGreedy(
           continue;
         }
 
-        scop.promoteGroupToShared(
+        scop.promoteGroup(
+            Scop::PromotedDecl::Kind::SharedMem,
             tensorId,
             std::move(group),
             bandNode,

--- a/src/core/polyhedral/schedule_transforms.cc
+++ b/src/core/polyhedral/schedule_transforms.cc
@@ -135,17 +135,6 @@ isl::union_set activeDomainPoints(
   return domain;
 }
 
-std::unordered_set<isl::id, isl::IslIdIslHash> activeStatements(
-    const ScheduleTree* root,
-    const ScheduleTree* tree) {
-  std::unordered_set<isl::id, isl::IslIdIslHash> ids;
-  auto domain = activeDomainPoints(root, tree).universe();
-  for (auto d : isl::UnionAsVector<isl::union_set>(domain)) {
-    ids.insert(d.get_tuple_id());
-  }
-  return ids;
-}
-
 vector<ScheduleTree*> collectScheduleTreesPath(
     std::function<ScheduleTree*(ScheduleTree*)> next,
     ScheduleTree* start) {

--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -187,6 +187,22 @@ void Scop::promoteGroup(
     const std::unordered_set<isl::id, isl::IslIdIslHash>& activeStmts,
     isl::union_map schedule,
     bool forceLastExtentOdd) {
+  for (const auto& id : activeStmts) {
+    for (const auto& prom : activePromotions_[id]) {
+      if (promotedDecls_.count(prom.groupId) != 0 &&
+          promotedDecls_[prom.groupId].tensorId == tensorId) {
+        // FIXME: allow double promotion if copies are inserted properly,
+        // in particular if the new promotion is strictly smaller in scope
+        // and size than the existing ones (otherwise we would need to find
+        // the all the existing ones and change their copy relations).
+        std::cerr << "FIXME: not promoting because another promotion of tensor "
+                  << promotedDecls_[prom.groupId].tensorId << " is active in "
+                  << id << std::endl;
+        return;
+      }
+    }
+  }
+
   auto groupId = nextGroupIdForTensor(tensorId);
   insertCopiesUnder(*this, tree, *gr, tensorId, groupId);
   auto sizes = gr->approximationSizes();

--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -179,14 +179,9 @@ void checkFiltersDisjointStatements(const ScheduleTree* root) {
 }
 } // namespace
 
-void Scop::promoteGroup(
-    PromotedDecl::Kind kind,
-    isl::id tensorId,
-    std::unique_ptr<TensorReferenceGroup>&& gr,
-    ScheduleTree* tree,
-    isl::union_map schedule,
-    bool forceLastExtentOdd) {
-  auto activePoints = activeDomainPoints(scheduleRoot(), tree);
+std::vector<std::pair<isl::union_set, Scop::PromotionInfo>>
+Scop::activePromotions(isl::union_set activePoints, isl::id tensorId) {
+  std::vector<std::pair<isl::union_set, Scop::PromotionInfo>> result;
 
   for (const auto& kvp : activePromotions_) {
     if (kvp.first.intersect(activePoints).is_empty()) {
@@ -196,15 +191,32 @@ void Scop::promoteGroup(
     auto groupId = kvp.second.groupId;
     if (promotedDecls_.count(groupId) != 0 &&
         promotedDecls_[groupId].tensorId == tensorId) {
-      // FIXME: allow double promotion if copies are inserted properly,
-      // in particular if the new promotion is strictly smaller in scope
-      // and size than the existing ones (otherwise we would need to find
-      // the all the existing ones and change their copy relations).
-      std::cerr << "FIXME: not promoting because another promotion of tensor "
-                << promotedDecls_[groupId].tensorId << " is active in "
-                << kvp.first << std::endl;
-      return;
+      result.push_back(kvp);
     }
+  }
+
+  return result;
+}
+
+void Scop::promoteGroup(
+    PromotedDecl::Kind kind,
+    isl::id tensorId,
+    std::unique_ptr<TensorReferenceGroup>&& gr,
+    ScheduleTree* tree,
+    isl::union_map schedule,
+    bool forceLastExtentOdd) {
+  auto activePoints = activeDomainPoints(scheduleRoot(), tree);
+
+  auto activeProms = activePromotions(activePoints, tensorId);
+  if (activeProms.size() != 0) {
+    // FIXME: allow double promotion if copies are inserted properly,
+    // in particular if the new promotion is strictly smaller in scope
+    // and size than the existing ones (otherwise we would need to find
+    // the all the existing ones and change their copy relations).
+    std::cerr << "FIXME: not promoting because another promotion of tensor "
+              << tensorId << " is active in " << activeProms[0].first
+              << std::endl;
+    return;
   }
 
   auto groupId = nextGroupIdForTensor(tensorId);

--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -188,19 +188,22 @@ void Scop::promoteGroup(
     bool forceLastExtentOdd) {
   auto activePoints = activeDomainPoints(scheduleRoot(), tree);
 
-  for (const auto& id : activeStmts) {
-    for (const auto& prom : activePromotions_[id]) {
-      if (promotedDecls_.count(prom.groupId) != 0 &&
-          promotedDecls_[prom.groupId].tensorId == tensorId) {
-        // FIXME: allow double promotion if copies are inserted properly,
-        // in particular if the new promotion is strictly smaller in scope
-        // and size than the existing ones (otherwise we would need to find
-        // the all the existing ones and change their copy relations).
-        std::cerr << "FIXME: not promoting because another promotion of tensor "
-                  << promotedDecls_[prom.groupId].tensorId << " is active in "
-                  << id << std::endl;
-        return;
-      }
+  for (const auto& kvp : activePromotions_) {
+    if (kvp.first.intersect(activePoints).is_empty()) {
+      continue;
+    }
+
+    auto groupId = kvp.second.groupId;
+    if (promotedDecls_.count(groupId) != 0 &&
+        promotedDecls_[groupId].tensorId == tensorId) {
+      // FIXME: allow double promotion if copies are inserted properly,
+      // in particular if the new promotion is strictly smaller in scope
+      // and size than the existing ones (otherwise we would need to find
+      // the all the existing ones and change their copy relations).
+      std::cerr << "FIXME: not promoting because another promotion of tensor "
+                << promotedDecls_[groupId].tensorId << " is active in "
+                << kvp.first << std::endl;
+      return;
     }
   }
 


### PR DESCRIPTION
* If a group of references was promoted into shared memory, but it could
be also promoted to registers while covering exactly the same statement
instances accessing it, demote it from shared memory before promoting to
registers.

Stacked on #149 