### PR TITLE
unit test for mul reduction, use pytest + gen=2/pop=1 to improve test time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ third-party/llvm_sources*
 third-party-install/*
 buck-out
 .buckd
+.pytest_cache
 conda
 .nfs*
 */.nfs*

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -72,6 +72,7 @@ if [[ "$DISTRIB_RELEASE" == 14.04 ]]; then
     source activate tc-env
     conda install -y -c pytorch pytorch
     conda install -y pyyaml
+    conda install -yc conda-forge pytest
     WITH_PYTHON_C2=OFF CORES=$(nproc) CLANG_PREFIX=/usr/local/clang+llvm-tapir5.0 BUILD_TYPE=Release ./build.sh --all
   else
     echo "Building TC in non-conda env"
@@ -86,6 +87,7 @@ if [[ "$DISTRIB_RELEASE" == 16.04 ]]; then
     source activate tc-env
     conda install -y pytorch cuda90 -c pytorch
     conda install -y pyyaml
+    conda install -yc conda-forge pytest
     WITH_PYTHON_C2=OFF CORES=$(nproc) CLANG_PREFIX=/usr/local/clang+llvm-tapir5.0 BUILD_TYPE=Release ./build.sh --all
   else
     echo "Building TC in non-conda env"

--- a/tensor_comprehensions/tc_unit.py
+++ b/tensor_comprehensions/tc_unit.py
@@ -31,13 +31,13 @@ logger = logging.getLogger(__name__)
 
 # these are quick options for finishing autotuning
 autotuner_settings = {
-    "threads": 32, "generations": 2, "pop_size": 5,
+    "threads": 32, "generations": 1, "pop_size": 2,
 }
 
 # TC prunes autotuning for kernels which require < 256 threads. So to tune small
 # size kernels, we set the min kernel threads to 1
 small_sizes_autotuner_settings = {
-    "threads": 32, "generations": 2, "pop_size": 5, "tuner_min_launch_total_threads": 1,
+    "threads": 32, "generations": 1, "pop_size": 2, "tuner_min_launch_total_threads": 1,
 }
 
 ###############################################################################

--- a/test_python/layers/test_matmul_train.py
+++ b/test_python/layers/test_matmul_train.py
@@ -20,7 +20,7 @@ class TestTrainMatMul(unittest.TestCase):
         }
         """
 
-        matmul = tc.define(MATMUL_LANG, name="matmul", training=True, backward="matmul_grad")
+        matmul = tc.define(LANG, name="matmul", training=True, backward="matmul_grad")
         mat1 = Parameter(torch.randn(3, 4).cuda())
         mat2 = Variable(torch.randn(4, 5).cuda(), requires_grad=True)
         out = matmul(mat1, mat2, options=[tc.Options("mlp"), tc.Options("mlp")])

--- a/test_python/layers/test_multiply_reduction.py
+++ b/test_python/layers/test_multiply_reduction.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+import tensor_comprehensions as tc
+
+import torch
+import unittest
+
+
+class TestMultReduction(unittest.TestCase):
+
+   def test_mult_reduction(self):
+       LANG = """
+       def conv_mult(float(N,C,H,W) I, float(M,C,KH,KW) W1) -> (O) {
+           O(n, m, h, w) *=! I(n, c, h + kh, w + kw) * W1(m, c, kh, kw)
+       }
+       """
+       N, C, H, W, O, kH, kW = 64, 10, 24, 24, 10, 7, 7
+       conv_mult = tc.define(LANG, name="conv_mult")
+       I, W1 = torch.ones(N, C, H, W).cuda(), torch.ones(O, C, kH, kW).cuda()
+       # Note: There is no bias here
+       out = conv_mult(I, W1)
+       assert out.data.min() > 0
+
+
+if __name__ == '__main__':
+   unittest.main()

--- a/test_python/run_test.sh
+++ b/test_python/run_test.sh
@@ -30,43 +30,7 @@ $PYTHON test_tc_torch.py -v
 # PyTorch layer tests
 ###############################################################################
 echo "Running all PyTorch layers tests"
-$PYTHON layers/test_absolute.py -v
-$PYTHON layers/test_autotuner.py -v
-$PYTHON layers/test_avgpool.py -v
-$PYTHON layers/test_avgpool_autotune.py -v
-$PYTHON layers/test_batchmatmul.py -v
-$PYTHON layers/test_batchnorm.py -v
-$PYTHON layers/test_layernorm.py -v
-$PYTHON layers/test_cast.py -v
-$PYTHON layers/test_concat.py -v
-$PYTHON layers/test_convolution.py -v
-$PYTHON layers/test_convolution_strided.py -v
-$PYTHON layers/test_convolution_reorder.py -v
-$PYTHON layers/test_convolution_strided_autotune.py -v
-$PYTHON layers/test_convolution_train.py -v
-$PYTHON layers/test_copy.py -v
-$PYTHON layers/test_cos.py -v
-$PYTHON layers/test_cosine_similarity.py -v
-$PYTHON layers/test_dump_cuda.py -v
-$PYTHON layers/test_external_cuda_injection.py -v
-$PYTHON layers/test_fc.py -v
-$PYTHON layers/test_fusion_fcrelu.py -v
-$PYTHON layers/test_broadcast_fcrelu.py -v
-$PYTHON layers/test_group_convolution.py -v
-$PYTHON layers/test_group_convolution_strided.py -v
-$PYTHON layers/test_indexing.py -v
-$PYTHON layers/test_lookup_table.py -v
-$PYTHON layers/test_matmul.py -v
-$PYTHON layers/test_matmul_reuse_outputs.py -v
-$PYTHON layers/test_maxpool.py -v
-$PYTHON layers/test_relu.py -v
-$PYTHON layers/test_scale.py -v
-$PYTHON layers/test_sigmoid.py -v
-$PYTHON layers/test_small_mobilenet.py -v
-$PYTHON layers/test_softmax.py -v
-$PYTHON layers/test_tanh.py -v
-$PYTHON layers/test_tensordot.py -v
-$PYTHON layers/test_transpose.py -v
+$PYTHON -m pytest -v --full-trace --junit-xml="/tmp/tensorcomp/python/result.xml" layers/
 
 echo "All PyTorch layer tests have finished"
 


### PR DESCRIPTION
This PR makes following changes:

1. A user reported some issue related to *=! here https://tensorcomprehensions.slack.com/archives/C98GR4E10/p1522443828000045 add a unit test for *=! for reasonable tensor data
2. use pytest to spin one python process for running test. If separate process is run for separate test, cuda driver initialization cost is incurred when using pytorch. Using pytest allows running all tests in one python process. This saves about 2 minutes of time on my terminal
3. Use gen=1 and population size = 2 setting as the minimal. I am not quite sure why population size=1 doesn't work.  I am not myself comfortable with having gen=1 as in past, when running python test, I have often seen errors in gen=2 for some layers but the errors don't happen in gen=1. Hence open to suggestions if anyone has any. 

overall, I have 7m of python test on my terminal.

closes #245

[the reason this PR closes #245 is by providing a test case that the *=! works as expected]
