### PR TITLE
pass TC_DIR on cmake command line instead of through environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "CMAKE_INSTALL_PREFIX is ${CMAKE_INSTALL_PREFIX}")
 
 add_subdirectory(third-party/pybind11)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTC_DIR=\"\\\"$ENV{TC_DIR}\\\"\" ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTC_DIR=\"\\\"${TC_DIR}\\\"\" ")
 
 set(LLVM_DIR ${CLANG_PREFIX}/lib/cmake/llvm)
 message(STATUS "Looking for LLVM in ${LLVM_DIR}")

--- a/build.sh
+++ b/build.sh
@@ -412,6 +412,7 @@ function install_tc() {
         -DCLANG_PREFIX=${CLANG_PREFIX} \
         -DCUDNN_ROOT_DIR=${CUDNN_ROOT_DIR} \
         -DWITH_CUDA=${WITH_CUDA} \
+        -DTC_DIR=${TC_DIR} \
         -DCMAKE_C_COMPILER=${CC} \
         -DCMAKE_CXX_COMPILER=${CXX} .. || exit 1
   fi


### PR DESCRIPTION
The environment is not preserved by cmake, resulting in a TC_DIR
set to "" whenever cmake gets called during make.