### PR TITLE
[C++ API] Step 2: add the new compiler files

### DIFF
--- a/tc/core/compiler-inl.h
+++ b/tc/core/compiler-inl.h
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/core/compiler.h"
+
+#include <sstream>
+#include <string>
+
+#include "tc/core/flags.h"
+#include "tc/core/halide_utils.h"
+#include "tc/core/tensor.h"
+#include "tc/lang/canonicalize.h"
+
+namespace tc {
+namespace detail {
+void checkInputsCompliant(
+    const tc2halide::HalideComponents& halideComponents,
+    const std::vector<const DLConstTensor*>& inputsInfo);
+} // namespace detail
+
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<const DLConstTensor*>& inputs,
+    /* TODO: in the future also pass outputs for stride and alignment info */
+    const typename Backend::MappingOptionsType& options) {
+  auto parsedTcs = detail::parse(tc);
+  CHECK_EQ(parsedTcs.count(entryPoint), 1u)
+      << "attempting to access undefined function " << entryPoint;
+  return compile<Backend>(parsedTcs[entryPoint], inputs, options);
+}
+
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+    lang::TreeRef tcDefinition,
+    const std::vector<const DLConstTensor*>& inputs,
+    /* TODO: in the future also pass outputs for stride and alignment info */
+    const typename Backend::MappingOptionsType& options) {
+  using CompilationResultType = typename Backend::CompilationResultType;
+
+  auto inputsInfo = makeTensorInfoVector(inputs);
+  auto outputsInfo = detail::inferOutputTensorInfo(tcDefinition, inputs);
+  auto halideComponents =
+      tc2halide::translate(isl::with_exceptions::globalIslCtx(), tcDefinition);
+  detail::checkInputsCompliant(halideComponents, inputs);
+
+  auto tcName = lang::Def(tcDefinition).name().name();
+  CompilationResultType compilationResult = Backend::compileWithTcMapper(
+      tcName,
+      halideComponents,
+      inputs,
+      /* TODO outputs, */
+      options);
+  return std::unique_ptr<typename Backend::ExecutorType>(
+      new typename Backend::ExecutorType(
+          inputsInfo, outputsInfo, halideComponents, compilationResult));
+}
+} // namespace tc

--- a/tc/core/compiler.cc
+++ b/tc/core/compiler.cc
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/core/compiler.h"
+
+#include <sstream>
+#include <string>
+
+#include "tc/core/flags.h"
+#include "tc/core/halide_utils.h"
+#include "tc/core/tensor.h"
+#include "tc/lang/canonicalize.h"
+
+namespace tc {
+std::vector<TensorInfo> inferOutputTensorInfo(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<const DLConstTensor*> inputs) {
+  auto parsedTcs = detail::parse(tc);
+  CHECK_EQ(1, parsedTcs.count(entryPoint))
+      << "attempting to access undefined function " << entryPoint;
+  return tc::detail::inferOutputTensorInfo(parsedTcs[entryPoint], inputs);
+}
+
+namespace detail {
+void checkInputsCompliant(
+    const tc2halide::HalideComponents& halideComponents,
+    const std::vector<const DLConstTensor*>& inputsInfo) {
+  if (inputsInfo.size() != halideComponents.inputs.size()) {
+    throw lang::ErrorReport(halideComponents.getDef())
+        << "expected " << halideComponents.inputs.size() << " inputs but found "
+        << inputsInfo.size();
+  }
+  for (size_t i = 0; i < inputsInfo.size(); ++i) {
+    auto dlType = inputsInfo[i]->dtype;
+    auto hType = halideComponents.inputs[i].type();
+    // we have three type representations here: (1) halide Type (2) DLTensor
+    // type, and (3) the token representing the type in the frontend (e.g.
+    // TK_FLOAT) we need to translate to (3) to report user facing errors
+    auto dlLangType =
+        lang::TypeInfo(lang::TypeInfo::Code(dlType.code), dlType.bits)
+            .toScalarToken();
+    auto hLangType =
+        lang::TypeInfo(lang::TypeInfo::Code(hType.code()), hType.bits())
+            .toScalarToken();
+    if (dlLangType != hLangType) {
+      throw lang::ErrorReport(halideComponents.getDef().params()[i])
+          << "expected type " << lang::kindToString(hLangType) << " but found "
+          << lang::kindToString(dlLangType);
+    }
+    int hdim = halideComponents.inputs[i].dimensions();
+    int dldim = inputsInfo[i]->ndim;
+    if (dldim != hdim) {
+      throw lang::ErrorReport(halideComponents.getDef().params()[i])
+          << "expected a tensor with " << hdim << " dimensions but found "
+          << dldim << " dimensions.";
+    }
+  }
+}
+
+std::vector<TensorInfo> inferOutputTensorInfo(
+    lang::TreeRef tcDefinition,
+    const std::vector<const DLConstTensor*> inputs) {
+  return tc::inferOutputTensorInfo(
+      tc2halide::translate(isl::with_exceptions::globalIslCtx(), tcDefinition),
+      inputs);
+}
+
+std::map<std::string, lang::TreeRef> parse(const std::string& tc) {
+  lang::Parser parser(tc);
+  std::map<std::string, lang::TreeRef> parsed;
+  while (parser.L.cur().kind != lang::TK_EOF) {
+    auto t = parser.parseFunction();
+    auto name = lang::Def(t).name().name();
+    parsed.emplace(std::make_pair(name, t));
+  }
+  return parsed;
+}
+} // namespace detail
+} // namespace tc

