### PR TITLE
polyhedral/codegen_*.cc: remove comment about schedule space

### DIFF
--- a/src/core/polyhedral/codegen_cuda.cc
+++ b/src/core/polyhedral/codegen_cuda.cc
@@ -872,8 +872,6 @@ string emitCudaKernel(
            IteratorMapsType* iteratorMaps) -> isl::ast_node {
       auto expr = node.user_get_expr();
       auto stmtId = expr.get_op_arg(0).get_id();
-      // Note that the schedule obtained from build does NOT live in the
-      // schedule space obtained from build, despite the naming.
       // We rename loop-related dimensions manually.
       auto schedule = build.get_schedule();
       auto scheduleSpace = build.get_schedule_space();

--- a/src/core/polyhedral/codegen_llvm.cc
+++ b/src/core/polyhedral/codegen_llvm.cc
@@ -702,8 +702,6 @@ IslCodegenRes codegenISL(const Scop& scop) {
            const Scop& scop,
            StmtSubscriptExprMapType& stmtSubscripts) -> isl::ast_node {
       auto expr = node.user_get_expr();
-      // Note that the schedule obtained from build does NOT live in the
-      // schedule space obtained from build, despite the naming.
       // We rename loop-related dimensions manually.
       auto schedule = build.get_schedule();
       auto scheduleSpace = build.get_schedule_space();


### PR DESCRIPTION
Apparently, there was some confusion before about
the relation between the schedule and the schedule space,
but that appears to have been cleared up.
Now the comment itself is confusing.  Remove it.