### PR TITLE
insertCopiesUnder: drop iteration over tensor dimensions of size 1 up front

### DIFF
--- a/tc/core/polyhedral/cuda/codegen.cc
+++ b/tc/core/polyhedral/cuda/codegen.cc
@@ -592,8 +592,7 @@ void emitMappedTensorAccess(
     return;
   }
 
-  auto tensorId =
-      context.scop().promotedDecls().at(promotionInfo.groupId).tensorId;
+  auto tensorId = context.scop().promotedDecl(promotionInfo.groupId).tensorId;
 
   // Here and below in comments: D = domain, O = original tensor, P = promoted
   // tensor, S = partial schedule, A = AST loops;

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -112,12 +112,7 @@ void mapCopiesToThreads(MappedScop& mscop, bool unroll) {
           filterSets.begin(), filterSets.end(), [&mscop, i](isl::set s) {
             auto groupId =
                 s.get_space().unwrap().get_tuple_id(isl::dim_type::out);
-            if (mscop.scop().promotedDecls().count(groupId) != 1) {
-              std::stringstream ss;
-              ss << "promoted group " << groupId << " has no declaration";
-              throw promotion::PromotionLogicError(ss.str());
-            }
-            auto decl = mscop.scop().promotedDecls().at(groupId);
+            auto decl = mscop.scop().promotedDecl(groupId);
             return static_cast<size_t>(i) >= decl.sizes.size() ||
                 decl.sizes[i] == 1;
           });

--- a/tc/core/polyhedral/memory_promotion.cc
+++ b/tc/core/polyhedral/memory_promotion.cc
@@ -422,6 +422,30 @@ isl::set tensorElementsSet(const Scop& scop, isl::id tensorId) {
   }
   return tensorElements;
 }
+
+/*
+ * "schedule" iterates over the elements of the tensor described by "decl".
+ * Remove the schedule dimensions that correspond to tensor dimensions
+ * of size 1.
+ * Note that this function drops the name of the target space of "schedule",
+ * but this space is irrelevant for the caller.
+ */
+isl::multi_aff dropDummyTensorDimensions(
+    isl::multi_aff schedule,
+    const Scop::PromotedDecl& decl) {
+  auto list = schedule.get_aff_list();
+  auto space = schedule.get_space().domain();
+
+  auto n = list.n();
+  for (int i = n - 1; i >= 0; --i) {
+    if (decl.sizes[i] == 1) {
+      list = list.drop(i, 1);
+    }
+  }
+
+  space = space.from_domain().add_dims(isl::dim_type::out, list.n());
+  return isl::multi_aff(space, list);
+}
 } // namespace
 
 ScheduleTree* insertCopiesUnder(
@@ -449,6 +473,9 @@ ScheduleTree* insertCopiesUnder(
       isl::multi_aff::identity(promotionSpace.range().map_from_set());
   identityCopySchedule =
       identityCopySchedule.pullback(isl::multi_aff::range_map(promotionSpace));
+  // Only iterate over significant tensor dimensions.
+  auto decl = scop.promotedDecl(groupId);
+  identityCopySchedule = dropDummyTensorDimensions(identityCopySchedule, decl);
   auto readSchedule = isl::multi_union_pw_aff(
       identityCopySchedule.set_tuple_id(isl::dim_type::in, readId));
   auto writeSchedule = isl::multi_union_pw_aff(

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -201,12 +201,12 @@ void Scop::promoteGroup(
   }
 
   auto groupId = nextGroupIdForTensor(tensorId);
-  insertCopiesUnder(*this, tree, *gr, tensorId, groupId);
   auto sizes = gr->approximationSizes();
   if (sizes.size() > 0 && forceLastExtentOdd && (sizes.back() % 2) == 0) {
     sizes.back() += 1;
   }
   promotedDecls_[groupId] = PromotedDecl{tensorId, sizes, kind};
+  insertCopiesUnder(*this, tree, *gr, tensorId, groupId);
 
   // FIXME: we can now store a unique pointer...
   auto group = std::shared_ptr<TensorReferenceGroup>(std::move(gr));

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -311,6 +312,17 @@ struct Scop {
   const std::unordered_map<isl::id, PromotedDecl, isl::IslIdIslHash>&
   promotedDecls() const {
     return promotedDecls_;
+  }
+
+  // Return the promoted declaration information associated to
+  // the given identifier of a promoted tensor reference group.
+  const PromotedDecl& promotedDecl(isl::id groupId) const {
+    if (promotedDecls().count(groupId) != 1) {
+      std::stringstream ss;
+      ss << "promoted group " << groupId << " has no declaration";
+      throw std::logic_error(ss.str());
+    }
+    return promotedDecls().at(groupId);
   }
 
   const std::vector<std::pair<isl::union_set, PromotionInfo>>&


### PR DESCRIPTION
When mapping the code for copying arrays to/from shared memory to threads,
the band members of the copying schedule that iterate over
a tensor dimension of size 1 do not get mapped to a thread identifier.
This was handled by code in mapCopiesToThreads that is relatively
complicated and that needs to take into account situations
that may never arise in practice.

It is much simpler to make sure that those band members
do not even appear in the copying schedule, by removing
them while the copying schedule is being constructed in
insertCopiesUnder.