### PR TITLE
Scop::makeContextFromInputs: fix check for fixed parameter values

### DIFF
--- a/src/core/polyhedral/scop.cc
+++ b/src/core/polyhedral/scop.cc
@@ -324,7 +324,8 @@ isl::set Scop::makeContextFromInputs(
           paramSet & (isl::aff_set(parametricAff) == inputs[i]->shape[j]);
     }
   }
-  CHECK(paramSet.is_singleton()) << "could not infer the values of parameters";
+  CHECK(paramSet.is_equal(paramSet.sample()))
+      << "could not infer the values of parameters";
   return paramSet;
 }
 


### PR DESCRIPTION
Calling is_singleton() on a parametric set makes little sense,
since every parametric set is a singleton.