### PR TITLE
clean-ups in the mapper

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -239,7 +239,7 @@ bool MappedScop::detectReductions(detail::ScheduleTree* tree) {
   if (!inits.is_empty()) {
     orderBefore(scop_->scheduleRoot(), tree, inits);
   }
-  reductionBandUpdates_.emplace(tree, Reduction(updateIds, reductionDim));
+  reductionBandUpdates_.emplace(tree, Reduction(updateIds));
   return true;
 }
 
@@ -261,11 +261,9 @@ isl::multi_union_pw_aff MappedScop::reductionMapSchedule(
   // mapped to threads.
   auto reductionSchedule = reductionBand->mupa_;
   auto nMember = reductionBand->nMember();
-  auto reductionDim = reductionBandUpdates_.at(st).reductionDim;
-  auto nMappedThreads =
-      std::min(numThreads.view.size(), reductionBand->nOuterCoincident() + 1);
+  auto reductionDim = reductionBand->nOuterCoincident();
+  auto nMappedThreads = std::min(numThreads.view.size(), reductionDim + 1);
   CHECK_GE(nMember, reductionDim);
-  CHECK_GE(reductionDim + 1, nMappedThreads);
   reductionSchedule = reductionSchedule.drop_dims(
       isl::dim_type::set, reductionDim + 1, nMember - (reductionDim + 1));
   reductionSchedule = reductionSchedule.drop_dims(

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -158,13 +158,13 @@ void MappedScop::mapToBlocksAndScaleBand(
 }
 
 /*
- * Given a filter node in the schedule tree of a mapped scop,
- * insert another filter underneath (if needed) that fixes
+ * Given a node in the schedule tree of a mapped scop,
+ * insert a mapping filter underneath (if needed) that fixes
  * the remaining thread identifiers starting at "begin" to zero.
  */
-void fixThreadsBelowFilter(
+void fixThreadsBelow(
     MappedScop& mscop,
-    detail::ScheduleTree* filterTree,
+    detail::ScheduleTree* tree,
     size_t begin) {
   size_t end = mscop.numThreads.view.size();
   if (begin == end) {
@@ -172,7 +172,7 @@ void fixThreadsBelowFilter(
   }
 
   auto band = detail::ScheduleTree::makeEmptyBand(mscop.scop().scheduleRoot());
-  auto bandTree = insertNodeBelow(filterTree, std::move(band));
+  auto bandTree = insertNodeBelow(tree, std::move(band));
   mscop.mapRemaining<mapping::ThreadId>(bandTree, begin);
 }
 
@@ -426,7 +426,7 @@ size_t MappedScop::mapInnermostBandsToThreads(detail::ScheduleTree* st) {
     auto needSync = st->elemAs<detail::ScheduleTreeElemSequence>() && n > 0;
     if (n > 0) {
       for (size_t i = 0; i < nChildren; ++i) {
-        fixThreadsBelowFilter(*this, children[i], nInner[i]);
+        fixThreadsBelow(*this, children[i], nInner[i]);
       }
     }
     if (needSync) {

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -155,13 +155,16 @@ class MappedScop {
   // The remaining parts, if any, are no longer considered for replacement
   // by a library call.
   detail::ScheduleTree* separateReduction(detail::ScheduleTree* band);
-  // Split out reduction bands and insert reduction synchronizations.
-  void splitOutReductionsAndInsertSyncs();
+  // Split out reduction member at position "dim" in "band" and
+  // insert reduction synchronizations.
+  void splitOutReductionAndInsertSyncs(detail::ScheduleTree* band, int dim);
   // Map "band" to thread identifiers using as many blockSizes values as outer
-  // coincident dimensions (plus reduction dimension, if any), and
+  // coincident dimensions (plus reduction dimension, if any),
+  // insert synchronization in case of a reduction, and
   // return the number of mapped thread identifiers.
   size_t mapToThreads(detail::ScheduleTree* band);
-  // Map innermost bands to thread identifiers and
+  // Map innermost bands to thread identifiers,
+  // inserting synchronization in case of a reduction, and
   // return the number of mapped thread identifiers.
   size_t mapInnermostBandsToThreads(detail::ScheduleTree* st);
 

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -187,14 +187,11 @@ class MappedScop {
   // Information about a detected reduction that can potentially
   // be mapped to a library call.
   struct Reduction {
-    Reduction(std::vector<isl::id> ids, size_t index)
-        : ids(ids), separated(false), reductionDim(index) {}
+    Reduction(std::vector<isl::id> ids) : ids(ids), separated(false) {}
     // The statement identifiers of the reduction update statements.
     std::vector<isl::id> ids;
     // Has the reduction been separated out as a full block?
     bool separated;
-    // Index of the band member in which the reduction was detected.
-    size_t reductionDim;
   };
   // Map isolated innermost reduction band members to information
   // about the detected reduction.

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -158,8 +158,8 @@ class MappedScop {
   // Split out reduction bands and insert reduction synchronizations.
   void splitOutReductionsAndInsertSyncs();
   // Map "band" to thread identifiers using as many blockSizes values as outer
-  // coincident dimensions, unroll band members that execute at most "unroll"
-  // instances and return the number of mapped thread identifiers.
+  // coincident dimensions (plus reduction dimension, if any), and
+  // return the number of mapped thread identifiers.
   size_t mapToThreads(detail::ScheduleTree* band);
   // Map innermost bands to thread identifiers and
   // return the number of mapped thread identifiers.

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -102,10 +102,10 @@ class MappedScop {
   }
 
   // Given that "nMapped" identifiers of type "MappingTypeId" have already
-  // been mapped, map the remaining ones (up to "nToMap") to zero
+  // been mapped, map the remaining ones to zero
   // for all statement instances.
   template <typename MappingTypeId>
-  void mapRemaining(detail::ScheduleTree* tree, size_t nMapped, size_t nToMap);
+  void mapRemaining(detail::ScheduleTree* tree, size_t nMapped);
 
   // Fix the values of the specified parameters in the context
   // to the corresponding specified values.

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -115,8 +115,7 @@ void mapCopiesToThreads(MappedScop& mscop, bool unroll) {
           mscop.numThreads.view[t]);
       ++t;
     }
-    mscop.mapRemaining<mapping::ThreadId>(
-        bandNode, t, mscop.numThreads.view.size());
+    mscop.mapRemaining<mapping::ThreadId>(bandNode, t);
 
     // Unroll if requested.
     if (unroll) {

--- a/tc/core/polyhedral/memory_promotion.cc
+++ b/tc/core/polyhedral/memory_promotion.cc
@@ -469,20 +469,15 @@ ScheduleTree* insertCopiesUnder(
       isl::set::universe(promotionSpace.domain().unwrap().domain());
   auto arrayId =
       promotionSpace.domain().unwrap().get_tuple_id(isl::dim_type::out);
-  auto approximatedRead =
-      isl::map(
-          scheduleUniverse,
-          group.approximateFootprint().set_tuple_id(arrayId).intersect(
-              tensorElements))
-          .wrap();
-  approximatedRead = isl::map(approximatedRead, promotedFootprint).wrap();
+  auto approximatedRead = scheduleUniverse.product(
+      group.approximateFootprint().set_tuple_id(arrayId).intersect(
+          tensorElements));
+  approximatedRead = approximatedRead.product(promotedFootprint);
   auto readExtension = extension.intersect_range(approximatedRead)
                            .set_tuple_id(isl::dim_type::out, readId);
   auto writtenElements =
-      isl::map(
-          group.scopedWrites().intersect_range(tensorElements).wrap(),
-          promotedFootprint)
-          .wrap();
+      group.scopedWrites().intersect_range(tensorElements).wrap();
+  writtenElements = writtenElements.product(promotedFootprint);
   auto writeExtension = extension.intersect_range(writtenElements)
                             .set_tuple_id(isl::dim_type::out, writeId);
 

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -208,6 +208,14 @@ std::unique_ptr<ScheduleTree> ScheduleTree::makeBand(
   return res;
 }
 
+ScheduleTreeUPtr ScheduleTree::makeEmptyBand(const ScheduleTree* root) {
+  auto domain = root->elemAs<ScheduleTreeElemDomain>();
+  CHECK(domain);
+  auto space = domain->domain_.get_space().set_from_params();
+  auto zero = isl::multi_union_pw_aff::zero(space);
+  return ScheduleTree::makeBand(zero);
+}
+
 std::unique_ptr<ScheduleTree> ScheduleTree::makeDomain(
     isl::union_set domain,
     std::vector<ScheduleTreeUPtr>&& children) {

--- a/tc/core/polyhedral/schedule_tree.h
+++ b/tc/core/polyhedral/schedule_tree.h
@@ -285,6 +285,9 @@ struct ScheduleTree {
       isl::multi_union_pw_aff mupa,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
+  // Return a zero-dimensional band for use in a tree with the given root.
+  static ScheduleTreeUPtr makeEmptyBand(const ScheduleTree* root);
+
   static ScheduleTreeUPtr makeDomain(
       isl::union_set domain,
       std::vector<ScheduleTreeUPtr>&& children = {});

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -488,11 +488,7 @@ detail::ScheduleTree* obtainOuterBand(detail::ScheduleTree* root) {
       continue;
     }
 
-    auto domain = root->elemAs<ScheduleTreeElemDomain>();
-    CHECK(domain);
-    auto space = domain->domain_.get_space().set_from_params();
-    auto zero = isl::multi_union_pw_aff::zero(space);
-    auto band = ScheduleTree::makeBand(zero);
+    auto band = ScheduleTree::makeEmptyBand(root);
     if (n == 0) {
       return setPermutable(insertNodeBelow(tree, std::move(band)));
     } else {


### PR DESCRIPTION
Some of these clean-ups prepare for getting rid of `ThreadIdxXScheduleDepthState`,
but they should also be useful independently.