### PR TITLE
disallow mapping nested bands to threads

### DIFF
--- a/include/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/include/tc/core/polyhedral/cuda/mapped_scop.h
@@ -162,9 +162,10 @@ class MappedScop {
   // (if nInner == 0) and
   // return the updated number of mapped thread identifiers.
   size_t mapToThreads(detail::ScheduleTree* band, size_t nInner);
-  // Map innermost bands to thread identifiers and
-  // return the number of mapped thread identifiers.
-  size_t mapInnermostBandsToThreads(detail::ScheduleTree* st);
+  // Map innermost bands to thread identifiers.
+  // Return the number of mapped thread identifiers
+  // and a flag indicating whether the mapping can continue for ancestors.
+  std::pair<size_t, bool> mapInnermostBandsToThreads(detail::ScheduleTree* st);
 
  private:
   std::unique_ptr<Scop> scop_;


### PR DESCRIPTION
mapInnermostBandsToThreads maps coincident band members to threads
while traversing the tree recursively in DFS postorder.  It is possible
that members of two nested bands get mapped to thread dimensions.
Moreover, this is necessary for parallel reduction support as the
reduction dimension is split out into a separate band.  However, such
mapping is not valid in general because members of different bands are
not necessarily permutable with each other. Since thread dimensions are
not executed in any specific order, i.e. there is no guarantee that, for
a given value of threadIdx.y, all threadIdx.x threads will be executed
before (or after) those with another value of threadIdx.y, permutability
is a necessary condition for mapping to multiple thread dimensions.
Only allow mapping a band to threads if its children are not already
mapped to threads, except for a single child node with reduction mapped
only to threadIdx.x under condition that this node was split out of a
larger permutable band.