### PR TITLE
Fix compilation issue: undefined template

### DIFF
--- a/include/tc/core/polyhedral/schedule_tree_elem.h
+++ b/include/tc/core/polyhedral/schedule_tree_elem.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <memory>
+#include <sstream>
 #include <unordered_set>
 #include <vector>
 

--- a/src/core/polyhedral/codegen.cc
+++ b/src/core/polyhedral/codegen.cc
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <sstream>
 #include "tc/core/polyhedral/codegen.h"
+#include <sstream>
 
 namespace tc {
 namespace polyhedral {

--- a/src/core/polyhedral/codegen.cc
+++ b/src/core/polyhedral/codegen.cc
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <sstream>
 #include "tc/core/polyhedral/codegen.h"
 
 namespace tc {


### PR DESCRIPTION
This diff fixes the following compilation issue: 
tc/tc/include/tc/core/polyhedral/schedule_tree_elem.h:165:31: error: implicit instantiation of undefined template 'std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >'
            std::stringstream ss;
                              ^
third-party-buck/gcc-5-glibc-2.23/build/libgcc/include/c++/trunk/iosfwd:108:11: note: template is declared here
    class basic_stringstream;
          ^
1 error generated.
In file included from tc/tc/src/core/polyhedral/unroll.cc:17:
In file included from tc/tc/include/tc/core/polyhedral/unroll.h:18:
In file included from tc/tc/include/tc/core/polyhedral/schedule_tree.h:24:

