### PR TITLE
Drop default cache filename

### DIFF
--- a/include/tc/core/flags.h
+++ b/include/tc/core/flags.h
@@ -47,7 +47,6 @@ DECLARE_uint32(tuner_gen_number_elites);
 DECLARE_uint32(tuner_threads);
 DECLARE_string(tuner_gpus);
 DECLARE_bool(tuner_print_best);
-DECLARE_string(tuner_proto);
 DECLARE_string(tuner_rng_restore);
 DECLARE_bool(tuner_gen_restore_from_proto);
 DECLARE_uint32(tuner_gen_restore_number);

--- a/src/core/flags.cc
+++ b/src/core/flags.cc
@@ -84,11 +84,6 @@ DEFINE_bool(
     tuner_print_best,
     false,
     "Print to INFO the best tuning options after each generation");
-DEFINE_string(
-    tuner_proto,
-    "/tmp/tuner.txt",
-    "Filename to load and store proto cache "
-    "(TODO: Hardcoded default a security liability?)");
 DEFINE_string(tuner_rng_restore, "", "Rng state to restore");
 DEFINE_bool(
     tuner_gen_restore_from_proto,

--- a/tensor_comprehensions/pybinds/pybind_autotuner.cc
+++ b/tensor_comprehensions/pybinds/pybind_autotuner.cc
@@ -86,11 +86,6 @@ PYBIND11_MODULE(autotuner, m) {
             tc::FLAGS_tuner_gpus = gpus;
           })
       .def(
-          "proto",
-          [](tc::autotune::GeneticAutotunerATen& instance, std::string& proto) {
-            tc::FLAGS_tuner_proto = proto;
-          })
-      .def(
           "restore_from_proto",
           [](tc::autotune::GeneticAutotunerATen& instance,
              bool restore_from_proto) {


### PR DESCRIPTION
To avoid surprises, protobuf cache filename is by default empty
and the user has to explicitly specify it.