### PR TITLE
Warning for uninitialized reductions.

### DIFF
--- a/tc/lang/sema.h
+++ b/tc/lang/sema.h
@@ -497,10 +497,9 @@ struct Sema {
         nullptr == lookup(stmt.ident(), false)) {
       ErrorReport err(stmt);
       std::string tk = kindToToken(stmt.assignment()->kind());
-      err << "Reduction without initialization. "
-          << "It reads from the uninitialized " << stmt.ident().name()
-          << " before writing to it.\n"
-          << "Consider using the !-suffixed reduction operator " << tk
+      err << "Reduction without initialization. If " << stmt.ident().name()
+          << " is not pre-initialized before calling the TC function,"
+          << " consider using the !-suffixed reduction operator " << tk
           << "! instead of " << tk;
       warn(err);
     }

--- a/tc/lang/sema.h
+++ b/tc/lang/sema.h
@@ -490,6 +490,21 @@ struct Sema {
       }
     }
 
+    // After checking rhs and before creating lhs, we check if it is a reduction
+    // without initialization (i.e., reduction operator without "!" suffix, and
+    // lhs not defined previously).
+    if (isUninitializedReductionOperation(stmt.assignment()) &&
+        nullptr == lookup(stmt.ident(), false)) {
+      ErrorReport err(stmt);
+      std::string tk = kindToToken(stmt.assignment()->kind());
+      err << "Reduction without initialization. "
+          << "It reads from the uninitialized " << stmt.ident().name()
+          << " before writing to it.\n"
+          << "Consider using the !-suffixed reduction operator " << tk
+          << "! instead of " << tk;
+      warn(err);
+    }
+
     auto type = TensorType::create(
         stmt.range(),
         scalar_type,
@@ -543,6 +558,17 @@ struct Sema {
     let_env.clear();
 
     return result;
+  }
+  static bool isUninitializedReductionOperation(TreeRef assignment) {
+    switch (assignment->kind()) {
+      case TK_PLUS_EQ:
+      case TK_TIMES_EQ:
+      case TK_MIN_EQ:
+      case TK_MAX_EQ:
+        return true;
+      default:
+        return false;
+    }
   }
   bool isNotInplace(TreeRef assignment) {
     switch (assignment->kind()) {


### PR DESCRIPTION
This PR adds warnings for uninitialized reductions, which is described in issue #190 .

Such checking happens in sema stage. When checking a stmt, if it is a reduction, we raise a warning if the following two conditions hold: (1) the reduction operator is not suffixed with !, and (2) the lhs has not been previously defined.

Some test cases are also included.
