### PR TITLE
Fix bug introduced by #259

### DIFF
--- a/benchmarks/benchmark_fixture.h
+++ b/benchmarks/benchmark_fixture.h
@@ -36,6 +36,7 @@
 #include "tc/core/cuda/cuda_tc_executor.h"
 #include "tc/core/flags.h"
 #include "tc/core/scope_guard.h"
+#include "tc/lang/canonicalize.h"
 
 #include <cublas_v2.h> // Must be the same as Caffe2
 #include <cuda_runtime_api.h>
@@ -270,7 +271,8 @@ struct Benchmark : public ::testing::Test {
       auto inputsPair = tc::toConstDlpackTensors(inputs);
       auto outputs = atCompl.inferOutputTensorInfo(name, inputs);
       tc::ScopeGuard g([&]() { tc::deleteDlmTensors(inputsPair.second); });
-      return tc::autotune::restoreCandidates(name, inputsPair.first, outputs);
+      return tc::autotune::restoreCandidates(
+          lang::canonicalTc(tc), inputsPair.first, outputs);
     }();
     auto handle = atCompl.compile(name, inputs, mappingOptions[0]);
     std::vector<at::Tensor> outputs;

--- a/benchmarks/benchmark_fixture.h
+++ b/benchmarks/benchmark_fixture.h
@@ -69,25 +69,6 @@ std::vector<const DLTensor*> inferOutputTensorInfo(
   return atCompl.inferOutputTensorInfo(name, inputs);
 }
 
