### PR TITLE
[Hotfix] fix python tests

### DIFF
--- a/docs/source/autotuner.rst
+++ b/docs/source/autotuner.rst
@@ -31,7 +31,6 @@ The parameters that control the autotuner's behavior are the following:
 * :code:`Number of threads`: The number of threads that are used to compile different candidates in parallel.
 * :code:`GPUs`: A comma separated list of GPUs (ids) to use for evaluating candidates (e.g., "0,1,2,3").
 * :code:`RNG state`: The state used to seed the tuner's RNG.
-* :code:`Proto`: A protobuf filename to (re)store compilation results and profiling information of the candidate solutions.
 * :code:`min_launch_total_threads`: Prune out kernels mapped to fewer than this many threads and block. Set this to :code:`1` to avoid pruning.
 
 Caching

--- a/tensor_comprehensions/tc_unit.py
+++ b/tensor_comprehensions/tc_unit.py
@@ -192,8 +192,8 @@ class TcAutotuner(object):
 
     def set_autotuner_parameters(
         self, pop_size=20, crossover_rate=80, mutation_rate=7, generations=10,
-        number_elites=1, threads=8, gpus="0", proto="/tmp/tuner.txt",
-        restore_from_proto=False, restore_number=10, log_generations=False,
+        number_elites=1, threads=8, gpus="0", restore_from_proto=False,
+        restore_number=10, log_generations=False,
         tuner_min_launch_total_threads=64, **kwargs
     ):
         self.autotuner.pop_size(pop_size)
@@ -203,7 +203,6 @@ class TcAutotuner(object):
         self.autotuner.number_elites(number_elites)
         self.autotuner.threads(threads)
         self.autotuner.gpus(gpus)
-        self.autotuner.proto(proto)
         self.autotuner.restore_from_proto(restore_from_proto)
         self.autotuner.restore_number(restore_number)
         self.autotuner.log_generations(log_generations)


### PR DESCRIPTION
This cherry-picks 479c78d0367b823bb7c61b7a8e8ee8dd385e4902 to fix the python side of things for which the proto disappeared.
This was dead C++ code that got removed but Jenkins being down over the weekend it turns out that master was broken.