### PR TITLE
MappedScop::mapToThreads: fix depth of threadIdxX in case of reduction

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -334,10 +334,10 @@ size_t MappedScop::mapToThreads(detail::ScheduleTree* band) {
   if (reductionBandUpdates_.count(band) == 1) {
     // A reduction is assumed to get mapped to threadIdx.x
     CHECK(reductionBandUpdates_.at(band).separated);
+    auto reductionDim = reductionBandUpdates_.at(band).reductionDim;
     threadIdxXScheduleDepthState.emplace_back(std::make_pair(
         activeDomainPoints(schedule(), band),
-        band->scheduleDepth(schedule()) + 0));
-    auto reductionDim = reductionBandUpdates_.at(band).reductionDim;
+        band->scheduleDepth(schedule()) + reductionDim));
     band = map(band, reductionDim, mapping::ThreadId::x());
     nMappedReductionThreads = 1;
   }


### PR DESCRIPTION
Commit 88764d37 (split out reduction band after thread mapping
to remove nested mapping, Mon Apr 9 17:43:18 2018 +0200) removed
the condition that the reduction member always appears first
in its band at the point of MappedScop::mapToThreads.
The actual mapping was updated to take into account the depth
inside the band, but the threadIdxXScheduleDepthState was
not updated accordingly.