### PR TITLE
do not promote to registers before promoting to shared in tests

### DIFF
--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -66,7 +66,7 @@ class MapperMemoryPromotion2DHelper : public TestMapper {
         CudaMappingOptions::makeNaiveCudaMappingOptions()
             .tile(tileSizes) // passing more tiling values triggers a check...
             .useSharedMemory(false) // do not auto-promote
-            .usePrivateMemory(true);
+            .usePrivateMemory(false);
     return makeMappedScop(tc, mappingOptions, problemSizes);
   }
 };
@@ -86,7 +86,7 @@ def fun(float(N,M,K,L) A, float(N,M,K,L) B) -> (C) {
     auto mappingOptions = CudaMappingOptions::makeNaiveCudaMappingOptions()
                               .tile(tileSizes)
                               .useSharedMemory(false) // do not autopromote
-                              .usePrivateMemory(true);
+                              .usePrivateMemory(false);
     auto mscop = makeMappedScop(
         tc,
         mappingOptions,


### PR DESCRIPTION
MapperMemoryPromotionRAW and Sum4D tests call the mapping strategy with
promotion to private enabled, which may insert copies to private, and
promotion to shared disabled.  They then call promotion to shared
separately through a dedicated call to avoid using the main heuristic
dependent on the shared memory size available on the current device.
Therefore, promotion to shared happens after promotion to private, and
neither expects that.  In particular, mapCopiesToThreads is a part of
the promotion to shared and expects to be called before the promotion to
private happens.  Do not request promotion to private in the tests that
do not check for it.