### PR TITLE
Add TC format (a pretty printer for AST)

### DIFF
--- a/include/tc/lang/lexer.h
+++ b/include/tc/lang/lexer.h
@@ -99,7 +99,11 @@ enum TokenKind {
 #undef DEFINE_TOKEN
 };
 
+// Returns a human-readable description of the token
 std::string kindToString(int kind);
+// Returns the string used by the lexer to match a given token, or throws
+// if it can't be produced by the lexer.
+std::string kindToToken(int kind);
 
 // nested hash tables that indicate char-by-char what is a valid token.
 struct TokenTrie;

--- a/include/tc/lang/tc_format.h
+++ b/include/tc/lang/tc_format.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "tc/lang/tree.h"
+
+#include <ostream>
+
+namespace lang {
+
+/// \file tc_format.h
+/// A pretty printer that turns a Def (TC AST) into a valid TC string that
+/// could be e.g. re-parsed.
+
+void tcFormat(std::ostream& s, TreeRef def);
+
+} // namespace lang

--- a/include/tc/lang/tree_views.h
+++ b/include/tc/lang/tree_views.h
@@ -82,6 +82,9 @@ struct ListView : public TreeView {
   size_t size() const {
     return tree_->trees().size();
   }
+  bool empty() const {
+    return size() == 0;
+  }
   static TreeRef create(const SourceRange& range, TreeList elements) {
     return Compound::create(TK_LIST, range, std::move(elements));
   }

--- a/src/lang/CMakeLists.txt
+++ b/src/lang/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
 
   parser.cc
   lexer.cc
+  tc_format.cc
 )
 
 install(

--- a/src/lang/lexer.cc
+++ b/src/lang/lexer.cc
@@ -32,6 +32,22 @@ std::string kindToString(int kind) {
   }
 }
 