-tc::CudaMappingOptions loadOptionsFromProto(
-    const std::string cacheFilename,
-    const std::string& name,
-    const std::vector<at::Tensor>& inputs,
-    const std::vector<const DLTensor*>& outputs) {
-  tc::OptionsCache::enableCache();
-  tc::OptionsCache::loadCacheFromProtobuf(cacheFilename);
-  tc::CudaCache::enableCache();
-  tc::CudaCache::loadCacheFromProtobuf(tc::makeCudaFilename(cacheFilename));
-  tc::FLAGS_tuner_gen_restore_number = 1;
-
-  auto mappingOptions = [&]() {
-    auto inputsPair = tc::toConstDlpackTensors(inputs);
-    tc::ScopeGuard g([&]() { tc::deleteDlmTensors(inputsPair.second); });
-    return tc::autotune::restoreCandidates(name, inputsPair.first, outputs);
-  }();
-  return mappingOptions[0];
-}
-
 struct Benchmark : public ::testing::Test {
   void SetUp() {
     if (!FLAGS_disable_version_checks) {

--- a/include/tc/autotuner/utils/utils.h
+++ b/include/tc/autotuner/utils/utils.h
@@ -21,6 +21,7 @@
 #include "tc/core/cuda/cuda.h"
 #include "tc/core/cuda/cuda_mapping_options.h"
 #include "tc/core/utils/dlpack.h"
+#include "tc/lang/tree.h"
 
 #include <llvm/ADT/Optional.h>
 
@@ -58,6 +59,8 @@ llvm::Optional<CudaMappingOptions> getBestOptions(
     const std::string& id,
     const std::vector<const DLTensor*>& inputs,
     const std::vector<const DLTensor*>& outputs);
+
+std::string canonicalTC(const lang::TreeRef& tc);
 
 } // namespace autotune
 } // namespace tc

--- a/include/tc/autotuner/utils/utils.h
+++ b/include/tc/autotuner/utils/utils.h
@@ -21,17 +21,13 @@
 #include "tc/core/cuda/cuda.h"
 #include "tc/core/cuda/cuda_mapping_options.h"
 #include "tc/core/utils/dlpack.h"
+#include "tc/lang/canonicalize.h"
 #include "tc/lang/tree.h"
 
 #include <llvm/ADT/Optional.h>
 
 namespace tc {
 namespace autotune {
-
-struct OptionsWithMedianTime {
-  CudaMappingOptions options;
-  Duration medianRuntime;
-};
 
 /// Returns all the powers of 2 up to the first one that is larger than val
 /// and the result of ceil(val/pow2) for each of those powers of 2 (except for
@@ -41,26 +37,28 @@ std::vector<std::size_t> powers2andCeilDivisors(std::size_t val);
 template <typename Vector, typename... Vectors>
 Vector mergeVectors(Vector&& v, Vectors&&... vs);
 
-std::vector<OptionsWithMedianTime> getOptionsAndMedianRuntimes(
-    const std::string& id,
-    const std::vector<const DLTensor*>& inputs);
-
+/// The following API allows interacting with the autotuner caches.
+/// Caches generally take arbitrary strings for keys.
+/// The autotuner uses a canonicalized TC expression to load / store into
+/// caches. Add a layer of type safety to interact with these.
 std::vector<CudaMappingOptions> restoreCandidates(
-    const std::string& id,
-    const std::vector<const DLTensor*>& inputs,
-    const std::vector<const DLTensor*>& outputs);
-
-std::vector<CudaMappingOptions> restoreCandidates(
-    const lang::TreeRef& tc,
+    const lang::CanonicalTcString& tc,
     const std::vector<const DLTensor*>& inputs,
     const std::vector<const DLTensor*>& outputs);
 
 llvm::Optional<CudaMappingOptions> getBestOptions(
-    const std::string& id,
+    const lang::CanonicalTcString& id,
     const std::vector<const DLTensor*>& inputs,
     const std::vector<const DLTensor*>& outputs);
 
-std::string canonicalTC(const lang::TreeRef& tc);
+struct OptionsWithMedianTime {
+  CudaMappingOptions options;
+  Duration medianRuntime;
+};
+
+std::vector<OptionsWithMedianTime> getOptionsAndMedianRuntimes(
+    const lang::CanonicalTcString& id,
+    const std::vector<const DLTensor*>& inputs);
 
 } // namespace autotune
 } // namespace tc

--- a/include/tc/core/tc_executor.h
+++ b/include/tc/core/tc_executor.h
@@ -124,7 +124,7 @@ class TcExecutor {
 
   tc2halide::HalideComponents halideComponents_;
   lang::TreeRef tcTree_;
-  lang::CanonicalTcString cacheKeyId;
+  lang::CanonicalTcString cacheKeyId_;
 };
 
 // templating to match both const and non-const DLTensor pointers

--- a/include/tc/core/tc_executor.h
+++ b/include/tc/core/tc_executor.h
@@ -25,7 +25,7 @@
 #include "tc/core/utils/dlpack.h"
 #include "tc/core/utils/time.h"
 
-#include "tc/lang/parser.h"
+#include "tc/lang/canonicalize.h"
 
 namespace tc {
 
@@ -124,7 +124,7 @@ class TcExecutor {
 
   tc2halide::HalideComponents halideComponents_;
   lang::TreeRef tcTree_;
-  std::string cacheKeyId;
+  lang::CanonicalTcString cacheKeyId;
 };
 
 // templating to match both const and non-const DLTensor pointers

--- a/include/tc/lang/canonicalize.h
+++ b/include/tc/lang/canonicalize.h
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include "tc/lang/parser.h"
+#include "tc/lang/sema.h"
 #include "tc/lang/tree.h"
 #include "tc/lang/tree_views.h"
 
@@ -24,7 +26,7 @@ namespace lang {
 
 // takes a tree after semantic analysis and create
 // a canonicalized version that is agnostic to the choice of identifiers
-TreeRef canonicalize(TreeRef tree) {
+inline TreeRef canonicalize(TreeRef tree) {
   struct Context {
     std::unordered_map<std::string, std::string> identMap;
     std::string rename(const std::string& name) {
@@ -52,5 +54,20 @@ TreeRef canonicalize(TreeRef tree) {
 
   Context ctx;
   return ctx.apply(tree);
+}
+
+struct CanonicalTcString : public std::string {
+  explicit CanonicalTcString(const std::string& s) : std::string(s) {}
+};
+
+inline CanonicalTcString canonicalTc(const lang::TreeRef& tc) {
+  std::stringstream ss;
+  // TODO: use tcFormat when more robust
+  ss << lang::canonicalize(lang::Sema().checkFunction(tc));
+  return CanonicalTcString(ss.str());
+}
+
+inline CanonicalTcString canonicalTc(const std::string& tc) {
+  return canonicalTc(lang::Parser(tc).parseFunction());
 }
 } // namespace lang

--- a/src/autotuner/genetic_autotuner.cc
+++ b/src/autotuner/genetic_autotuner.cc
@@ -81,7 +81,7 @@ std::vector<CudaMappingOptions> GeneticAutotuner::load(
   ee.define(tc_);
   auto outputs = ee.inferOutputTensorInfo(tcName, inputs);
   return tc::autotune::restoreCandidates(
-      tcNameMap_.at(tcName), inputs, outputs);
+      canonicalTc(tcNameMap_.at(tcName)), inputs, outputs);
 }
 
 namespace {
@@ -186,7 +186,7 @@ llvm::Optional<CudaMappingOptions> GeneticAutotuner::tune(
 
   CHECK_GT(inputs.size(), 0);
   return tc::autotune::getBestOptions(
-      canonicalTC(tcNameMap_.at(tcName)), inputs.begin()->second, outputPtrs);
+      canonicalTc(tcNameMap_.at(tcName)), inputs.begin()->second, outputPtrs);
 }
 
 } // namespace detail

--- a/src/autotuner/genetic_autotuner.cc
+++ b/src/autotuner/genetic_autotuner.cc
@@ -186,7 +186,7 @@ llvm::Optional<CudaMappingOptions> GeneticAutotuner::tune(
 
   CHECK_GT(inputs.size(), 0);
   return tc::autotune::getBestOptions(
-      tcName, inputs.begin()->second, outputPtrs);
+      canonicalTC(tcNameMap_.at(tcName)), inputs.begin()->second, outputPtrs);
 }
 
 } // namespace detail

--- a/src/autotuner/utils/utils.cc
+++ b/src/autotuner/utils/utils.cc
@@ -23,7 +23,6 @@
 #include "tc/lang/canonicalize.h"
 #include "tc/lang/parser.h"
 #include "tc/lang/sema.h"
-#include "tc/lang/tree.h"
 
 namespace tc {
 namespace autotune {
@@ -74,20 +73,18 @@ std::vector<OptionsWithMedianTime> getOptionsAndMedianRuntimes(
   return c;
 }
 
-namespace {
 std::string canonicalTC(const lang::TreeRef& tc) {
   std::stringstream ss;
-  ss << lang::canonicalize(tc);
+  ss << lang::canonicalize(lang::Sema().checkFunction(tc));
   return ss.str();
 }
-} // namespace
 
 std::vector<CudaMappingOptions> restoreCandidates(
     const lang::TreeRef& tc,
     const std::vector<const DLTensor*>& inputs,
     const std::vector<const DLTensor*>& outputs) {
-  auto candidates = getOptionsAndMedianRuntimes(
-      canonicalTC(lang::Sema().checkFunction(tc)), inputs, outputs);
+  auto candidates =
+      getOptionsAndMedianRuntimes(canonicalTC(tc), inputs, outputs);
   LOG_IF(INFO, candidates.size() < FLAGS_tuner_gen_restore_number)
       << "Requested " << FLAGS_tuner_gen_restore_number
       << " candidates but there are only " << candidates.size() << " in cache.";

--- a/src/core/cuda/cuda_tc_executor.cc
+++ b/src/core/cuda/cuda_tc_executor.cc
@@ -56,7 +56,7 @@ void CudaTcExecutor::compile(const tc::CudaMappingOptions& options) {
   auto cachedOp = [&]() -> std::unique_ptr<CudaCache::RetrievalResult> {
     if (ManualCudaCache::cacheEnabled()) {
       auto rr = ManualCudaCache::getCache()->retrieveKernel(
-          cacheKeyId,
+          cacheKeyId_,
           extractRawPtrs(executionInfo_.inputsInfo),
           extractRawPtrs(executionInfo_.outputsInfo));
       if (rr) {
@@ -71,7 +71,7 @@ void CudaTcExecutor::compile(const tc::CudaMappingOptions& options) {
         << "options string is empty, are you trying compile "
         << "a dummy CudaTcExecutor?";
     return CudaCache::getCache()->retrieveKernel(
-        cacheKeyId,
+        cacheKeyId_,
         options,
         extractRawPtrs(executionInfo_.inputsInfo),
         extractRawPtrs(executionInfo_.outputsInfo));
@@ -93,7 +93,7 @@ void CudaTcExecutor::compile(const tc::CudaMappingOptions& options) {
       LOG_IF(INFO, FLAGS_debug_tc_mapper) << "original grid: " << grid;
       LOG_IF(INFO, FLAGS_debug_tc_mapper) << "original block: " << block;
       CudaCache::getCache()->cacheKernel(
-          cacheKeyId,
+          cacheKeyId_,
           options,
           extractRawPtrs(executionInfo_.inputsInfo),
           extractRawPtrs(executionInfo_.outputsInfo),
@@ -212,7 +212,7 @@ Duration CudaTcExecutor::run(
       profile);
   if (profile and OptionsCache::cacheEnabled()) {
     OptionsCache::getCache()->recordRuntime(
-        cacheKeyId,
+        cacheKeyId_,
         CudaMappingOptions(executionInfo_.options),
         inputs,
         constPtrs(outputs),

--- a/src/core/tc_executor.cc
+++ b/src/core/tc_executor.cc
@@ -41,7 +41,7 @@ TcExecutor::TcExecutor(
       inputsInfo(dlutils::makeDLTensorVector(inputsInfo)),
       options(options),
       tcTree_(tcDefinition),
-      cacheKeyId(lang::canonicalTc(tcDefinition)) {
+      cacheKeyId_(lang::canonicalTc(tcDefinition)) {
   executionInfo_.kernelName = lang::Def(tcTree_).name().name();
   halideComponents_ =
       tc2halide::translate(isl::with_exceptions::globalIslCtx(), tcTree_);

--- a/test/cuda/test_autotuner_utility.cc
+++ b/test/cuda/test_autotuner_utility.cc
@@ -20,6 +20,7 @@
 #include "tc/core/cuda/cuda_compilation_cache.h"
 #include "tc/core/cuda/cuda_tc_executor.h"
 #include "tc/core/scope_guard.h"
+#include "tc/lang/canonicalize.h"
 
 using namespace tc;
 using namespace autotune;
@@ -54,7 +55,7 @@ std::vector<CudaMappingOptions> restoreCandidates(
   });
 
   return tc::autotune::restoreCandidates(
-      tc, inputsPair.first, outputsPair.first);
+      lang::canonicalTc(tc), inputsPair.first, outputsPair.first);
 }
 
 TEST(RestoreCandidates, NoCache) {

--- a/test/test_lang.cc
+++ b/test/test_lang.cc
@@ -147,12 +147,6 @@ TreeRef loadText(const std::string& text) {
   return Sema().checkFunction(Parser(text).parseFunction());
 }
 
-std::string canonicalText(const std::string& text) {
-  std::stringstream ss;
-  ss << canonicalize(loadText(text));
-  return ss.str();
-}
-
 void testTcFormat() {
   static std::ios_base::Init initIostreams;
   auto source = R"(def fun2(float(B, N, M) X, float(B, M, K) Y) -> (Q) {
@@ -334,7 +328,7 @@ int main(int argc, char** argv) {
             Q(b, ii, j) += X(b, ii, k) * Y(b, k, j)
     }
   )";
-  ASSERT(canonicalText(option_one) == canonicalText(option_two));
+  ASSERT(lang::canonicalTc(option_one) == lang::canonicalTc(option_two));
 
   testTcFormat();
 

--- a/test/test_tc_mapper_harness-inl.h
+++ b/test/test_tc_mapper_harness-inl.h
@@ -59,11 +59,8 @@ struct TcMapperTest : public ::testing::Test {
       tc::deleteDlmTensors(outputDLTensorsPair.second);
     });
     // Check that cache insertion worked properly (with canonicalized TC)
-    std::stringstream ss;
-    ss << lang::canonicalize(
-        lang::Sema().checkFunction(lang::Parser(tc).parseFunction()));
     auto cached = CacheType::getCache()->retrieveKernel(
-        ss.str(),
+        lang::canonicalTc(tc),
         mappingOptions,
         inputDLTensorsPair.first,
         outputDLTensorsPair.first);


### PR DESCRIPTION
#259 switched from TC function names to using whole TCs (canonicalized) as part of  compilation cache keys. However, the final step of the autotuner, that is retrieving the best found options, was not updated and it used just the function name. As a result, an empty `optional<CudaMappingOptions>` was always returned.