### PR TITLE
replace ThreadIdxXScheduleDepthState by thread specific markers

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -705,8 +705,7 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
 
   // 8. Promote to registers below the loops mapped to threads.
   if (cudaOptions.proto().use_private_memory()) {
-    promoteToRegistersBelowThreads(
-        mappedScop->scop(), mappedScop->threadIdxXScheduleDepthState, -1ull);
+    promoteToRegistersBelowThreads(mappedScop->scop(), -1ull);
   }
 
   // 9. Insert mapping context

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -637,7 +637,7 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
     auto child = outerBand->child({0});
     size_t numMappedInnerThreads =
         mappedScop->mapInnermostBandsToThreads(child);
-    mappedScop->mapRemaining<mapping::ThreadId>(child, numMappedInnerThreads);
+    fixThreadsBelow(*mappedScop, outerBand, numMappedInnerThreads);
     LOG_IF(INFO, FLAGS_debug_tc_mapper)
         << "After mapping to threads:" << std::endl
         << *mappedScop->schedule();

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -124,14 +124,6 @@ void MappedScop::mapRemaining(detail::ScheduleTree* tree, size_t nMapped) {
   auto filter = makeFixRemainingZeroFilter(domain, ids);
   auto mapping = detail::ScheduleTree::makeMappingFilter(filter, ids);
   insertNodeAbove(root, tree, std::move(mapping));
-
-  for (size_t i = nMapped; i < nToMap; ++i) {
-    if (MappingTypeId::makeId(i) == mapping::ThreadId::x()) {
-      threadIdxXScheduleDepthState.emplace_back(std::make_pair(
-          activeDomainPoints(schedule(), tree),
-          tree->scheduleDepth(schedule())));
-    }
-  }
 }
 
 // Uses as many blockSizes elements as outer coincident dimensions in the
@@ -374,11 +366,6 @@ size_t MappedScop::mapToThreads(detail::ScheduleTree* band) {
   for (size_t i = 0; i < nMappedThreads; ++i) {
     auto id = mapping::ThreadId::makeId(i);
     auto dim = nMappedThreads - 1 - i;
-    if (id == mapping::ThreadId::x()) {
-      threadIdxXScheduleDepthState.emplace_back(std::make_pair(
-          activeDomainPoints(schedule(), band),
-          band->scheduleDepth(schedule()) + dim));
-    }
     band = map(band, dim, id);
   }
   mapRemaining<mapping::ThreadId>(band, nMappedThreads);

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -381,12 +381,13 @@ size_t MappedScop::mapToThreads(detail::ScheduleTree* band) {
     }
     band = map(band, dim, id);
   }
+  mapRemaining<mapping::ThreadId>(band, nMappedThreads);
 
   if (isReduction) {
     splitOutReductionAndInsertSyncs(band, nMappedThreads - 1);
   }
 
