### PR TITLE
Fix tc_lang runtime error in FBcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ message(STATUS "CMAKE_INSTALL_PREFIX is ${CMAKE_INSTALL_PREFIX}")
 
 add_subdirectory(third-party/pybind11)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTC_DIR=\"\\\"$ENV{TC_DIR}\\\"\" ")
+
 set(LLVM_DIR ${CLANG_PREFIX}/lib/cmake/llvm)
 message(STATUS "Looking for LLVM in ${LLVM_DIR}")
 find_package(LLVM REQUIRED LLVM)

--- a/include/tc/lang/tree.h
+++ b/include/tc/lang/tree.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <sstream>
 #include <vector>
 
 #include "tc/lang/lexer.h"

--- a/test/test_lang.cc
+++ b/test/test_lang.cc
@@ -29,10 +29,10 @@
 using namespace lang;
 
 #ifdef ROOT_PATH
-  const std::string expected_file_path =
-      std::string(ROOT_PATH) + "src/lang/test_expected/";
+const std::string expected_file_path =
+    std::string(ROOT_PATH) + "src/lang/test_expected/";
 #else
-  const std::string expected_file_path = "src/lang/test_expected/";
+const std::string expected_file_path = "src/lang/test_expected/";
 #endif
 
 static inline void barf(const char* fmt, ...) {

--- a/test/test_lang.cc
+++ b/test/test_lang.cc
@@ -29,7 +29,8 @@
 using namespace lang;
 
 #ifdef ROOT_PATH
-  const std::string expected_file_path = std::string(ROOT_PATH) + "src/lang/test_expected/";
+  const std::string expected_file_path =
+      std::string(ROOT_PATH) + "src/lang/test_expected/";
 #else
   const std::string expected_file_path = "src/lang/test_expected/";
 #endif

--- a/test/test_lang.cc
+++ b/test/test_lang.cc
@@ -28,7 +28,11 @@
 
 using namespace lang;
 
-const std::string expected_file_path = "src/lang/test_expected/";
+#ifdef ROOT_PATH
+  const std::string expected_file_path = std::string(ROOT_PATH) + "src/lang/test_expected/";
+#else
+  const std::string expected_file_path = "src/lang/test_expected/";
+#endif
 
 static inline void barf(const char* fmt, ...) {
   char msg[2048];

--- a/test/test_lang.cc
+++ b/test/test_lang.cc
@@ -33,7 +33,7 @@ using namespace lang;
 #endif
 
 const std::string expected_file_path =
-    std::string(TC_DIR) + "src/lang/test_expected/";
+    std::string(TC_DIR) + "/src/lang/test_expected/";
 
 static inline void barf(const char* fmt, ...) {
   char msg[2048];

--- a/test/test_lang.cc
+++ b/test/test_lang.cc
@@ -28,12 +28,12 @@
 
 using namespace lang;
 
-#ifdef ROOT_PATH
-const std::string expected_file_path =
-    std::string(ROOT_PATH) + "src/lang/test_expected/";
-#else
-const std::string expected_file_path = "src/lang/test_expected/";
+#ifndef TC_DIR
+#error "TC_DIR must be defined"
 #endif
+
+const std::string expected_file_path =
+    std::string(TC_DIR) + "src/lang/test_expected/";
 
 static inline void barf(const char* fmt, ...) {
   char msg[2048];


### PR DESCRIPTION
This diff fixed a runtime error with tc_lang which was caused by incorrect file path. The added "ROOT_PATH" will be passed by the buck TARGET. 