### PR TITLE
backend compilation cache should not depend on CUDA

### DIFF
--- a/tc/core/compilation_cache.cc
+++ b/tc/core/compilation_cache.cc
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "tc/core/cuda/cuda_compilation_cache.h"
+#include "tc/core/compilation_cache.h"
 
 #include <version.h>
 

--- a/tc/core/compilation_cache.h
+++ b/tc/core/compilation_cache.h
@@ -26,9 +26,6 @@
 
 #include <compcache.pb.h>
 
-#include "tc/core/cuda/cuda.h"
-#include "tc/core/cuda/cuda_mapping_options.h"
-#include "tc/core/cuda/cuda_rtc.h"
 #include "tc/core/utils/time.h"
 
 namespace tc {

--- a/tc/core/utils/math.h
+++ b/tc/core/utils/math.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <exception>
 
 namespace tc {


### PR DESCRIPTION
This fixes the WITH_CUDA=0 build broken by 4f90354d (Split backend
compilation cache, Sun Apr 8 13:12:14 2018 -0600).