### PR TITLE
memory promotion: check for any reuse within outer schedule

### DIFF
--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -454,6 +454,14 @@ isl::multi_union_pw_aff prefixScheduleMupa(
   return prefix;
 }
 
+isl::multi_union_pw_aff partialScheduleMupa(
+    const detail::ScheduleTree* root,
+    const detail::ScheduleTree* tree) {
+  auto band = tree->elemAs<ScheduleTreeElemBand>();
+  CHECK(band);
+  return prefixScheduleMupa(root, tree).flat_range_product(band->mupa_);
+}
+
 ScheduleTree* insertBandAbove(
     ScheduleTree* root,
     ScheduleTree* tree,

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -276,6 +276,14 @@ isl::multi_union_pw_aff prefixScheduleMupa(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* tree);
 
+// Return the concatenation of all outer band node partial schedules,
+// including that of the node itself.
+// Note that this function does not take into account
+// any intermediate filter nodes.
+isl::multi_union_pw_aff partialScheduleMupa(
+    const detail::ScheduleTree* root,
+    const detail::ScheduleTree* tree);
+
 // Get the set of domain points active at the given node.  A domain
 // point is active if it was not filtered away on the path from the
 // root to the node.  The root must be a domain element, otherwise no


### PR DESCRIPTION
The original code checks for reuse by applying a "full schedule"
to the domain of the access relation and then checking if
there is more than one instance of this full schedule accessing
a group element for fixed values of some outer part of this
full schedule, where fixing these values is performed separately
for each statement.

The new code is much simpler and directly checks for multiple
statement instances accessing an element within an outer schedule.

Note that because of the way the "full schedule" is constructed,
some statement instances may get mapped to the same full schedule
instance and could therefore project out some reuse.
The new code may therefore detect some reuse where the old code did not.
Detecting more reuse is not the purpose of this commit,
but the new form of detection does make it easier to understand
which situation are considered to constitute reuse.