### PR TITLE
Update for LLVM JIT API Churn

### DIFF
--- a/tc/core/polyhedral/llvm_jit.cc
+++ b/tc/core/polyhedral/llvm_jit.cc
@@ -103,7 +103,8 @@ void Jit::addModule(std::shared_ptr<Module> M) {
 }
 #else
 Jit::Jit()
-    : Resolver(createLegacyLookupResolver(
+    : ES(),
+      Resolver(llvm::orc::createLegacyLookupResolver(
           [this](const std::string& Name) -> JITSymbol {
             if (auto Sym = compileLayer_.findSymbol(Name, false))
               return Sym;
@@ -115,7 +116,7 @@ Jit::Jit()
             return nullptr;
           },
           [](Error err) {
-            throw std::runtime_error("Lookup failed: " + err);
+            throw std::runtime_error("Lookup failed: ");// + err);
           })),
       TM_(EngineBuilder().selectTarget()),
       DL_(TM_->createDataLayout()),

--- a/tc/core/polyhedral/llvm_jit.cc
+++ b/tc/core/polyhedral/llvm_jit.cc
@@ -128,8 +128,7 @@ Jit::Jit()
       compileLayer_(objectLayer_, orc::SimpleCompiler(*TM_)) {
   std::string err;
 
-  auto path = find_library_path("libcilkrts.so");
-  sys::DynamicLibrary::LoadLibraryPermanently(path.c_str(), &err);
+  sys::DynamicLibrary::LoadLibraryPermanently(nullptr, &err);
   if (err != "") {
     throw std::runtime_error("Failed to find cilkrts: " + err);
   }

--- a/tc/core/polyhedral/llvm_jit.cc
+++ b/tc/core/polyhedral/llvm_jit.cc
@@ -103,7 +103,8 @@ void Jit::addModule(std::shared_ptr<Module> M) {
 }
 #else
 Jit::Jit()
-    : ES(),
+    : SSP(),
+      ES(SSP),
       Resolver(llvm::orc::createLegacyLookupResolver(
           [this](const std::string& Name) -> JITSymbol {
             if (auto Sym = compileLayer_.findSymbol(Name, false))
@@ -115,9 +116,7 @@ Jit::Jit()
               return JITSymbol(SymAddr, JITSymbolFlags::Exported);
             return nullptr;
           },
-          [](Error err) {
-            throw std::runtime_error("Lookup failed: ");// + err);
-          })),
+          [](Error err) { throw std::runtime_error("Lookup failed!"); })),
       TM_(EngineBuilder().selectTarget()),
       DL_(TM_->createDataLayout()),
       objectLayer_(

--- a/tc/core/polyhedral/llvm_jit.h
+++ b/tc/core/polyhedral/llvm_jit.h
@@ -21,6 +21,10 @@
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/Target/TargetMachine.h"
 
+#if LLVM_VERSION_MAJOR > 6
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#endif
+
 namespace tc {
 
 namespace polyhedral {
@@ -29,6 +33,10 @@ class Scop;
 
 class Jit {
  private:
+#if LLVM_VERSION_MAJOR > 6
+  llvm::orc::ExecutionSession ES;
+  std::shared_ptr<llvm::orc::SymbolResolver> Resolver;
+#endif
   std::unique_ptr<llvm::TargetMachine> TM_;
   const llvm::DataLayout DL_;
   llvm::orc::RTDyldObjectLinkingLayer objectLayer_;
@@ -38,12 +46,10 @@ class Jit {
  public:
   Jit();
 
-  using ModuleHandle = decltype(compileLayer_)::ModuleHandleT;
   std::shared_ptr<llvm::Module> codegenScop(
       const std::string& specializedName,
       const polyhedral::Scop& scop);
-  ModuleHandle addModule(std::shared_ptr<llvm::Module> M);
-  void removeModule(ModuleHandle H);
+  void addModule(std::shared_ptr<llvm::Module> M);
 
   llvm::JITSymbol findSymbol(const std::string name);
   llvm::JITTargetAddress getSymbolAddress(const std::string name);

--- a/tc/core/polyhedral/llvm_jit.h
+++ b/tc/core/polyhedral/llvm_jit.h
@@ -34,6 +34,7 @@ class Scop;
 class Jit {
  private:
 #if LLVM_VERSION_MAJOR > 6
+  llvm::orc::SymbolStringPool SSP;
   llvm::orc::ExecutionSession ES;
   std::shared_ptr<llvm::orc::SymbolResolver> Resolver;
 #endif


### PR DESCRIPTION
To quote LLVM docs "The text will be updated once the API churn dies down."

Master JIT LLVM api is undergoing major churn atm, so this adds some initial code to unblock FB folks since it seems to be time-sensitive.

Once LLVM API churn dies down, this code will be made nicer.