### PR TITLE
rename *Idxx* to *IdxX*

### DIFF
--- a/include/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/include/tc/core/polyhedral/cuda/mapped_scop.h
@@ -179,7 +179,7 @@ class MappedScop {
   // XXX: this is a partially redundant state as this information can
   // potentially be extracted from the schedule tree; however, until we get a
   // first-class MappingNode, it requires some dirty hacks.
-  ThreadIdxxScheduleDepthState threadIdxxScheduleDepthState;
+  ThreadIdxXScheduleDepthState threadIdxXScheduleDepthState;
 
  private:
   // Information about a detected reduction that can potentially

--- a/include/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/include/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -22,7 +22,7 @@
 
 namespace tc {
 namespace polyhedral {
-using ThreadIdxxScheduleDepthState =
+using ThreadIdxXScheduleDepthState =
     std::vector<std::pair<isl::union_set, size_t>>;
 
 class MappedScop;
@@ -32,19 +32,19 @@ class Scop;
 // promote to shared memory at "depth" until "sharedMemorySize" is used.
 // Map copies between global and shared memory to threads and unroll those
 // copies if "unrollCopies" is set, using the options in "mscop".
-// "threadIdxxScheduleDepthState" contains the schedule depth at which the
+// "threadIdxXScheduleDepthState" contains the schedule depth at which the
 // computation was mapped to thread x and is used to check whether the global
 // memory is accessed in a coalesced way.
 void promoteGreedilyAtDepth(
     MappedScop& scop,
-    const ThreadIdxxScheduleDepthState& threadIdxxScheduleDepthState,
+    const ThreadIdxXScheduleDepthState& threadIdxXScheduleDepthState,
     std::size_t depth,
     std::size_t sharedMemorySize,
     bool unrollCopies);
 
 void promoteToRegistersBelowThreads(
     Scop& scop,
-    const ThreadIdxxScheduleDepthState& threadIdxxScheduleDepthState,
+    const ThreadIdxXScheduleDepthState& threadIdxXScheduleDepthState,
     std::size_t nRegisters);
 } // namespace polyhedral
 } // namespace tc

--- a/src/core/polyhedral/cuda/mapped_scop.cc
+++ b/src/core/polyhedral/cuda/mapped_scop.cc
@@ -113,7 +113,7 @@ void MappedScop::mapRemaining(
 
   for (size_t i = nMapped; i < nToMap; ++i) {
     if (MappingTypeId::makeId(i) == mapping::ThreadId::x()) {
-      threadIdxxScheduleDepthState.emplace_back(std::make_pair(
+      threadIdxXScheduleDepthState.emplace_back(std::make_pair(
           activeDomainPoints(schedule(), tree),
           tree->scheduleDepth(schedule())));
     }
@@ -179,7 +179,7 @@ void fixThreadsBelowFilter(
       // Mapping happend below filterTree, so we need points active for its
       // children.  After insertion, filterTree is guaranteed to have at least
       // one child.
-      mscop.threadIdxxScheduleDepthState.emplace_back(std::make_pair(
+      mscop.threadIdxXScheduleDepthState.emplace_back(std::make_pair(
           activeDomainPoints(mscop.schedule(), filterTree->child({0})),
           filterTree->scheduleDepth(mscop.schedule())));
     }
@@ -339,7 +339,7 @@ size_t MappedScop::mapToThreads(detail::ScheduleTree* band, size_t nInner) {
       return nInner;
     }
     CHECK(reductionBandUpdates_.at(band).separated);
-    threadIdxxScheduleDepthState.emplace_back(std::make_pair(
+    threadIdxXScheduleDepthState.emplace_back(std::make_pair(
         activeDomainPoints(schedule(), band),
         band->scheduleDepth(schedule()) + 0));
     band = map(band, 0, mapping::ThreadId::x());
@@ -380,7 +380,7 @@ size_t MappedScop::mapToThreads(detail::ScheduleTree* band, size_t nInner) {
        ++i, --dim) {
     auto id = mapping::ThreadId::makeId(nInner + i);
     if (id == mapping::ThreadId::x()) {
-      threadIdxxScheduleDepthState.emplace_back(std::make_pair(
+      threadIdxXScheduleDepthState.emplace_back(std::make_pair(
           activeDomainPoints(schedule(), band),
           band->scheduleDepth(schedule()) + dim));
     }
@@ -677,7 +677,7 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
 
       promoteGreedilyAtDepth(
           *mappedScop,
-          mappedScop->threadIdxxScheduleDepthState,
+          mappedScop->threadIdxXScheduleDepthState,
           std::min(band->nOuterCoincident(), mappedScop->numBlocks.view.size()),
           sharedMemorySize,
           cudaOptions.proto().unroll_copy_shared() &&
@@ -695,7 +695,7 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
   // 8. Promote to registers below the loops mapped to threads.
   if (cudaOptions.proto().use_private_memory()) {
     promoteToRegistersBelowThreads(
-        mappedScop->scop(), mappedScop->threadIdxxScheduleDepthState, -1ull);
+        mappedScop->scop(), mappedScop->threadIdxXScheduleDepthState, -1ull);
   }
 
   // 9. Insert mapping context

--- a/test/test_mapper_memory_promotion.cc
+++ b/test/test_mapper_memory_promotion.cc
@@ -397,7 +397,7 @@ def fun(float(N, M) A) -> (B, C) {
         tc, {{"N", problemSize1}, {"M", problemSize2}}, {tileSize1, tileSize2});
     promoteGreedilyAtDepth(
         *mscop,
-        mscop->threadIdxxScheduleDepthState,
+        mscop->threadIdxXScheduleDepthState,
         depth,
         maxSharedMemory,
         false);


### PR DESCRIPTION
The identifier name x is a new (if short) word, so it should
get its own capital letter.