### PR TITLE
remove code that depends on order of parameters in isl objects

### DIFF
--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -128,16 +128,6 @@ struct Scop {
     return makeSpecializationSet(s, sizes);
   }
 
-  // Returns a set that specializes the (positional) scop's subset of
-  // parameter space to the integer values passed to the function.
-  template <typename T>
-  isl::set makeContext(
-      const std::unordered_map<int, T>& sizes =
-          std::unordered_map<int, T>()) const {
-    auto s = domain().get_space().params();
-    return makeSpecializationSet(s, sizes);
-  }
-
   // Returns a set that specializes the named scop's subset of
   // parameter space to the integer values passed to the function.
   template <typename T>

--- a/include/tc/core/polyhedral/scop.h
+++ b/include/tc/core/polyhedral/scop.h
@@ -118,12 +118,12 @@ struct Scop {
     writes = writes.intersect_params(globalParameterContext);
   }
 
-  // Returns a set that specializes (all) the scop's parameter space to the
-  // integer values passed to the function.
-  // WARNING: this version relies on parameter ordering, be sure you know what
-  // you are doing.
+  // Returns a set that specializes the named scop's subset of
+  // parameter space to the integer values passed to the function.
   template <typename T>
-  isl::set makeContext(const std::vector<T>& sizes = std::vector<T>()) const {
+  isl::set makeContext(
+      const std::unordered_map<std::string, T>& sizes =
+          std::unordered_map<std::string, T>()) const {
     auto s = domain().get_space().params();
     return makeSpecializationSet(s, sizes);
   }
@@ -132,8 +132,7 @@ struct Scop {
   // parameter space to the integer values passed to the function.
   template <typename T>
   isl::set makeContext(
-      const std::unordered_map<std::string, T>& sizes =
-          std::unordered_map<std::string, T>()) const {
+      std::initializer_list<std::pair<const std::string, T>> sizes) {
     auto s = domain().get_space().params();
     return makeSpecializationSet(s, sizes);
   }

--- a/include/tc/external/detail/islpp.h
+++ b/include/tc/external/detail/islpp.h
@@ -348,6 +348,14 @@ inline isl::set makeSpecializationSet(
   return makeSpecializationSet(space, aux);
 }
 
+template <typename T>
+inline isl::set makeSpecializationSet(
+    isl::space space,
+    std::initializer_list<std::pair<const std::string, T>> paramValues) {
+  std::unordered_map<std::string, T> map(paramValues);
+  return makeSpecializationSet(space, map);
+}
+
 // WARNING: this version relies on parameter ordering, be sure you know what
 // you are doing.
 template <typename T>

--- a/include/tc/external/detail/islpp.h
+++ b/include/tc/external/detail/islpp.h
@@ -356,18 +356,15 @@ inline isl::set makeSpecializationSet(
   return makeSpecializationSet(space, map);
 }
 
-// WARNING: this version relies on parameter ordering, be sure you know what
-// you are doing.
 template <typename T>
 inline isl::set makeSpecializationSet(
     isl::space space,
-    const std::vector<T>& paramValues) {
-  CHECK_EQ(space.dim(isl::dim_type::param), paramValues.size());
-  std::unordered_map<int, T> paramValuesMap;
-  for (int i = 0; i < paramValues.size(); ++i) {
-    paramValuesMap[i] = paramValues[i];
+    std::initializer_list<std::pair<isl::id, T>> paramValues) {
+  std::unordered_map<std::string, T> map;
+  for (auto kvp : paramValues) {
+    map.emplace(kvp.first.get_name(), kvp.second);
   }
-  return makeSpecializationSet(space, paramValuesMap);
+  return makeSpecializationSet(space, map);
 }
 
 namespace detail {

--- a/test/test_mapper.cc
+++ b/test/test_mapper.cc
@@ -333,7 +333,7 @@ TEST_F(PolyhedralMapperTest, MergedContexts) {
   auto scop = PrepareAndJoinBands(makeMatmulTc());
 
   // Unit test claims to use scop->globalParameterContext properly
-  auto context = scop->makeContext(std::vector<int>{64, 64, 64});
+  auto context = scop->makeContext<int>({{"M", 64}, {"N", 64}, {"K", 64}});
   auto& globalParameterContext =
       const_cast<isl::set&>(scop->globalParameterContext);
   globalParameterContext = globalParameterContext.intersect(context);
@@ -349,7 +349,7 @@ TEST_F(PolyhedralMapperTest, FilterMerge) {
   auto schedule = scop->scheduleRoot();
 
   // Unit test claims to use scop->globalParameterContext properly
-  auto context = scop->makeContext(std::vector<int>{64, 64, 64});
+  auto context = scop->makeContext<int>({{"M", 64}, {"N", 64}, {"K", 64}});
   auto& globalParameterContext =
       const_cast<isl::set&>(scop->globalParameterContext);
   globalParameterContext = globalParameterContext.intersect(context);

--- a/test/test_mapper_memory_promotion.cc
+++ b/test/test_mapper_memory_promotion.cc
@@ -275,7 +275,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
     blockSpace = blockSpace.set_dim_id(isl::dim_type::param, 0, BX)
                      .set_dim_id(isl::dim_type::param, 1, BY);
     isl::set blockZero =
-        makeSpecializationSet(blockSpace, std::vector<int>{{0, 0}});
+        isl::makeSpecializationSet<int>(blockSpace, {{BX, 0}, {BY, 0}});
 
     // Must have groups for these tensors, in arbitrary order.
     unordered_set<string> names{"A", "B", "C"};


### PR DESCRIPTION
While the parameters may still have the expected order,
it is better not to rely on the order at all.
The mainline C++ bindings will also try to avoid exposing this order.