--- a/tc/core/compiler.h
+++ b/tc/core/compiler.h
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "tc/core/mapping_options.h"
+#include "tc/core/tensor.h"
+#include "tc/lang/tree.h"
+
+/**
+ * This provides a simple functional-style C++ API with multi-backend
+ * capabilities to:
+ *   1. compile a TC function and return an Executor for the specified Backend
+ *      on which the run method can be called;
+ *   2. infer actual tmp/output tensor shapes given input tensor shapes;
+ *   3. parse a TC definition and retrieve the map of TC function to parsed TC
+ *      trees.
+ *
+ * Compilation is backed by a compilation cache, its correspondance is:
+ * 1 TcExecutor <-> 1 compiled tuple<TC function, input shapes, MappingOptions>
+ *
+ * The compile function is templated by the Backend type.
+ * For each backend, the specific Backend type lives in
+ *   backendname/backendname_backend.h and declares all the required dependent
+ *   **derived** types.
+ * For example:
+ *   CudaBackend is declared in core/cuda/cuda_backend.h
+ *
+ * struct CudaBackend {
+ *   using ExecutorType = CudaTcExecutor;
+ *   using MappingOptionsType = CudaMappingOptions;
+ *   using CompilationResultType = CudaCompilationResult;
+ *   using RTCFunctionType = CudaRTCFunction;
+ * };
+ *
+ * Sketching usage resembles:
+ *   std::string someTc = "...";
+ *   auto pExecutor = tc::compile<CudaBackend>(
+ *     someTc, tcFunctionName, inputs, mappingOptions);
+ *   auto profilingInfo = pExecutor->profile(handle, inputs, outputs, true);
+ *   // alternatively:
+ *   // auto kernelTiming = pExecutor->uncheckedRun(inputs, outputs, true);
+ */
+namespace tc {
+/// Given a TC string containing multiple functions and a TC function name
+/// "entryPoint", this function compiles a new TcExecutor for the specified
+/// Backend. For now, contiguous output sizes are inferred given input sizes.
+/// If you need another kernel for another entryPoint or other inputs or
+//  other options then just compile another TcExecutor; because atm we fully
+/// JIT specialize on all sizes.
+/// \returns a new TcExecutor on which the run method can be called to run
+/// entryPoint
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<const DLConstTensor*>& inputs,
+    /* TODO: in the future also pass outputs for stride and alignment info */
+    const typename Backend::MappingOptionsType& options);
+
+/// Given a TC representation as a TC + TC function name entryPoint and a list
+/// of input tensors that match the definition in the TC function definition
+/// (in positional order), this generates the output TensorInfo resulting from
+/// running inference.
+/// The typical flow is to infer output sizes, allocate/resize them within
+/// you favorite ML framework/tensor library and then call compile and run.
+/// \returns a vector of TensorInfo which can be used for allocating and
+/// performing output shape validation.
+std::vector<TensorInfo> inferOutputTensorInfo(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<const DLConstTensor*> inputs);
+
+namespace detail {
+/// Given a TC representation, this parses the TC functions into a map of
+/// TreeRef indexed by TC function names.
+/// \returns an ordered map of TC function name to parsed TC tree
+std::map<std::string, lang::TreeRef> parse(const std::string& tc);
+
+/// Given a TC representation as a TreeRef, this function compiles a new
+/// TcExecutor for the specified Backend.
+/// For now, contiguous output sizes are inferred given input sizes.
+/// If you need another kernel for another TC or other inputs or options then
+/// just compile another TcExecutor; because atm we fully JIT specialize on all
+/// sizes.
+/// \returns a new TcExecutor on which the run method can be called
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+    lang::TreeRef tcDefinition,
+    const std::vector<const DLConstTensor*>& inputs,
+    /* TODO: in the future also pass outputs for stride and alignment info */
+    const typename Backend::MappingOptionsType& options);
+
+/// Given a TC representation as a TreeRef and a list of input tensors that
+/// match the definition in the TC function definition (in positional order),
+/// this generates the output TensorInfo resulting from running inference.
+/// The typical flow is to infer output sizes, allocate/resize them within
+/// you favorite ML framework/tensor library and then call compile and run.
+/// \returns a vector of TensorInfo which can be used for allocating and
+/// performing output shape validation.
+std::vector<TensorInfo> inferOutputTensorInfo(
+    lang::TreeRef tcDefinition,
+    const std::vector<const DLConstTensor*> inputs);
+} // namespace detail
+} // namespace tc
+
+#include "tc/core/compiler-inl.h"


### PR DESCRIPTION
This PR adds the files implementing the new compiler API #322. This allows
retiring the ExecutionEngine #309 which has been a significant source of
unnecessary complexity.

More specifically, this implements a more functional-style API for
compilation. ```compile``` returns an owning pointer to a TcExecutor
on which ```run``` and ```uncheckedRun``` can be called.

This also implements support for ```parse``` and ```inferOutputTensorInfo```
as well as operations on the parsed ```TreeRef``` in the ```detail`` namespace.

Higher-level layers are responsible for caching compilation results.

As part of the bigger refactoring, these files are not yet activated
(or even compiled) therefore the changeset cannot be tested independently.
This new implementation will be switched in as part of the last commit of the
the global refactoring.