### PR TITLE
Proposed API changes for ExecutionEngine

### DIFF
--- a/tc/aten/aten_compiler_api_rfc.h
+++ b/tc/aten/aten_compiler_api_rfc.h
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "tc/aten/aten.h"
+#include "tc/core/utils/time.h"
+#include "tc/lang/tree.h"
+
+namespace tc {
+/// Run inference on the TC tree resulting from parsing a TC function and
+/// applied to the specified input shapes.
+/// This is used for manual processing of outptu metadata on the ATen user
+/// side.
+/// \returns the (contiguous) output tensor shapes as a metadata-owning
+/// DLTensorUPtr.
+std::vector<DLTensorUPtr> inferOutputTensorInfo(
+  lang::TreeRef tcDefinition,
+  const std::vector<at::Tensor>& inputs);
+
+/// Allocate fresh new output tensors.
+/// If one wants inplace/resize behavior, one can implement it using
+/// inferOutputTensorInfo.
+/// \returns the (contiguous) output tensors with properly inferred sizes.
+std::vector<at::Tensor> prepareOutputs(
+  lang::TreeRef tcDefinition,
+  const std::vector<at::Tensor>& inputs);
+
+/// Given a TC tree resulting from parsing a TC function, compile the TC for
+/// the specified input shapes with the prescribed options.
+/// \returns an Executor for the specified backend with an underlying
+/// JIT-compiled callable function.
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+    lang::TreeRef tcDefinition,
+    const std::vector<at::Tensor>& inputs,
+    const typename Backend::MappingOptionsType& options);
+
+/// Given an executor resulting from compiling a TC, run the TC and fill the
+/// outputs vector with the results.
+/// \returns ProfilingInfo (cpuOverhead + kernelRuntime) in microseconds.
+/// If profile=false, kernelRuntime is set to Duration::max.
+template <typename Executor>
+ProfilingInfo run(
+  const Executor& executor,
+  const std::vector<at::Tensor>& inputs,
+  std::vector<at::Tensor>& outputs,
+  bool profile = false);
+
+/// This is the "low-latency" mode in which we just propagate ATen tensors
+/// Sizes are not checked and it is the user's responsibility to ensure that
+/// they match. If the user doesn't then segfault will likely occur.
+/// \returns the kernel runtime in microseconds if profile=true.
+/// If profile=false, kernelRuntime is set to Duration::max.
+template <typename Executor>
+Duration uncheckedRun(
+    const Executor& executor,
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    bool profile = false);
+} // namespace tc
+
+#include "tc/aten/aten_compiler-inl.h"

--- a/tc/core/execution_engine_api_rfc.h
+++ b/tc/core/execution_engine_api_rfc.h
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "tc/core/compilation_cache.h"
+#include "tc/core/tc_executor.h"
+#include "tc/core/tensor.h"
+#include "tc/core/utils/time.h"
+#include "tc/lang/tree.h"
+
+namespace tc {
+
+/**
+ * The ExecutionEngine is the entry point to using TC in C++.
+ * It provides simple backend-agnostic capabilities to:
+ *   1. construct the tree IR for parsed TCs from
+ *      a string representation and store (a shared_ptr to) it
+ *   2. infer actual tmp/output tensor shapes given input tensor shapes;
+ *   3. compile and run TCs on backend-specific TcExecutors;
+ *   4. store the TcExecutors for memoization of compilations.
+ *      The correspondance is:
+ *      1 TcExecutor <-> 1 tuple<TC function, input shapes, MappingOptions>
+ *
+ * ExecutionEngine is templated by the Backend type.
+ * For each backend, the specific Backend type lives in
+ *   backend/backed_tc_executor.h and declares all the required dependent
+ *   **concrete** types.
+ * For example:
+ *   CudaBackend is declared in core/cuda/cuda_tc_executor.h
+ *
+ * struct CudaBackend {
+ *   using ExecutorType = CudaTcExecutor;
+ *   using MappingOptionsType = CudaMappingOptions;
+ *   using ProtobufType = CudaCacheProto;
+ *   using CacheType = CudaCache;
+ *   using CacheEntryType = CudaCacheEntry;
+ *   using CacheKeyType = typename CacheEntryType::Key;
+ *   using CacheValueType = typename CacheEntryType::Values;
+ *   using RTCFunctionType = CudaRTCFunction;
+ * };
+ *
+ * Sketching usage resembles:
+ *   std::string someTc = "...";
+ *   ExecutionEngine<CudaBackend> engine;
+ *   engine.define(someTc)
+ *   auto handle = engine.compile(someTc, inputs, mappingOptions)
+ *   auto cpuKernelProfilingInfo = engine.run(handle, inputs, outputs, true);
+ *   // alternatively:
+ *   // auto kernelTiming = engine.uncheckedRun(handle, inputs, outputs, true);
+ */
+template <typename Backend>
+class ExecutionEngine {
+ public:
+  using BackendType = Backend;
+  using ExecutorType = typename BackendType::ExecutorType;
+  using MappingOptionsType = typename BackendType::MappingOptionsType;
+
+  ExecutionEngine() = default;
+
+  /// Parse TC definitions provided as string, store parsed trees internally.
+  void define(const std::string& language);
+
+  /// Store the provided parsed trees internally.
+  void define(const std::vector<lang::TreeRef>& treeRefs);
+
+  /// For a given TC kernel name, compute the shapes of the output tensors
+  /// provided the shapes of the input TC tensors.  The caller can use the
+  /// computed shapes to allocate memory for outputs.
+  std::vector<TensorInfo> inferOutputTensorInfo(
+      const std::string& name,
+      const std::vector<const DLConstTensor*>& inTensorPtrs);
+
+  /// JIT-compile given the TC kernel name, the shapes of the input tensors and
+  /// the compilation options.  Must be overridden by a specific
+  /// ExecutionEngine, which also interprets the options as it sees fit.
+  /// \returns opaque handle of a compiled kernel.
+  size_t compile(
+      const std::string& name,
+      const std::vector<const DLConstTensor*>& inputs,
+      const MappingOptionsType& options);
+
+  /// Run a compiled TC kernel given its handle, on the given input tensors and
+  /// fill in the outputs.  All tensors must be allocated and have appropriate
+  /// shapes (inputs same as for copmilation, outputs same as returned by
+  /// inferOutputTensorInfo).
+  /// \returns The pair of (cpu,kernel) runtimes. If profile is set, the
+  /// kernel is profiled otherwise its duration is set to Duration::max().
+  ProfilingInfo run(
+      size_t handle,
+      const std::vector<const DLConstTensor*>& inputs,
+      const std::vector<const DLTensor*>& outputs,
+      bool profileKernel = false,
+      std::function<bool(const ExecutorType*)> pruningFunction =
+          [](const ExecutorType*) { return false; });
+
+  /// "Low-latency" execution mode in which we just propagate raw pointers to
+  /// data in GPU address space.
+  /// No tensor-related information can be checked so it is the user's
+  /// responsibility to ensure that shapes and strides match.
+  Duration uncheckedRun(
+      size_t handle,
+      const std::vector<const void*>& inputs,
+      const std::vector<void*>& outputs,
+      bool profileKernel = false);
+
+  /// Clear the compilation result for the given handle.
+  void clear(size_t handle);
+
+ private:
+  size_t emplaceExecutor(std::unique_ptr<ExecutorType>&& p);
+
+  size_t getHandle(
+      const std::string& name,
+      const std::vector<const DLConstTensor*>& inputs,
+      const MappingOptionsType& options);
+
+ private:
+  /// For thread-safety perform all cheap operations under lock.
+  std::mutex tcExecutorMutex_;
+
+  /// Parsed TC trees.
+  std::map<std::string, lang::TreeRef> tcNameMap_;
+
+  /// List of executors, indexed by handle.
+  std::vector<std::unique_ptr<ExecutorType>> executors_;
+
+  size_t nextHandle = 0;
+};
+} // namespace tc
+
+#include "tc/core/execution_engine-inl.h"

