### PR TITLE
ScheduleTreeElemContext::write: do not treat context as union set

### DIFF
--- a/src/core/polyhedral/schedule_print.cc
+++ b/src/core/polyhedral/schedule_print.cc
@@ -165,12 +165,7 @@ std::ostream& ScheduleTreeElemBand::write(std::ostream& os) const {
 
 std::ostream& ScheduleTreeElemContext::write(std::ostream& os) const {
   WS w;
-  os << w.tab() << "context(";
-  for (const auto& u : isl::UNION_SET(context_)) {
-    WS w2;
-    os << std::endl << w2.tab() << u;
-  }
-  os << ")";
+  os << w.tab() << "context(" << context_ << ")";
   return os;
 }
 


### PR DESCRIPTION
This partially reverts a pretty printing clean-up, but this part
was presumably introduced by mistake in analogy with
other fields that are represented by union sets.