### PR TITLE
emitHalideExpr: print parentheses around compound nested expressions

### DIFF
--- a/include/tc/core/polyhedral/cuda/codegen.h
+++ b/include/tc/core/polyhedral/cuda/codegen.h
@@ -31,10 +31,6 @@ struct CodegenStatementContext;
 
 namespace detail {
 
-void emitDirectSubscripts(
-    isl::pw_multi_aff subscripts,
-    const CodegenStatementContext& context);
-
 std::string toString(isl::pw_aff subscript);
 
 isl::pw_aff makeAffFromMappedExpr(

--- a/include/tc/core/polyhedral/cuda/codegen.h
+++ b/include/tc/core/polyhedral/cuda/codegen.h
@@ -31,8 +31,6 @@ struct CodegenStatementContext;
 
 namespace detail {
 
-std::string toString(isl::pw_aff subscript);
-
 isl::pw_aff makeAffFromMappedExpr(
     const Halide::Expr& expr,
     const CodegenStatementContext& context);

--- a/src/core/polyhedral/cuda/codegen.cc
+++ b/src/core/polyhedral/cuda/codegen.cc
@@ -359,6 +359,17 @@ void emitReductionInit(
   context.ss << ";" << endl;
 }
 
+namespace {
+template <typename AFF>
+void emitAccess(AFF access, const CodegenStatementContext& context) {
+  // Use a temporary isl::ast_build to print the expression.
+  // Ideally, this should use the build at the point
+  // where the user statement was created.
+  auto astBuild = isl::ast_build::from_context(access.domain());
+  context.ss << astBuild.access_from(access).to_C_str();
+}
+} // namespace
+
 void emitCopyStmt(const CodegenStatementContext& context) {
   using detail::emitDirectSubscripts;
 
@@ -613,8 +624,7 @@ void emitMappedTensorAccess(
   auto astToPromoted =
       isl::pw_multi_aff(promotion).pullback(astToScheduledOriginal);
 
-  auto astBuild = isl::ast_build::from_context(astToPromoted.domain());
-  context.ss << astBuild.access_from(astToPromoted).to_C_str();
+  emitAccess(astToPromoted, context);
 }
 
 void emitDirectSubscripts(

--- a/src/core/polyhedral/cuda/codegen.cc
+++ b/src/core/polyhedral/cuda/codegen.cc
@@ -452,14 +452,6 @@ void AstPrinter::emitAst(isl::ast_node node) {
 
 namespace detail {
 
-std::string toString(isl::pw_aff subscript) {
-  // Use a temporary isl::ast_build to print the expression.
-  // Ideally, this should use the build at the point
-  // where the user statement was created.
-  auto astBuild = isl::ast_build::from_context(subscript.domain());
-  return astBuild.expr_from(subscript).to_C_str();
-}
-
 isl::pw_aff makeAffFromMappedExpr(
     const Halide::Expr& expr,
     const CodegenStatementContext& context) {
@@ -514,7 +506,12 @@ void emitHalideExpr(
       // a name to look up somewhere.
       auto pwAff = tc::polyhedral::detail::makeAffFromMappedExpr(
           Halide::Expr(op), context);
-      context.ss << tc::polyhedral::detail::toString(pwAff);
+      // Use a temporary isl::ast_build to print the expression.
+      // Ideally, this should use the build at the point
+      // where the user statement was created.
+      auto astBuild = isl::ast_build::from_context(pwAff.domain());
+      auto s = astBuild.expr_from(pwAff).to_C_str();
+      context.ss << s;
     }
     void visit(const Halide::Internal::Call* op) {
       if (substitutions.count(op->name)) {

--- a/test/test_mapper.cc
+++ b/test/test_mapper.cc
@@ -186,7 +186,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
   float32 (*B)[M] = reinterpret_cast<float32 (*)[M]>(pB);
   for (int c1 = 16 * b1; c1 < M; c1 += 4096) {
     if (M >= t1 + c1 + 1) {
-      C[t0 + 16 * b0][t1 + c1] = (A[t0 + 16 * b0][t1 + c1] + B[t0 + 16 * b0][t1 + c1]);
+      C[(t0 + 16 * b0)][(t1 + c1)] = (A[(t0 + 16 * b0)][(t1 + c1)] + B[(t0 + 16 * b0)][(t1 + c1)]);
     }
   }
 }
@@ -318,9 +318,9 @@ constexpr auto kExpectedMatmul_64_64_64 =
     for (int c1 = 0; c1 <= 63; c1 += 16) {
       for (int c2 = t1; c2 <= 15; c2 += 8) {
         for (int c3 = 0; c3 <= 15; c3 += 1) {
-          O[c0 + c2][c1 + c3] = 0.000000f;
+          O[(c0 + c2)][(c1 + c3)] = 0.000000f;
           for (int c4 = t0; c4 <= 63; c4 += 32) {
-            O[c0 + c2][c1 + c3] = (O[c0 + c2][c1 + c3] + (A[c0 + c2][c4]*B[c4][c1 + c3]));
+            O[(c0 + c2)][(c1 + c3)] = (O[(c0 + c2)][(c1 + c3)] + (A[(c0 + c2)][c4]*B[c4][(c1 + c3)]));
           }
         }
       }
@@ -443,7 +443,7 @@ TEST_F(PolyhedralMapperTest, Unroll1D) {
   auto mscop = MappedScop::makeWithOuterBlockInnerThreadStrategy(
       std::move(scop), mappingOptions);
   auto code = std::get<0>(mscop->codegen(specializedName));
-  std::string expected("C[64 * b0 + c2][t0 + 64 * b1]");
+  std::string expected("C[(64 * b0 + c2)][(t0 + 64 * b1)]");
   ASSERT_TRUE(code.find(expected) != std::string::npos) << code;
 }
 
@@ -462,7 +462,7 @@ TEST_F(PolyhedralMapperTest, Unroll2D) {
   auto mscop = MappedScop::makeWithOuterBlockInnerThreadStrategy(
       std::move(scop), mappingOptions);
   auto code = std::get<0>(mscop->codegen(specializedName));
-  std::string expected("C[t1 + 64 * b0 + 32][t0 + 64 * b1 + 32]");
+  std::string expected("C[(t1 + 64 * b0 + 32)][(t0 + 64 * b1 + 32)]");
   ASSERT_TRUE(code.find(expected) != std::string::npos);
 }
 
@@ -712,7 +712,7 @@ TEST_F(PolyhedralMapperTest, ReductionMM1D) {
   auto code = codegenMapped(kTcMM, mappingOptions);
   using tc::code::cuda::kCUBReductionName;
   EXPECT_TRUE(code.find(kCUBReductionName) != std::string::npos);
-  EXPECT_TRUE(code.find("C[c0 + c3][t0 + c1] = (C") != std::string::npos);
+  EXPECT_TRUE(code.find("C[(c0 + c3)][(t0 + c1)] = (C") != std::string::npos);
 }
 
 /*
@@ -730,7 +730,7 @@ TEST_F(PolyhedralMapperTest, ReductionMM2D) {
   auto code = codegenMapped(kTcMM, mappingOptions);
   using tc::code::cuda::kCUBReductionName;
   EXPECT_TRUE(code.find(kCUBReductionName) != std::string::npos);
-  EXPECT_TRUE(code.find("C[t1 + c0][t0 + c1] = (C") != std::string::npos);
+  EXPECT_TRUE(code.find("C[(t1 + c0)][(t0 + c1)] = (C") != std::string::npos);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Despite what the original comment claims, the expression in the output
that corresponds to a variable in the input may not be an identifier
by itself.  Since the variable may appear in a Halide expression
at any position (e.g., as an argument to "-" or "*"), parentheses
need to be put around the expression if it is anything other than
an identifier or a non-negative number.