### PR TITLE
Fix MappingOptionsPrinter

### DIFF
--- a/tc/core/cuda/cuda_mapping_options_cpp_printer.cc
+++ b/tc/core/cuda/cuda_mapping_options_cpp_printer.cc
@@ -22,9 +22,7 @@ namespace tc {
 CudaMappingOptionsCppPrinter& operator<<(
     CudaMappingOptionsCppPrinter& prn,
     const CudaMappingOptions& cudaOptions) {
-  std::stringstream ss;
-  ss << cudaOptions.generic;
-  prn.printString(ss.str());
+  prn.print(cudaOptions.generic);
   prn.printListOption("mapToThreads", cudaOptions.block.extractVector());
   prn.printListOption("mapToBlocks", cudaOptions.grid.extractVector());
   prn.printBooleanOption(

--- a/tc/core/cuda/cuda_mapping_options_cpp_printer.h
+++ b/tc/core/cuda/cuda_mapping_options_cpp_printer.h
@@ -38,6 +38,8 @@ class CudaMappingOptionsCppPrinter : public MappingOptionsCppPrinter {
   CudaMappingOptionsCppPrinter(std::ostream& out, size_t ws = 0)
       : MappingOptionsCppPrinter(out, ws) {}
 
+  ~CudaMappingOptionsCppPrinter() = default;
+
   friend CudaMappingOptionsCppPrinter& operator<<(
       CudaMappingOptionsCppPrinter& prn,
       const CudaMappingOptions& options);

--- a/tc/core/mapping_options.cc
+++ b/tc/core/mapping_options.cc
@@ -60,18 +60,6 @@ std::ostream& operator<<(
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const MappingOptions& options) {
-  OstreamBoolalphaScope scope(os);
-  tc::MappingOptionsAsCpp cpp(options);
-  os << cpp;
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os, const MappingOptionsView& view) {
-  os << MappingOptions(view);
-  return os;
-}
-
 MappingOptionsView& MappingOptionsView::tile(
     const std::string& commaSeparatedSizes) {
   return tile(parseCommaSeparatedIntegers<uint64_t>(commaSeparatedSizes));

--- a/tc/core/mapping_options_cpp_printer.cc
+++ b/tc/core/mapping_options_cpp_printer.cc
@@ -19,6 +19,8 @@
 
 namespace tc {
 
+MappingOptionsCppPrinter::~MappingOptionsCppPrinter() = default;
+
 MappingOptionsCppPrinter& MappingOptionsCppPrinter::printSchedulerOptions(
     const SchedulerOptionsView& schedulerOptions,
     const std::string& prefix) {
@@ -28,38 +30,28 @@ MappingOptionsCppPrinter& MappingOptionsCppPrinter::printSchedulerOptions(
       "tc::FusionStrategy::" + FusionStrategy_Name(proto.fusion_strategy()));
   printBooleanOption(prefix + "AllowSkewing", proto.allow_skewing());
   printBooleanOption(prefix + "PositiveOrthant", proto.positive_orthant());
-
   return *this;
 }
 
-MappingOptionsCppPrinter& operator<<(
-    MappingOptionsCppPrinter& prn,
-    const std::string& str) {
-  prn.printString(str);
-  return prn;
-}
-
-MappingOptionsCppPrinter& operator<<(
-    MappingOptionsCppPrinter& prn,
+MappingOptionsCppPrinter& MappingOptionsCppPrinter::print(
     const MappingOptions& options) {
-  prn.printString("tc::MappingOptions::makeNaiveMappingOptions()")
+  printString("tc::MappingOptions::makeNaiveMappingOptions()")
       .printSchedulerOptions(
           options.view.outerScheduleOptions, "outerSchedule");
   if (options.view.proto.has_intra_tile_schedule_options()) {
-    prn.printSchedulerOptions(
+    printSchedulerOptions(
         options.view.intraTileScheduleOptions, "intraTileSchedule");
   }
   if (options.view.proto.has_tiling()) {
-    prn.printListOption("tile", options.view.tiling.extractVector());
+    printListOption("tile", options.view.tiling.extractVector());
   }
   if (options.view.proto.has_unroll()) {
-    prn.printValueOption("unroll", options.view.proto.unroll());
+    printValueOption("unroll", options.view.proto.unroll());
   }
-  prn.printBooleanOption(
+  printBooleanOption(
       "tileImperfectlyNested", options.view.proto.tile_imperfectly_nested());
-  prn.printBooleanOption(
+  printBooleanOption(
       "matchLibraryCalls", options.view.proto.match_library_calls());
-  prn.endStmt();
-  return prn;
+  return *this;
 }
 } // namespace tc

--- a/tc/core/mapping_options_cpp_printer.h
+++ b/tc/core/mapping_options_cpp_printer.h
@@ -37,13 +37,7 @@ class MappingOptionsCppPrinter {
   MappingOptionsCppPrinter(std::ostream& out, size_t ws = 0)
       : out_(out), ws_(ws) {}
 
-  friend MappingOptionsCppPrinter& operator<<(
-      MappingOptionsCppPrinter& prn,
-      const std::string& str);
-
-  friend MappingOptionsCppPrinter& operator<<(
-      MappingOptionsCppPrinter& prn,
-      const MappingOptions& options);
+  virtual ~MappingOptionsCppPrinter() = 0;
 
  protected:
   inline MappingOptionsCppPrinter& tab();
@@ -71,18 +65,12 @@ class MappingOptionsCppPrinter {
       const SchedulerOptionsView& schedulerOptions,
       const std::string& prefix);
 
+  MappingOptionsCppPrinter& print(const MappingOptions& options);
+
   std::ostream& out_;
   size_t ws_;
   bool lineContinuation_ = false;
 };
-
-inline std::ostream& operator<<(
-    std::ostream& out,
-    const MappingOptionsAsCpp& mo) {
-  auto prn = MappingOptionsCppPrinter(out, mo.indent);
-  prn << mo.options;
-  return out;
-}
 
 MappingOptionsCppPrinter& MappingOptionsCppPrinter::tab() {
   for (size_t i = 0; i < ws_; ++i) {


### PR DESCRIPTION
This PR addresses #294 by making the base mapping printer not print a newline
This is safe only if one cannot print the base class so this changeset also:
1. drops the operator<< functions that operate on the base class;
2. adds a pure virtual destructor to the base class;
3. implements CudaMappingOptionsCppPrinter in terms of the parent print function

We now correctly see entries such as:
```
[TUNER][GENERATION LOG] best option so far:
tc::MappingOptions::makeNaiveMappingOptions()
.outerScheduleFusionStrategy(tc::FusionStrategy::Max)
.outerScheduleAllowSkewing(false)
.outerSchedulePositiveOrthant(true)
.intraTileScheduleFusionStrategy(tc::FusionStrategy::Min)
.intraTileScheduleAllowSkewing(false)
.intraTileSchedulePositiveOrthant(true)
.tile(256, 13)
.unroll(64)
.tileImperfectlyNested(false)
.matchLibraryCalls(true)
.mapToThreads(25, 7)
.mapToBlocks(128)
.useSharedMemory(true)
.usePrivateMemory(true)
.unrollCopyShared(true);
```