### PR TITLE
CudaRTCFunction: do not unload the module that was never loaded

### DIFF
--- a/tc/core/cuda/cuda_rtc.cc
+++ b/tc/core/cuda/cuda_rtc.cc
@@ -138,14 +138,14 @@ Duration CudaRTCFunction::Launch(
   int dev;
   TC_CUDA_RUNTIMEAPI_ENFORCE(cudaGetDevice(&dev));
   if (perGpuModule_.count(dev) == 0) {
-    perGpuModule_.emplace(dev, CUmodule());
-    perGpuKernel_.emplace(dev, CUfunction());
-    TC_CUDA_DRIVERAPI_ENFORCE(cuModuleLoadDataEx(
-        &(perGpuModule_.at(dev)), nvrtc_ptx.data(), 0, 0, 0));
-    TC_CUDA_DRIVERAPI_ENFORCE(cuModuleGetFunction(
-        &(perGpuKernel_.at(dev)),
-        perGpuModule_.at(dev),
-        specializedName.c_str()));
+    CUmodule module;
+    CUfunction function;
+    TC_CUDA_DRIVERAPI_ENFORCE(
+        cuModuleLoadDataEx(&module, nvrtc_ptx.data(), 0, 0, 0));
+    perGpuModule_.emplace(dev, module);
+    TC_CUDA_DRIVERAPI_ENFORCE(
+        cuModuleGetFunction(&function, module, specializedName.c_str()));
+    perGpuKernel_.emplace(dev, function);
   }
 
   constexpr int kNumMaxParameters = 100;


### PR DESCRIPTION
In CudaRTCFunction::Launch, we first add (empty) module to the per-GPU
list of modules, and only then try to load it from PTX. The load part
may fail and throw, the module in the list remaining empty. When the
CudaRTCFunction is destroyed, its destructor tries to unload the module
available in the list. Since the module is empty, unloading fails and
throws. The exception does not seem to be handled, and can even happen
during unwinding of another exception leading to immediate termination.

Load CUmodule and extract CUfunction using local variables, and insert
the values into respective per-GPU lists only when both the loading and
the extraction completed without errors.  If they throw, nothing is
inserted and thus the destructor will not attempt to clean non-existent
objects.

Closes #292 