### PR TITLE
Enable Werror compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,13 @@ project (TensorComprehensions C CXX)
 
 # Display compiler flags for build modes: Release/Debug
 message(STATUS "BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+message(STATUS "CMAKE_CXX_COMPILER_VERSION is ${CMAKE_CXX_COMPILER_VERSION}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.4")
+  # we officially support these compiler flags for compiler version 5.4 or less
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Werror")
+endif()
+message(STATUS "CMAKE_CXX_FLAGS is ${CMAKE_CXX_FLAGS}")
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
   set(CMAKE_CXX_FLAGS_DEBUG "-g")
   message(STATUS "CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")

--- a/tc/lang/lexer.h
+++ b/tc/lang/lexer.h
@@ -418,9 +418,9 @@ struct Lexer {
 
  private:
   Token lex() {
-    int kind;
-    size_t start;
-    size_t length;
+    int kind = -1;
+    size_t start = 0;
+    size_t length = 0;
     assert(file);
     if (!shared.match(*file, pos, &kind, &start, &length)) {
       reportError(


### PR DESCRIPTION
enabling `Werror` required as part of modernization task #194 

this should run by default on CI as well now.


also cc @mingzhe09088 (couldn't tag as reviewer hence cc'ing)