### PR TITLE
Add pybindings for gflags

### DIFF
--- a/docs/source/framework/pytorch_integration/debugging.rst
+++ b/docs/source/framework/pytorch_integration/debugging.rst
@@ -28,7 +28,7 @@ Example usage
     import tensor_comprehensions as tc
     import torch
 
-    tc.GlobalDebugInit(["--debug_tc_mapper=true", "--debug_lang=false"])
+    tc.GlobalDebugInit(debug_tc_mapper=True, debug_lang=False)
 
     matmul = tc.define(tc.database['matmul']['lang'], name='matmul')
     mat1, mat2 = torch.randn(3, 4).cuda(), torch.randn(4, 5).cuda()
@@ -50,7 +50,7 @@ and the generated CUDA code will be printed on command line.
     import tensor_comprehensions as tc
     import torch
 
-    tc.GlobalDebugInit(["--dump_cuda=true"])
+    tc.GlobalDebugInit(dump_cuda=True)
 
     matmul = tc.define(tc.database['matmul']['lang'], name='matmul')
     mat1, mat2 = torch.randn(3, 4).cuda(), torch.randn(4, 5).cuda()

--- a/docs/source/framework/pytorch_integration/debugging.rst
+++ b/docs/source/framework/pytorch_integration/debugging.rst
@@ -16,7 +16,7 @@ can use these flags to enable logging. Various types of flags exposed are:
 * :code:`debug_tuner`: print debug spew for the tuner multithreading behavior.
 
 
-In order to use enable these flags, you need to call :code:`tc.GlobalDebugInit`
+In order to use enable these flags, you need to call :code:`tc.SetDebugFlags`
 and set the proper flags to :code:`true`. All of these flags are :code:`boolean`
 flags that take values :code:`true` or :code:`false`.
 
@@ -28,14 +28,14 @@ Example usage
     import tensor_comprehensions as tc
     import torch
 
-    tc.GlobalDebugInit(debug_tc_mapper=True, debug_lang=False)
+    tc.SetDebugFlags(debug_tc_mapper=True, debug_lang=False)
 
     matmul = tc.define(tc.database['matmul']['lang'], name='matmul')
     mat1, mat2 = torch.randn(3, 4).cuda(), torch.randn(4, 5).cuda()
     out = matmul(mat1, mat2)
 
 In above example, when the TC executes, we will see the TC mapper information.
-You can chose to set any number of flags but the :code:`tc.GlobalDebugInit` should
+You can chose to set any number of flags but the :code:`tc.SetDebugFlags` should
 only be called once.
 
 Printing TC generated CUDA code
@@ -50,7 +50,7 @@ and the generated CUDA code will be printed on command line.
     import tensor_comprehensions as tc
     import torch
 
-    tc.GlobalDebugInit(dump_cuda=True)
+    tc.SetDebugFlags(dump_cuda=True)
 
     matmul = tc.define(tc.database['matmul']['lang'], name='matmul')
     mat1, mat2 = torch.randn(3, 4).cuda(), torch.randn(4, 5).cuda()

--- a/include/tc/core/flags.h
+++ b/include/tc/core/flags.h
@@ -61,10 +61,4 @@ DECLARE_bool(schedule_tree_verbose_validation);
 // random seed setting for reproducibility and debugging purposes
 uint64_t initRandomSeed();
 const uint64_t& randomSeed();
-
-// python
-namespace python {
-bool globalDebugGflagsGlogInit(int* pargc, char*** pargv);
-} // namespace python
-
 } // namespace tc

--- a/src/core/flags.cc
+++ b/src/core/flags.cc
@@ -111,34 +111,6 @@ DEFINE_int64(
     -1,
     "The number of best candidates to restore from the proto cache");
 
