### PR TITLE
Reduce unrolling factors during tuning

### DIFF
--- a/tc/autotuner/genetic_tuning_harness.cc
+++ b/tc/autotuner/genetic_tuning_harness.cc
@@ -172,8 +172,7 @@ void GeneticTunerHarness::setupTuningParameters() {
   configuration.blockParams.setRange(range, "b");
   configuration.gridParams.setRange(range, "g");
 
-  configuration.unrollFactor =
-      RangeParameter({1, 2, 4, 8, 16, 32, 64, 128, 256}, "unroll");
+  configuration.unrollFactor = RangeParameter({1, 2, 4, 8, 16, 32}, "unroll");
 }
 
 CudaMappingOptions GeneticTunerHarness::makeOptions(

--- a/tc/autotuner/genetic_tuning_harness.cc
+++ b/tc/autotuner/genetic_tuning_harness.cc
@@ -110,17 +110,6 @@ void GeneticTunerHarness::stopAfterCurrentGeneration() {
 
 namespace {
 
-std::vector<size_t> filterHigherThan(
-    const std::vector<size_t>& v,
-    size_t limit) {
-  std::vector<size_t> newV;
-  std::copy_if(
-      v.begin(), v.end(), std::back_inserter(newV), [limit](size_t val) {
-        return val <= limit;
-      });
-  return newV;
-}
-
 void removeDuplicates(std::vector<size_t>& v) {
   std::sort(v.begin(), v.end());
   v.erase(std::unique(v.begin(), v.end()), v.end());
@@ -159,7 +148,6 @@ size_t largestDim(const std::vector<const DLTensor*>& inputs) {
 void GeneticTunerHarness::setupTuningParameters() {
   CHECK_GT(kInputs_.size(), 0u);
   auto range = inputDivisorsAndPowers2(kInputs_.begin()->second);
-  auto rangeUpTo64 = filterHigherThan(range, 64);
 
   // 0 is a valid tiling annotation and signals no tiling of that dimension
   // 0 is not a valid block / grid annotation


### PR DESCRIPTION
For some reason rangeUpTo64 is unsed and unrolling factors are powers of 2 up to 256.
I can correlate that with bad compilation times locally.
Let's use rangeUpTo64 instead which can full unroll by divisors of problem sizes and avoids the 128 and 256 cases. Tested locally, looks good to me.