### PR TITLE
emitLLVMKernel: avoid relying on isl set variable names

### DIFF
--- a/include/tc/core/halide2isl.h
+++ b/include/tc/core/halide2isl.h
@@ -51,6 +51,8 @@ isl::aff makeIslAffFromInt(isl::space space, int64_t i);
 // does not correspond to a parameter or set dimension of the space.
 isl::aff makeIslAffFromExpr(isl::space space, const Halide::Expr& e);
 
+typedef std::unordered_map<isl::id, std::vector<std::string>, isl::IslIdIslHash>
+    IteratorMap;
 typedef std::unordered_map<isl::id, Halide::Internal::Stmt, isl::IslIdIslHash>
     StatementMap;
 typedef std::unordered_map<const Halide::Internal::IRNode*, isl::id> AccessMap;
@@ -73,6 +75,10 @@ struct ScheduleTreeAndAccesses {
   /// The correspondence between leaf Stmts and the statement ids
   /// refered to above.
   StatementMap statements;
+
+  /// The correspondence between statement ids and the outer loop iterators
+  /// of the corresponding leaf Stmt.
+  IteratorMap iterators;
 };
 
 /// Make a schedule tree from a Halide Stmt, along with auxiliary data

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -421,7 +421,7 @@ struct Scop {
     std::unordered_map<const Halide::Internal::IRNode*, isl::id> accesses;
   } halide;
 
-  // Poyhedral IR
+  // Polyhedral IR
   //
   // The domain is collected from the root of the ScheduleTree; no redundant
   // state is kept.

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -419,6 +419,7 @@ struct Scop {
     std::unordered_map<isl::id, Halide::Internal::Stmt, isl::IslIdIslHash>
         statements;
     std::unordered_map<const Halide::Internal::IRNode*, isl::id> accesses;
+    halide2isl::IteratorMap iterators;
   } halide;
 
   // Polyhedral IR

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -358,6 +358,17 @@ struct Scop {
   // Assumes such argument exists.
   const Halide::OutputImageParam& findArgument(isl::id id) const;
 
+  // Make an affine function from a Halide Expr that is defined
+  // over the instance set of the statement with identifier "stmtId" and
+  // with parameters specified by "paramSpace".  Return a
+  // null isl::aff if the expression is not affine.  Fail if any
+  // of the variables does not correspond to a parameter or
+  // an instance identifier of the statement.
+  isl::aff makeIslAffFromStmtExpr(
+      isl::id stmtId,
+      isl::space paramSpace,
+      const Halide::Expr& e) const;
+
   // Promote a tensor reference group to a storage of a given "kind",
   // inserting the copy
   // statements below the given node.  Inserts an Extension node below the give

--- a/src/core/halide2isl.cc
+++ b/src/core/halide2isl.cc
@@ -316,6 +316,20 @@ struct ScheduleTreeAndDomain {
   isl::union_set domain;
 };
 
+/*
+ * Helper function for extracting a schedule tree from a Halide Stmt,
+ * recursively descending over the Stmt.
+ * "s" is the current position in the recursive descent.
+ * "set" describes the bounds on the outer loop iterators.
+ * Return the schedule tree corresponding to the subtree at "s",
+ * along with a separated out domain.
+ *
+ * "reads" and "writes" collect the accesses found along the way.
+ * "accesses" collects the mapping from Call (for the reads) and Provide nodes
+ * (for the writes) to the corresponding tag in the access relations.
+ * "statements" collects the mapping from instance set tuple identifiers
+ * to the corresponding Provide node.
+ */
 ScheduleTreeAndDomain makeScheduleTreeHelper(
     const Stmt& s,
     isl::set set,

--- a/src/core/polyhedral/codegen_llvm.cc
+++ b/src/core/polyhedral/codegen_llvm.cc
@@ -72,8 +72,9 @@ isl::aff makeIslAffFromExpr(isl::space space, const Halide::Expr& e);
 
 namespace polyhedral {
 
+using IteratorMapType = isl::pw_multi_aff;
 using IteratorMapsType =
-    std::unordered_map<isl::id, isl::pw_multi_aff, isl::IslIdIslHash>;
+    std::unordered_map<isl::id, IteratorMapType, isl::IslIdIslHash>;
 
 using IteratorLLVMValueMapType =
     std::unordered_map<isl::id, llvm::Value*, isl::IslIdIslHash>;
@@ -214,7 +215,7 @@ static constexpr int kOptLevel = 3;
 
 class CodeGen_TC : public Halide::Internal::CodeGen_X86 {
  public:
-  const isl::pw_multi_aff* iteratorMap_;
+  const IteratorMapType* iteratorMap_;
   CodeGen_TC(Target t) : CodeGen_X86(t) {}
 
   using CodeGen_X86::codegen;

--- a/src/core/polyhedral/codegen_llvm.cc
+++ b/src/core/polyhedral/codegen_llvm.cc
@@ -646,7 +646,7 @@ class LLVMCodegen {
         }
         case isl_ast_expr_type::isl_ast_expr_int: {
           auto val = isl::manage(isl_ast_expr_get_val(subscript.get()));
-          CHECK_EQ(val.get_den_si(), 1);
+          CHECK(val.is_int());
           subscriptValues.push_back(
               getLLVMConstantSignedInt64(val.get_num_si()));
           break;

--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -70,6 +70,7 @@ ScopUPtr Scop::makeScop(
   scop->halide.statements = std::move(tree.statements);
   scop->halide.accesses = std::move(tree.accesses);
   scop->halide.reductions = halide2isl::findReductions(components.stmt);
+  scop->halide.iterators = std::move(tree.iterators);
 
   // Set partial schedule tuples for proper comparison with ISL
   // schedules (needs DFSPreorder numbering). Just for testing.

--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -558,5 +558,23 @@ const Halide::OutputImageParam& Scop::findArgument(isl::id id) const {
   return *halide.inputs.begin();
 }
 
+isl::aff Scop::makeIslAffFromStmtExpr(
+    isl::id stmtId,
+    isl::space paramSpace,
+    const Halide::Expr& e) const {
+  auto ctx = stmtId.get_ctx();
+  auto iterators = halide.iterators.at(stmtId);
+  auto space = paramSpace.set_from_params();
+  space = space.add_dims(isl::dim_type::set, iterators.size());
+  // Set the names of the set dimensions of "space" for use
+  // by halide2isl::makeIslAffFromExpr.
+  for (int i = 0; i < iterators.size(); ++i) {
+    isl::id id(ctx, iterators[i]);
+    space = space.set_dim_id(isl::dim_type::set, i, id);
+  }
+  space = space.set_tuple_id(isl::dim_type::set, stmtId);
+  return halide2isl::makeIslAffFromExpr(space, e);
+}
+
 } // namespace polyhedral
 } // namespace tc


### PR DESCRIPTION
codegenISL relied on set variable names in two ways.
First, it assumed that the variable names of the domain
of the schedule were preserved through the entire
AST generation process.
Explicitly set the names of the space sent to
halide2isl::makeIslAffFromExpr instead of assuming
they are still available in the schedule.
halide2isl::makeIslAffFromExpr itself still relies on
the names in the space itself being preserved, but
the space does not get modified in between,
so the risk of the names disappearing is reduced.

Second, codegenISL would manually set the names of the range
of the schedule, expecting them to be preserved across subsequent operations,
but this is again not guaranteed.
Convert the corresponding expressions to isl::ast_expr objects instead.
As a nice bonus, the code generation for subscripts and variables
now share the same mechanism, while before one used isl::ast_expr
objects, while the other used an isl::pw_multi_aff.
As a result, a lot of code can be removed.