### PR TITLE
Fix compilation issue: hides overloaded virtual functions

### DIFF
--- a/src/core/polyhedral/codegen_llvm.cc
+++ b/src/core/polyhedral/codegen_llvm.cc
@@ -250,6 +250,7 @@ class CodeGen_TC : public Halide::Internal::CodeGen_X86 {
   }
 
  protected:
+  using CodeGen_X86::visit;
   void visit(const Halide::Internal::Call* call) override {
     if (call->call_type == Halide::Internal::Call::CallType::Image ||
         call->call_type == Halide::Internal::Call::CallType::Halide) {


### PR DESCRIPTION
This diff fixed this compilation issue: 

tc/tc/src/core/polyhedral/codegen_llvm.cc:273:8: error: 'tc::polyhedral::(anonymous namespace)::CodeGen_TC::visit' hides overloaded virtual functions [-Werror,-Woverloaded-virtual]
  void visit(const Halide::Internal::Variable* op) override {
       ^
I have tested it locally. 