### PR TITLE
Activate conda env which has TC build for test time

### DIFF
--- a/.jenkins/run_test.sh
+++ b/.jenkins/run_test.sh
@@ -10,6 +10,7 @@ source /etc/lsb-release
 
 if [[ $(conda --version | wc -c) -ne 0 ]]; then
   echo "Running TC PyTorch tests"
+  source activate tc-env
   ./test_python/run_test.sh
 else
   # TODO: modify 2LUT tests from example_MLP_model and enable on CI


### PR DESCRIPTION
we have dedicated 4 gpu machines finally configured and running now. In attempt to revive jenkins CI, found this fix. The reason is in commit message. 

partially helps #338 