### PR TITLE
Add instuctions for building TC with PyTorch master build

### DIFF
--- a/docs/source/installation_conda.rst
+++ b/docs/source/installation_conda.rst
@@ -200,6 +200,40 @@ Now, you need to install TC from source. For installing TC from source, checkout
 .. note::
     Please also make sure that you don't have gflags or glog in your system path. Those might conflict with the TC gflags/glog.
 
+Optional: Building TC with PyTorch master
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are interested in using PyTorch master with TC, there are two options:
+
+- Install PyTorch nightly conda package (these packages are built for PyTorch master every day) OR
+- Install PyTorch from source
+
+For the above two options, the :code:`Install TC` instructions would be as below:
+
+**1. Using PyTorch nightly**:
+
+.. code-block:: bash
+
+    $ conda create -y --name tc-build-conda python=3.6 && source activate tc-build-conda
+    $ conda install -y pyyaml mkl-include
+    $ conda install -yc conda-forge pytest
+    $ conda install -y pytorch-nightly -c pytorch
+    $ cd $HOME && git clone https://github.com/facebookresearch/TensorComprehensions.git --recursive
+    $ cd TensorComprehensions && git submodule update --init --recursive
+    $ BUILD_TYPE=Release INSTALL_PREFIX=$CONDA_PREFIX WITH_CAFFE2=OFF CLANG_PREFIX=$(llvm-config --prefix) ./build.sh --all
+
+**1. With PyTorch install from source**:
+
+.. code-block:: bash
+
+    $ conda create -y --name tc-build-conda python=3.6 && source activate tc-build-conda
+    $ cd $HOME && git clone --recursive https://github.com/pytorch/pytorch && cd pytorch && git submodule update --init --recursive
+    $ conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
+    $ python setup.py install
+    $ cd $HOME && git clone https://github.com/facebookresearch/TensorComprehensions.git --recursive
+    $ cd TensorComprehensions && git submodule update --init --recursive
+    $ BUILD_TYPE=Release INSTALL_PREFIX=$CONDA_PREFIX WITH_CAFFE2=OFF CLANG_PREFIX=$(llvm-config --prefix) ./build.sh --all
+
 
 Step 8: Verify TC installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/installation_conda_dep.rst
+++ b/docs/source/installation_conda_dep.rst
@@ -126,7 +126,7 @@ conda packages of TC dependencies and then build TC.
 .. code-block:: bash
 
     $ conda create -y --name tc-build-conda python=3.6 && source activate tc-build-conda
-    $ conda install -y -c tensorcomp llvm-tapir50 isl-tc gflags glog protobuf
+    $ conda install -y -c tensorcomp llvm-tapir50 gflags glog protobuf
     $ conda install -y -c pytorch pytorch
     $ cd $HOME && git clone https://github.com/facebookresearch/TensorComprehensions.git --recursive
     $ cd TensorComprehensions && git submodule update --init --recursive
@@ -134,6 +134,43 @@ conda packages of TC dependencies and then build TC.
 
 .. note::
     Please also make sure that you don't have :code:`gflags` or :code:`glog` in your system path. Those might conflict with the TC gflags/glog.
+
+
+Optional: Building TC with PyTorch master
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are interested in using PyTorch master with TC, there are two options:
+
+- Install PyTorch nightly conda package (these packages are built for PyTorch master every day) OR
+- Install PyTorch from source
+
+For the above two options, the :code:`Install TC` instructions would be as below:
+
+**1. Using PyTorch nightly**:
+
+.. code-block:: bash
+
+    $ conda create -y --name tc-build-conda python=3.6 && source activate tc-build-conda
+    $ conda install -y -c tensorcomp llvm-tapir50 gflags glog protobuf
+    $ conda install -y pyyaml mkl-include
+    $ conda install -yc conda-forge pytest
+    $ conda install -y pytorch-nightly -c pytorch
+    $ cd $HOME && git clone https://github.com/facebookresearch/TensorComprehensions.git --recursive
+    $ cd TensorComprehensions && git submodule update --init --recursive
+    $ BUILD_TYPE=Release INSTALL_PREFIX=$CONDA_PREFIX WITH_CAFFE2=OFF CLANG_PREFIX=$(llvm-config --prefix) ./build.sh --all
+
+**1. With PyTorch install from source**:
+
+.. code-block:: bash
+
+    $ conda create -y --name tc-build-conda python=3.6 && source activate tc-build-conda
+    $ conda install -y -c tensorcomp llvm-tapir50 gflags glog protobuf
+    $ cd $HOME && git clone --recursive https://github.com/pytorch/pytorch && cd pytorch && git submodule update --init --recursive
+    $ conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
+    $ python setup.py install
+    $ cd $HOME && git clone https://github.com/facebookresearch/TensorComprehensions.git --recursive
+    $ cd TensorComprehensions && git submodule update --init --recursive
+    $ BUILD_TYPE=Release INSTALL_PREFIX=$CONDA_PREFIX WITH_CAFFE2=OFF CLANG_PREFIX=$(llvm-config --prefix) ./build.sh --all
 
 
 Step 6: Verify TC installation


### PR DESCRIPTION
There were multiple user requests recently (email, slack) where they wanted to build PyTorch from master and have TC build with that. This required bumping ATen submodule as well (done in https://github.com/facebookresearch/TensorComprehensions/pull/183 )

add the instructions for how to build TC with pytorch master in docs in this PR

closes #130 