### PR TITLE
Move protobufs generated files to tc/proto/*.{h/cc}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *~
 build/*
 docs/build/*
+tc/proto/*.py
+tc/proto/*.cc
+tc/proto/*.h
 third-party/*_cache
 third-party/llvm_sources*
 third-party-install/*

--- a/tc/core/compilation_cache.h
+++ b/tc/core/compilation_cache.h
@@ -24,7 +24,7 @@
 
 #include <dlpack/dlpack.h>
 
-#include <compcache.pb.h>
+#include "tc/proto/compcache.pb.h"
 
 #include "tc/core/utils/time.h"
 

--- a/tc/core/cpu/cpu_mapping_options.h
+++ b/tc/core/cpu/cpu_mapping_options.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <mapping_options.pb.h>
+#include "tc/proto/mapping_options.pb.h"
 
 #include "tc/core/mapping_options.h"
 

--- a/tc/core/cuda/cuda_compilation_cache.h
+++ b/tc/core/cuda/cuda_compilation_cache.h
@@ -24,7 +24,7 @@
 
 #include <dlpack/dlpack.h>
 
-#include <compcache.pb.h>
+#include "tc/proto/compcache.pb.h"
 
 #include "tc/core/compilation_cache.h"
 #include "tc/core/cuda/cuda.h"

--- a/tc/core/cuda/cuda_mapping_options.cc
+++ b/tc/core/cuda/cuda_mapping_options.cc
@@ -21,7 +21,7 @@
 #include <tuple>
 #include <type_traits>
 
-#include <mapping_options.pb.h>
+#include "tc/proto/mapping_options.pb.h"
 
 #include "tc/core/cuda/cuda_mapping_options_cpp_printer.h"
 #include "tc/core/flags.h"

--- a/tc/core/cuda/cuda_mapping_options.h
+++ b/tc/core/cuda/cuda_mapping_options.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <mapping_options.pb.h>
+#include "tc/proto/mapping_options.pb.h"
 
 #include <array>
 #include <iostream>

--- a/tc/core/mapping_options.cc
+++ b/tc/core/mapping_options.cc
@@ -21,7 +21,7 @@
 #include <tuple>
 #include <type_traits>
 
-#include <mapping_options.pb.h>
+#include "tc/proto/mapping_options.pb.h"
 
 #include "tc/core/flags.h"
 #include "tc/core/mapping_options_cpp_printer.h"

--- a/tc/core/mapping_options.h
+++ b/tc/core/mapping_options.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <mapping_options.pb.h>
+#include "tc/proto/mapping_options.pb.h"
 
 #include <array>
 #include <iostream>

--- a/tc/proto/CMakeLists.txt
+++ b/tc/proto/CMakeLists.txt
@@ -60,7 +60,7 @@ function(tc_protobuf_generate_cpp_py output_dir srcs_var hdrs_var python_var)
   set(${python_var} ${${python_var}} PARENT_SCOPE)
 endfunction()
 
-tc_protobuf_generate_cpp_py(${CMAKE_CURRENT_BINARY_DIR} PROTO_SRCS PROTO_HDRS PROTO_PY mapping_options.proto compcache.proto)
+tc_protobuf_generate_cpp_py(${PROJECT_SOURCE_DIR}/tc/proto PROTO_SRCS PROTO_HDRS PROTO_PY mapping_options.proto compcache.proto)
 
 add_library(tc_proto SHARED ${PROTO_SRCS} ${PROTO_HDRS})
 target_link_libraries(tc_proto ${PROTOBUF_LIBRARIES})


### PR DESCRIPTION
Motivation: posting excerpt from @salexspb below:

```
Currently in OSS includes are done as following:

#include "mapping_options.pb.h"

This is bad because in a bigger codebase it can clash with other files. Also it requires manual include paths which complicate the project, people don't know where to look for files, etc.

Solution we discussed is  to have tc/proto/*.proto files and then have protoc / cmake generate .cc and .h files in a way that .h is being includes with full path as tc/proto/mapping_options.pb.h

This would also unblock fbCode development. Where currently we have to fix the OSS code when doing a sync and store protobufs in a separate from OSS folder
```