-  return nMappedThreads;
+  return numThreads.view.size();
 }
 
 namespace {
@@ -475,9 +476,8 @@ size_t MappedScop::mapInnermostBandsToThreads(detail::ScheduleTree* st) {
       // because we cannot map parent bands anyway.
       auto nMapped = mapToThreads(st);
       if (nMapped > 0) {
-        mapRemaining<mapping::ThreadId>(st, nMapped);
         markUnroll(scop_->scheduleRoot(), st, unroll);
-        return numThreads.view.size();
+        return nMapped;
       }
     } else if (anyNonCoincidentMember(band)) {
       // If children were mapped to threads, and this band has a non-coincident

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -702,7 +702,6 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
 
       promoteGreedilyAtDepth(
           *mappedScop,
-          mappedScop->threadIdxXScheduleDepthState,
           std::min(band->nOuterCoincident(), mappedScop->numBlocks.view.size()),
           sharedMemorySize,
           cudaOptions.proto().unroll_copy_shared() &&

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -341,6 +341,10 @@ size_t MappedScop::mapToThreads(detail::ScheduleTree* band) {
   auto nMappedThreads =
       std::min(numThreads.view.size(), static_cast<size_t>(nCanMap));
 
+  if (nCanMap < bandNode->nMember()) {
+    bandSplit(scop_->scheduleRoot(), band, nCanMap);
+  }
+
   CHECK_GT(nMappedThreads, 0) << "not mapping to threads";
   CHECK_LE(nMappedThreads, 3) << "mapping to too many threads";
 

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -178,13 +178,6 @@ class MappedScop {
   const ::tc::Block numThreads;
   const uint64_t unroll;
 
-  // The schedule depth that was mapped to Thread::x for specific parts of the
-  // domain.
-  // XXX: this is a partially redundant state as this information can
-  // potentially be extracted from the schedule tree; however, until we get a
-  // first-class MappingNode, it requires some dirty hacks.
-  ThreadIdxXScheduleDepthState threadIdxXScheduleDepthState;
-
  private:
   // Information about a detected reduction that can potentially
   // be mapped to a library call.

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -162,6 +162,8 @@ class MappedScop {
   // coincident dimensions (plus reduction dimension, if any),
   // insert synchronization in case of a reduction, and
   // return the number of mapped thread identifiers.
+  // A marker is added to mark the part of the tree that is thread specific
+  // (right underneath the innermost band member mapped to a thread identifier).
   size_t mapToThreads(detail::ScheduleTree* band);
   // Map innermost bands to thread identifiers,
   // inserting synchronization in case of a reduction, and

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -65,6 +65,10 @@ void mapCopiesToThreads(MappedScop& mscop, bool unroll) {
       throw promotion::PromotionLogicError("no copy band");
     }
 
+    auto ctx = node->ctx_;
+    insertNodeBelow(
+        bandNode, detail::ScheduleTree::makeThreadSpecificMarker(ctx));
+
     // Check that we are not mapping to threads below other thread mappings.
     std::unordered_set<mapping::ThreadId, mapping::ThreadId::Hash> usedThreads;
     for (auto n : node->ancestors(root)) {

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -42,9 +42,6 @@ void promoteGreedilyAtDepth(
     std::size_t sharedMemorySize,
     bool unrollCopies);
 
-void promoteToRegistersBelowThreads(
-    Scop& scop,
-    const ThreadIdxXScheduleDepthState& threadIdxXScheduleDepthState,
-    std::size_t nRegisters);
+void promoteToRegistersBelowThreads(Scop& scop, std::size_t nRegisters);
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -37,7 +37,6 @@ class Scop;
 // memory is accessed in a coalesced way.
 void promoteGreedilyAtDepth(
     MappedScop& scop,
-    const ThreadIdxXScheduleDepthState& threadIdxXScheduleDepthState,
     std::size_t depth,
     std::size_t sharedMemorySize,
     bool unrollCopies);

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -22,9 +22,6 @@
 
 namespace tc {
 namespace polyhedral {
-using ThreadIdxXScheduleDepthState =
-    std::vector<std::pair<isl::union_set, size_t>>;
-
 class MappedScop;
 class Scop;
 

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -51,6 +51,7 @@ constexpr std::initializer_list<detail::ScheduleTreeType>
 
 namespace {
 
+isl::schedule_node insertChild(isl::schedule_node node, const ScheduleTree* st);
 isl::schedule_node extendChild(isl::schedule_node node, const ScheduleTree* st);
 
 /*
@@ -210,17 +211,27 @@ isl::schedule_node insert(isl::schedule_node node, const ScheduleTree* st) {
 
 /*
  * Recursively add nodes corresponding to the descendants of "st"
- * underneath "node".
+ * at "node".
  * If "st" does not have any children, then no descendants need to be added.
  */
-isl::schedule_node extendChild(
+isl::schedule_node insertChild(
     isl::schedule_node node,
     const ScheduleTree* st) {
   if (st->numChildren() == 0) {
     return node;
   }
 
-  return insert(node.child(0), st->child({0})).parent();
+  return insert(node, st->child({0}));
+}
+
+/*
+ * Recursively add nodes corresponding to the descendants of "st"
+ * underneath "node".
+ */
+isl::schedule_node extendChild(
+    isl::schedule_node node,
+    const ScheduleTree* st) {
+  return insertChild(node.child(0), st).parent();
 }
 } // namespace
 

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -203,6 +203,8 @@ isl::schedule_node insert(isl::schedule_node node, const ScheduleTree* st) {
     return insertBranch(node, st);
   } else if (st->elemAs<ScheduleTreeElemExtension>()) {
     return insertExtension(node, st);
+  } else if (st->elemAs<ScheduleTreeElemThreadSpecificMarker>()) {
+    return insertChild(node, st);
   } else {
     LOG(FATAL) << "NYI: insert type: " << *st;
   }
@@ -329,6 +331,7 @@ isl::space definitionParamSpace(const ScheduleTree* node) {
     case detail::ScheduleTreeType::None:
     case detail::ScheduleTreeType::Set:
     case detail::ScheduleTreeType::Sequence:
+    case detail::ScheduleTreeType::ThreadSpecificMarker:
       break;
   }
   return space;

--- a/tc/core/polyhedral/schedule_print.cc
+++ b/tc/core/polyhedral/schedule_print.cc
@@ -127,6 +127,8 @@ std::ostream& operator<<(std::ostream& os, detail::ScheduleTreeType nt) {
     os << "sequence";
   } else if (nt == detail::ScheduleTreeType::Set) {
     os << "seq";
+  } else if (nt == detail::ScheduleTreeType::ThreadSpecificMarker) {
+    os << "thread_specific";
   } else {
     LOG(FATAL) << "NYI: print type: " << static_cast<int>(nt);
   }
@@ -221,6 +223,13 @@ std::ostream& ScheduleTreeElemSequence::write(std::ostream& os) const {
 std::ostream& ScheduleTreeElemSet::write(std::ostream& os) const {
   WS w;
   os << w.tab() << "set()";
+  return os;
+}
+
+std::ostream& ScheduleTreeElemThreadSpecificMarker::write(
+    std::ostream& os) const {
+  WS w;
+  os << w.tab() << "thread_specific()";
   return os;
 }
 

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -264,6 +264,17 @@ std::unique_ptr<ScheduleTree> ScheduleTree::makeExtension(
   return res;
 }
 
+std::unique_ptr<ScheduleTree> ScheduleTree::makeThreadSpecificMarker(
+    isl::ctx ctx,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  ScheduleTreeUPtr res(new ScheduleTree(ctx));
+  res->elem_ = std::unique_ptr<ScheduleTreeElemThreadSpecificMarker>(
+      new ScheduleTreeElemThreadSpecificMarker());
+  res->type_ = detail::ScheduleTreeType::ThreadSpecificMarker;
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //                        Collector member functions
 ////////////////////////////////////////////////////////////////////////////////

--- a/tc/core/polyhedral/schedule_tree.h
+++ b/tc/core/polyhedral/schedule_tree.h
@@ -311,6 +311,10 @@ struct ScheduleTree {
       isl::union_map extension,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
+  static ScheduleTreeUPtr makeThreadSpecificMarker(
+      isl::ctx ctx,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+
   template <typename... Args>
   static ScheduleTreeUPtr makeBand(
       isl::multi_union_pw_aff mupa,

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -113,6 +113,7 @@ std::unique_ptr<ScheduleTreeElemBase> ScheduleTreeElemBase::make(
   ELEM_MAKE_CASE(ScheduleTreeElemMappingFilter)
   ELEM_MAKE_CASE(ScheduleTreeElemSequence)
   ELEM_MAKE_CASE(ScheduleTreeElemSet)
+  ELEM_MAKE_CASE(ScheduleTreeElemThreadSpecificMarker)
 
 #undef ELEM_MAKE_CASE
 

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -38,6 +38,7 @@ enum class ScheduleTreeType {
   Sequence,
   Set,
   MappingFilter,
+  ThreadSpecificMarker,
   Any,
 };
 
@@ -277,6 +278,30 @@ struct ScheduleTreeElemBand : public ScheduleTreeElemBase {
   // For each member, should the corresponding loop in the generated code
   // be (fully) unrolled?
   std::vector<bool> unroll_;
+};
+
+/*
+ * A node of type ThreadSpecificMarker marks part of a schedule tree
+ * that is specific to a thread.  That is, the marker appears right
+ * underneath the innermost band member mapped to threads.
+ */
+struct ScheduleTreeElemThreadSpecificMarker : public ScheduleTreeElemBase {
+  static constexpr std::initializer_list<detail::ScheduleTreeType>
+      NodeDerivedTypes{detail::ScheduleTreeType::None};
+  static constexpr detail::ScheduleTreeType NodeType =
+      detail::ScheduleTreeType::ThreadSpecificMarker;
+  explicit ScheduleTreeElemThreadSpecificMarker() {}
+  virtual ~ScheduleTreeElemThreadSpecificMarker() override {}
+  bool operator==(const ScheduleTreeElemThreadSpecificMarker& other) const {
+    return true;
+  }
+  bool operator!=(const ScheduleTreeElemThreadSpecificMarker& other) const {
+    return !(*this == other);
+  }
+  virtual std::ostream& write(std::ostream& os) const override;
+  virtual detail::ScheduleTreeType type() const override {
+    return NodeType;
+  }
 };
 
 bool elemEquals(

--- a/tc/external/detail/islpp.h
+++ b/tc/external/detail/islpp.h
@@ -395,21 +395,6 @@ auto end(L& list) -> ListIter<decltype(list.get(0)), L> {
 using detail::begin;
 using detail::end;
 
-template <typename T>
-isl::val getParamValIfFixed(T t, int pos) {
-  auto val = isl::val::nan(t.get_ctx());
-  for (auto set : isl::UnionAsVector<T>(t)) {
-    auto currentVal = set.plain_get_val_if_fixed(isl::dim_type::param, pos);
-    if (currentVal.is_nan()) {
-      return currentVal;
-    }
-    if (!val.is_nan() && val != currentVal) {
-      return isl::val::nan(t.get_ctx());
-    }
-    val = currentVal;
-  }
-  return val;
-}
 } // namespace isl
 
 namespace isl {

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -387,12 +387,7 @@ def fun(float(N, M) A) -> (B, C) {
       size_t maxSharedMemory) {
     auto mscop = prepareScop(
         tc, {{"N", problemSize1}, {"M", problemSize2}}, {tileSize1, tileSize2});
-    promoteGreedilyAtDepth(
-        *mscop,
-        mscop->threadIdxXScheduleDepthState,
-        depth,
-        maxSharedMemory,
-        false);
+    promoteGreedilyAtDepth(*mscop, depth, maxSharedMemory, false);
     return mscop;
   }
 };

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -204,8 +204,8 @@ TEST_F(Sum4D, CodeInnerBand) {
       "C[16 * b0 + c4][16 * b1 + c5][c2 + c6][t0 + c3] = _C_0[0][0][0][0];";
   auto sync = "__syncthreads()";
 
-  auto code =
-      emitCode({256, 128, 192, 224}, {16, 16, 16, 16}, {0, 0, 0, 0, 0, 0, 0});
+  auto code = emitCode(
+      {256, 128, 192, 224}, {16, 16, 16, 16}, {0, 0, 0, 0, 0, 0, 0, 0});
   // Order of copies may be arbitrary, but syncs must be inserted before and
   // after
   for (auto d : declarations) {


### PR DESCRIPTION
ThreadIdxXScheduleDepthState maintains duplicate state and
does so in an inconsistent way.  In particular, when at least
one member is mapped to a thread identifier, it holds
the depth of the member mapped to the x thread identifier
(which is one less that the schedule depth of the newly introduced marker),
but if no member is mapped, then it points to the depth
of where the marker is introduced.