-namespace {
-bool parseCommandLineFlags(int* pargc, char*** pargv) {
-  if (*pargc == 0) {
-    return true;
-  }
-  // TODO: (prigoyal): we need to do some filtering on flags here,
-  // add option for displaying the help message
-  return ::gflags::ParseCommandLineFlags(pargc, pargv, true);
-}
-
-bool initGoogleLogging(int* pargc, char** argv) {
-  if (*pargc == 0) {
-    return true;
-  }
-  ::google::InitGoogleLogging(argv[0]);
-  return true;
-}
-} // namespace
-
-namespace python {
-bool globalDebugGflagsGlogInit(int* pargc, char*** pargv) {
-  bool success = true;
-  success &= parseCommandLineFlags(pargc, pargv);
-  success &= initGoogleLogging(pargc, *pargv);
-  return success;
-}
-} // namespace python
-
 uint64_t initRandomSeed() {
   static std::mutex mut;
   static bool inited = false;

--- a/tensor_comprehensions/__init__.py
+++ b/tensor_comprehensions/__init__.py
@@ -18,7 +18,7 @@ from tensor_comprehensions.tc_unit import define
 from tensor_comprehensions.tc_unit import TcUnit
 from tensor_comprehensions.tc_unit import TcAutotuner
 from tensor_comprehensions.tc_unit import TcCompilationUnit
-from tensor_comprehensions.tc_unit import GlobalDebugInit
+from tensor_comprehensions.tc_unit import SetDebugFlags
 from tensor_comprehensions.tc_unit import autotuner_settings
 from tensor_comprehensions.tc_unit import small_sizes_autotuner_settings
 from tensor_comprehensions.tc_unit import ATenCompilationUnit
@@ -27,6 +27,6 @@ from tensor_comprehensions.library import database
 
 __all__ = [
     'define', 'TcUnit', 'TcAutotuner', 'TcCompilationUnit', 'autotuner_settings',
-    'small_sizes_autotuner_settings', 'GlobalDebugInit', 'ATenCompilationUnit',
+    'small_sizes_autotuner_settings', 'SetDebugFlags', 'ATenCompilationUnit',
     'Options', 'database', 'decode',
 ]

--- a/tensor_comprehensions/pybinds/pybind_engine.cc
+++ b/tensor_comprehensions/pybinds/pybind_engine.cc
@@ -39,21 +39,23 @@ namespace py = pybind11;
 using ATenCudaCompilationUnit = tc::ATenCompilationUnit<tc::CudaTcExecutor>;
 
 PYBIND11_MODULE(tc, m) {
+  m.def("set_debug_lang", [](bool debug_lang) {
+    tc::FLAGS_debug_lang = debug_lang;
+  });
+  m.def("set_debug_halide", [](bool debug_halide) {
+    tc::FLAGS_debug_halide = debug_halide;
+  });
+  m.def("set_debug_tc_mapper", [](bool debug_tc_mapper) {
+    tc::FLAGS_debug_tc_mapper = debug_tc_mapper;
+  });
+  m.def("set_debug_cuda", [](bool debug_cuda) {
+    tc::FLAGS_debug_cuda = debug_cuda;
+  });
+  m.def("set_debug_tuner", [](bool debug_tuner) {
+    tc::FLAGS_debug_tuner = debug_tuner;
+  });
   m.def(
-      "global_debug_init", // exposing the debugging flags to people
-      [](std::vector<std::string> args) {
-        if (args.size() > 0) {
-          args.insert(args.begin(), "tc");
-        }
-        int numArgs = args.size();
-        // now we construct a char** argv type from args
-        std::vector<char*> vargs; // char* vector args
-        for (auto& arg : args) {
-          vargs.push_back(const_cast<char*>(arg.data()));
-        }
-        char** argv = vargs.data();
-        tc::python::globalDebugGflagsGlogInit(&numArgs, &argv);
-      });
+      "set_dump_cuda", [](bool dump_cuda) { tc::FLAGS_dump_cuda = dump_cuda; });
 
   py::object dlpack;
   try {

--- a/tensor_comprehensions/pybinds/pybind_engine.cc
+++ b/tensor_comprehensions/pybinds/pybind_engine.cc
@@ -39,6 +39,9 @@ namespace py = pybind11;
 using ATenCudaCompilationUnit = tc::ATenCompilationUnit<tc::CudaTcExecutor>;
 
 PYBIND11_MODULE(tc, m) {
+  m.def("set_logtostderr", [](bool logtostderr) {
+    FLAGS_logtostderr = logtostderr;
+  });
   m.def("set_debug_lang", [](bool debug_lang) {
     tc::FLAGS_debug_lang = debug_lang;
   });

--- a/tensor_comprehensions/tc_unit.py
+++ b/tensor_comprehensions/tc_unit.py
@@ -19,7 +19,7 @@ import torch
 from torch.autograd import Variable
 
 from tensor_comprehensions.tc import ATenCompilationUnit
-from tensor_comprehensions.tc import set_debug_lang, set_debug_halide, set_debug_tc_mapper, set_debug_cuda, set_debug_tuner, set_dump_cuda
+from tensor_comprehensions.tc import set_logtostderr, set_debug_lang, set_debug_halide, set_debug_tc_mapper, set_debug_cuda, set_debug_tuner, set_dump_cuda
 from tensor_comprehensions.torch_tc.tc_function import TCFunction, unpack_variables, get_tensors, make_contiguous
 from tensor_comprehensions.autotuner import ATenAutotuner
 from tensor_comprehensions.mapping_options import Options
@@ -49,6 +49,7 @@ class SetDebugFlags(object):
         self, debug_lang=False, debug_halide=False, debug_tc_mapper=False,
         debug_cuda=False, debug_tuner=False, dump_cuda=False, **kwargs
     ):
+        set_logtostderr(True)
         set_debug_lang(debug_lang)
         set_debug_halide(debug_halide)
         set_debug_tc_mapper(debug_tc_mapper)

--- a/tensor_comprehensions/tc_unit.py
+++ b/tensor_comprehensions/tc_unit.py
@@ -41,7 +41,7 @@ small_sizes_autotuner_settings = {
 ###############################################################################
 # Set global debugging flags
 ###############################################################################
-class GlobalDebugInit(object):
+class SetDebugFlags(object):
     def __init__(self, **kwargs):
         self.set_gflags(**kwargs)
 

--- a/tensor_comprehensions/tc_unit.py
+++ b/tensor_comprehensions/tc_unit.py
@@ -19,7 +19,7 @@ import torch
 from torch.autograd import Variable
 
 from tensor_comprehensions.tc import ATenCompilationUnit
-from tensor_comprehensions.tc import global_debug_init as GlobalDebugInit
+from tensor_comprehensions.tc import set_debug_lang, set_debug_halide, set_debug_tc_mapper, set_debug_cuda, set_debug_tuner, set_dump_cuda
 from tensor_comprehensions.torch_tc.tc_function import TCFunction, unpack_variables, get_tensors, make_contiguous
 from tensor_comprehensions.autotuner import ATenAutotuner
 from tensor_comprehensions.mapping_options import Options
@@ -37,6 +37,25 @@ autotuner_settings = {"threads": 32}
 small_sizes_autotuner_settings = {
     "threads": 32, "generations": 5, "tuner_min_launch_total_threads": 1,
 }
+
+###############################################################################
+# Set global debugging flags
+###############################################################################
+class GlobalDebugInit(object):
+    def __init__(self, **kwargs):
+        self.set_gflags(**kwargs)
+
+    def set_gflags(
+        self, debug_lang=False, debug_halide=False, debug_tc_mapper=False,
+        debug_cuda=False, debug_tuner=False, dump_cuda=False, **kwargs
+    ):
+        set_debug_lang(debug_lang)
+        set_debug_halide(debug_halide)
+        set_debug_tc_mapper(debug_tc_mapper)
+        set_debug_cuda(debug_cuda)
+        set_debug_tuner(debug_tuner)
+        set_dump_cuda(dump_cuda)
+
 
 ###############################################################################
 # Some helper functions

--- a/test_python/layers/test_dump_cuda.py
+++ b/test_python/layers/test_dump_cuda.py
@@ -21,7 +21,7 @@ import unittest
 
 # enable this to dump cuda code generated whenever tc layer runs: simple run or
 # autotuner run
-tc.GlobalDebugInit(dump_cuda=True)
+tc.SetDebugFlags(dump_cuda=True)
 
 
 class TestDumpCuda(unittest.TestCase):

--- a/test_python/layers/test_dump_cuda.py
+++ b/test_python/layers/test_dump_cuda.py
@@ -21,7 +21,7 @@ import unittest
 
 # enable this to dump cuda code generated whenever tc layer runs: simple run or
 # autotuner run
-tc.GlobalDebugInit(["--dump_cuda=true"])
+tc.GlobalDebugInit(dump_cuda=True)
 
 
 class TestDumpCuda(unittest.TestCase):

--- a/test_python/layers/test_dump_cuda.py
+++ b/test_python/layers/test_dump_cuda.py
@@ -16,7 +16,6 @@
 import tensor_comprehensions as tc
 
 import torch
-import torch.cuda
 import unittest
 
 # enable this to dump cuda code generated whenever tc layer runs: simple run or

--- a/test_python/layers/test_layernorm.py
+++ b/test_python/layers/test_layernorm.py
@@ -19,7 +19,7 @@ import torch
 import torch.cuda
 import unittest
 
-tc.GlobalDebugInit(debug_tuner=False, debug_tc_mapper=False)
+tc.SetDebugFlags(debug_tuner=False, debug_tc_mapper=False)
 
 
 class TestLayerNorm(unittest.TestCase):

--- a/test_python/layers/test_layernorm.py
+++ b/test_python/layers/test_layernorm.py
@@ -19,7 +19,7 @@ import torch
 import torch.cuda
 import unittest
 
-tc.GlobalDebugInit(["--debug_tuner=false", "--debug_tc_mapper=false"])
+tc.GlobalDebugInit(debug_tuner=False, debug_tc_mapper=False)
 
 
 class TestLayerNorm(unittest.TestCase):

--- a/test_python/test_debug_init.py
+++ b/test_python/test_debug_init.py
@@ -19,7 +19,7 @@ import torch
 import torch.cuda
 import tensor_comprehensions as tc
 
-tc.GlobalDebugInit(["--dump_cuda=true", "--debug_tc_mapper=false"])
+tc.GlobalDebugInit(dump_cuda=True, debug_tc_mapper=True)
 
 
 class TestDebugInit(unittest.TestCase):

--- a/test_python/test_debug_init.py
+++ b/test_python/test_debug_init.py
@@ -19,7 +19,7 @@ import torch
 import torch.cuda
 import tensor_comprehensions as tc
 
-tc.GlobalDebugInit(dump_cuda=True, debug_tc_mapper=True)
+tc.SetDebugFlags(dump_cuda=True, debug_tc_mapper=True)
 
 
 class TestDebugInit(unittest.TestCase):

--- a/test_python/test_tc_torch.py
+++ b/test_python/test_tc_torch.py
@@ -24,7 +24,7 @@ import tensor_comprehensions as tc
 from tensor_comprehensions.mapping_options import Options
 from common import TestCase, run_tests
 
-tc.GlobalDebugInit(dump_cuda=False)
+tc.SetDebugFlags(dump_cuda=False)
 
 
 MATMUL_LANG = """

--- a/test_python/test_tc_torch.py
+++ b/test_python/test_tc_torch.py
@@ -24,7 +24,7 @@ import tensor_comprehensions as tc
 from tensor_comprehensions.mapping_options import Options
 from common import TestCase, run_tests
 
-tc.GlobalDebugInit(["--dump_cuda=false"])
+tc.GlobalDebugInit(dump_cuda=False)
 
 
 MATMUL_LANG = """


### PR DESCRIPTION
I have been thinking about how to go about it easily and the solution was in plain-sight. I added pybind for the flags.

Pros:
1. we can now replace std::cout -> LOG_IF
2. The flags can be reset many times and the init doesn't have to be just once

Cons:
1. bindings will have to be modified in future everytime a new flag is added that we want to expose to people

closes #113 