### PR TITLE
Fix serializeToProtobuf method of Options

### DIFF
--- a/tensor_comprehensions/pybinds/pybind_options.cc
+++ b/tensor_comprehensions/pybinds/pybind_options.cc
@@ -91,7 +91,7 @@ PYBIND11_MODULE(mapping_options, m) {
       .def(
           "serializeToProtobuf",
           [](tc::CudaMappingOptions& instance) {
-            std::string str = instance.toProtobufSerializedString;
+            std::string str = instance.toProtobufSerializedString();
             return py::bytes(str);
           },
           "Serialize the options to a protobuf string")

--- a/tensor_comprehensions/pybinds/pybind_options.cc
+++ b/tensor_comprehensions/pybinds/pybind_options.cc
@@ -90,7 +90,10 @@ PYBIND11_MODULE(mapping_options, m) {
           "Require TC to try and execute different TC expressions interleaved (Max), separately (Min)\nor interleaved as long as sufficient parallelism is exploited (Preserve3Coincident) by\nperforming loop fusion and fission. Applies before tiling")
       .def(
           "serializeToProtobuf",
-          &tc::CudaMappingOptions::toProtobufSerializedString,
+          []() {
+            std::string str = tc::CudaMappingOptions::toProtobufSerializedString;
+            return py::bytes(str);
+          },
           "Serialize the options to a protobuf string")
       .def(
           "tile",

--- a/tensor_comprehensions/pybinds/pybind_options.cc
+++ b/tensor_comprehensions/pybinds/pybind_options.cc
@@ -90,8 +90,8 @@ PYBIND11_MODULE(mapping_options, m) {
           "Require TC to try and execute different TC expressions interleaved (Max), separately (Min)\nor interleaved as long as sufficient parallelism is exploited (Preserve3Coincident) by\nperforming loop fusion and fission. Applies before tiling")
       .def(
           "serializeToProtobuf",
-          []() {
-            std::string str = tc::CudaMappingOptions::toProtobufSerializedString;
+          [](tc::CudaMappingOptions& instance) {
+            std::string str = instance.toProtobufSerializedString;
             return py::bytes(str);
           },
           "Serialize the options to a protobuf string")


### PR DESCRIPTION
In the Python binding of `Options` class, the method `toProtobufSerializedString` called inside of `serializeToProtobuf` seems to return a protobuf byte string, but the current wrapper seems to try to return it as a Python `str`. So it causes `UnicodeDecodeError` like this:

```
In [1]: import tensor_comprehensions as tc

In [2]: o = tc.Options('naive')

In [3]: o.serializeToProtobuf()
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-3-5b2f56afe628> in <module>()
----> 1 o.serializeToProtobuf()

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 35: invalid start byte
```

After merging this PR, we can get the protobuf string as byte string as follows:

```
In [1]: import tensor_comprehensions as tc

In [2]: o = tc.Options('naive')

In [3]: o.serializeToProtobuf()
Out[3]: b'\n \n\x06\x08\x02\x10\x00\x18\x01\x12\x06\x08\x02\x10\x00\x18\x01\x18\x00"\x06\x08 \x08 \x08 8\x01@\x00p\x00\x12\x04\x08 \x10\x08\x1a\x06\x08\x80\x02\x10\x80\x02 \x00(\x000\x00'
```