### PR TITLE
Reduce dependency in genetic_autotuner.h

### DIFF
--- a/tc/autotuner/genetic_autotuner.h
+++ b/tc/autotuner/genetic_autotuner.h
@@ -19,7 +19,7 @@
 #include <memory>
 #include <vector>
 
-#include "tc/autotuner/genetic_tuning_harness.h"
+#include "tc/autotuner/parameters.h"
 #include "tc/autotuner/utils/utils.h"
 #include "tc/lang/parser.h"
 

--- a/tc/autotuner/genetic_autotuner.h
+++ b/tc/autotuner/genetic_autotuner.h
@@ -19,7 +19,9 @@
 #include <memory>
 #include <vector>
 
-#include "tc/autotuner/parameters.h"
+#include "tc/autotuner/genetic_tuning_harness.h"
+#include "tc/autotuner/utils/utils.h"
+#include "tc/core/execution_engine.h"
 #include "tc/lang/parser.h"
 
 #include <llvm/ADT/Optional.h>

--- a/tc/autotuner/genetic_autotuner.h
+++ b/tc/autotuner/genetic_autotuner.h
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "tc/autotuner/parameters.h"
-#include "tc/autotuner/utils/utils.h"
 #include "tc/lang/parser.h"
 
 #include <llvm/ADT/Optional.h>

--- a/tc/autotuner/genetic_tuning_harness.h
+++ b/tc/autotuner/genetic_tuning_harness.h
@@ -22,10 +22,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include "tc/aten/aten_compiler.h"
 #include "tc/autotuner/genetic_search.h"
 #include "tc/autotuner/parameters.h"
 #include "tc/autotuner/utils/printer.h"
+#include "tc/core/utils/dlpack.h"
 #include "tc/lang/parser.h"
 
 namespace tc {

--- a/tc/autotuner/utils/utils.h
+++ b/tc/autotuner/utils/utils.h
@@ -16,8 +16,6 @@
 #pragma once
 #include <vector>
 
-#include <ATen/ATen.h>
-
 #include "tc/core/cuda/cuda.h"
 #include "tc/core/cuda/cuda_mapping_options.h"
 #include "tc/core/utils/dlpack.h"

--- a/test/cuda/test_autotuner_utility.cc
+++ b/test/cuda/test_autotuner_utility.cc
@@ -15,6 +15,8 @@
  */
 #include <gtest/gtest.h>
 
+#include "tc/aten/aten_compiler.h"
+#include "tc/aten/utils.h"
 #include "tc/autotuner/genetic_autotuner.h"
 #include "tc/autotuner/utils/utils.h"
 #include "tc/core/cuda/cuda_compilation_cache.h"


### PR DESCRIPTION
This PR makes `genetic_autotuner.h` independent from ATen headers.