--- a/tc/core/tc_api_rfc.h
+++ b/tc/core/tc_api_rfc.h
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "tc/lang/tree.h"
+#include "tc/core/mapping_options.h"
+#include "tc/core/tensor.h"
+
+namespace tc {
+// Given a TC representation as a TC + TC function name, this function
+// compiles a new TcExecutor for the specified Backend.
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+  std::string tc,
+  std::string tcFunctionName,
+  const std::vector<const DLConstTensor*>& inputs,
+  /* TODO: in the future also pass outputs for stride and alignment info */
+  const typename Backend::MappingOptionsType& options);
+
+namespace detail {
+// Given a Tc and a list of input tensors that match the definition in the
+// TC in positional order, this generates the output tensor infos issued
+// from forward inference.
+// The typical flow is to infer output sizes, allocate/resize them within
+// you favorite ML framework / tensor library and then call compile.
+std::vector<TensorInfo> inferOutputTensorInfo(
+  lang::TreeRef tcDefinition,
+  const std::vector<const DLConstTensor*> inputs);
+
+// Given a TC representation, this parses the TC functions into a map of
+// TreeRef indexed by TC function names.
+std::map<std::string, lang::TreeRef> parse(const std::string& tc);
+
+// Given a TC representation as a TreeRef, this function compiles a new
+// TcExecutor for the specified Backend.
+// For now, contiguous output sizes are inferred given input sizes.
+// If you need another kernel for another TC or another inputs, options then
+// just compile another TcExecutor; because atm we fully JIT specialize on all
+// sizes.
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+  lang::TreeRef tcDefinition,
+  const std::vector<const DLConstTensor*>& inputs,
+  /* TODO: in the future also pass outputs for stride and alignment info */
+  const typename Backend::MappingOptionsType& options);
+} // namespace detail
+} // namespace tc
+
+#include "tc/core/tc-inl.h"


### PR DESCRIPTION
The proposed changes to the API involve the following main things:
1. an explicit Backend type which keeps track of the concrete Executor, MappingOptions, Protobuf, Cache and RTCFunction types. By making types dependent it becomes significantly easier to write a type-safe, backend-agnostic JIT compiler and factor out the common behaviors across the Autotuner, the ExecutionEngine, the Executor and the Mapper and have them interact properly;
2. inferOutputTensorInfo now returns a TensorInfo object. In the current master, this returns a pointer backed by an underlying executor that needs to persist in the executors_ even though it is not yet compiled; clearly not great;
3. run returns a pair<Duration, Duration> which measure the CPU and kernel performance (when profileKernel == true). uncheckedRun returns the kernel time (when profileKernel == true). This will allow more easily to root out CPU overhead issues.
4. uncheckedRun now explicitly takes const void* and void*
5. inputs are now of type DLConstTensor to properly implement const-correctness cc @salexspb (RFC to follow)
6. thanks to 1. MappingOptions can now be properly typed and we don't need to resort to string serialization
7. clearer documentation with an example of usage

There is a currently working implementation here but it still needs work and cleanup. In particular, it also needs slicing up so that people can review more easily.
To facilitate the slicing work on the PR above, let's please have people comment on the proposed API changes and either signoff or proposed changes and iterate until we reach consensus.
Once consensus is reached on a particular piece of the API, independent commits can be created and sent for review.