+std::string kindToToken(int kind) {
+  if (kind < 256)
+    return std::string(1, kind);
+  switch (kind) {
+#define DEFINE_CASE(tok, _, str)                                       \
+  case tok:                                                            \
+    if (str == "")                                                     \
+      throw std::runtime_error("No token for: " + kindToString(kind)); \
+    return str;
+    TC_FORALL_TOKEN_KINDS(DEFINE_CASE)
+#undef DEFINE_CASE
+    default:
+      throw std::runtime_error("unknown kind: " + std::to_string(kind));
+  }
+}
+
 SharedParserData& sharedParserData() {
   static SharedParserData data; // safely handles multi-threaded init
   return data;

--- a/src/lang/tc_format.cc
+++ b/src/lang/tc_format.cc
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/lang/tc_format.h"
+#include "tc/lang/tree_views.h"
+
+namespace lang {
+
+namespace {
+
+void showExpr(std::ostream& s, const TreeRef& expr);
+
+template <typename T>
+void show(std::ostream& s, T x) {
+  s << x;
+}
+
+template <typename T, typename F>
+void showList(std::ostream& s, const ListView<T>& list, F elem_cb) {
+  bool first = true;
+  for (const auto& elem : list) {
+    if (!first) {
+      s << ", ";
+    }
+    elem_cb(s, elem);
+    first = false;
+  }
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& s, const ListView<T>& list) {
+  showList(s, list, show<T>);
+  return s;
+}
+
+std::ostream& operator<<(std::ostream& s, const Ident& id) {
+  return s << id.name();
+}
+
+std::ostream& operator<<(std::ostream& s, const Param& p) {
+  if (!p.typeIsInferred()) {
+    TensorType type{p.type()};
+    s << kindToString(type.scalarType()) << "(";
+    showList(s, type.dims(), showExpr);
+    s << ") ";
+  }
+  return s << p.ident();
+}
+
+std::ostream& operator<<(std::ostream& s, const Comprehension& comp) {
+  s << comp.ident() << "(" << comp.indices() << ") "
+    << kindToToken(comp.assignment()->kind()) << " ";
+  showExpr(s, comp.rhs());
+  if (!comp.whereClauses().empty())
+    throw std::runtime_error("Printing of where clauses is not supported yet");
+  if (comp.equivalent().present())
+    throw std::runtime_error(
+        "Printing of equivalent comprehensions is not supported yet");
+  return s;
+}
+
+void showExpr(std::ostream& s, const TreeRef& expr) {
+  switch (expr->kind()) {
+    case TK_IDENT: {
+      s << Ident(expr);
+      break;
+    }
+    case TK_AND:
+    case TK_OR:
+    case '<':
+    case '>':
+    case TK_EQ:
+    case TK_LE:
+    case TK_GE:
+    case TK_NE:
+    case '+':
+    case '*':
+    case '/': {
+      s << "(";
+      showExpr(s, expr->tree(0));
+      s << " " << kindToToken(expr->kind()) << " ";
+      showExpr(s, expr->tree(1));
+      s << ")";
+      break;
+      // '-' is annoying because it can be both unary and binary
+    }
+    case '-': {
+      if (expr->trees().size() == 1) {
+        s << "-";
+        showExpr(s, expr->tree(0));
+      } else {
+        s << "(";
+        showExpr(s, expr->tree(0));
+        s << " - ";
+        showExpr(s, expr->tree(1));
+        s << ")";
+      }
+      break;
+    }
+    case '!': {
+      s << "!";
+      showExpr(s, expr->tree(0));
+      break;
+    }
+    case TK_CONST: {
+      Const con{expr};
+      int scalarType = con.type()->kind();
+      switch (con.type()->kind()) {
+        case TK_FLOAT:
+        case TK_DOUBLE:
+          s << con.value();
+          break;
+        case TK_UINT8:
+        case TK_UINT16:
+        case TK_UINT32:
+        case TK_UINT64:
+          s << static_cast<uint64_t>(con.value());
+          break;
+        case TK_INT8:
+        case TK_INT16:
+        case TK_INT32:
+        case TK_INT64:
+          s << static_cast<int64_t>(con.value());
+          break;
+        default:
+          throw std::runtime_error(
+              "Unknown scalar type in const: " +
+              kindToString(con.type()->kind()));
+      }
+      break;
+    }
+    case TK_CAST: {
+      Cast cast{expr};
+      s << kindToToken(cast.type()->kind()) << "(";
+      showExpr(s, cast.value());
+      s << ")";
+      break;
+    }
+    case '.': {
+      Select sel{expr};
+      s << sel.name() << "." << sel.index();
+      break;
+    }
+    case TK_APPLY:
+    case TK_ACCESS:
+    case TK_BUILT_IN: {
+      s << Ident(expr->tree(0)) << "(";
+      showList(s, ListView<TreeRef>(expr->tree(1)), showExpr);
+      s << ")";
+      break;
+    }
+    default: {
+      throw std::runtime_error(
+          "Unexpected kind in showExpr: " + kindToString(expr->kind()));
+    }
+  }
+}
+
+} // anonymous namespace
+
+void tcFormat(std::ostream& s, TreeRef _def) {
+  Def def{_def};
+  s << "def " << def.name() << "(" << def.params() << ")"
+    << " -> (" << def.returns() << ") {\n";
+  for (const Comprehension& c : def.statements()) {
+    s << "  " << c << "\n";
+  }
+  s << "}";
+}
+
+} // namespace lang

--- a/test/test_lang.cc
+++ b/test/test_lang.cc
@@ -25,6 +25,7 @@
 #include "tc/lang/canonicalize.h"
 #include "tc/lang/parser.h"
 #include "tc/lang/sema.h"
+#include "tc/lang/tc_format.h"
 
 using namespace lang;
 
@@ -145,6 +146,17 @@ std::string canonicalText(const std::string& text) {
   std::stringstream ss;
   ss << canonicalize(loadText(text));
   return ss.str();
+}
+
+void testTcFormat() {
+  static std::ios_base::Init initIostreams;
+  auto source = R"(def fun2(float(B, N, M) X, float(B, M, K) Y) -> (Q) {
+  Q(b, ii, j) += (((exp(X(b, ii, k)) * int(Y(b, k, j))) * 2.5) + 3)
+})";
+  auto def_tree = Parser(source).parseFunction();
+  std::ostringstream s;
+  tcFormat(s, def_tree);
+  ASSERT(s.str() == source);
 }
 
 int main(int argc, char** argv) {
@@ -318,6 +330,8 @@ int main(int argc, char** argv) {
     }
   )";
   ASSERT(canonicalText(option_one) == canonicalText(option_two));
+
+  testTcFormat();
 
   // assertSemaEqual(
   //     "comments.expected",


### PR DESCRIPTION
This currently doesn't handle `where`, `let`, range constraints, and `<=>`, but this can be added later if needed.