### PR TITLE
create a single block mapping filter and a single thread mapping filter per branch

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -106,6 +106,45 @@ template <>
 const CudaDim& mappingSize<mapping::ThreadId>(const MappedScop* mscop) {
   return mscop->numThreads;
 }
+
+// Map "pos"-th schedule dimension of the band node identified by "tree" to a
+// _new_ parameter identified by "id" and limited by 0 <= id < extent.  The
+// parameter must not be present in the space of partial schedule of "tree" and
+// extent must be non-zero.  The mapping corresponds to inserting a filter
+// node with condition 'dim % extent = id' where dim is "pos"-th
+// schedule dimension.
+//
+// Returns a pointer to the updated band (below the inserted filter)
+// for call chaining purposes.
+template <typename MappingIdType>
+detail::ScheduleTree* mapToParameterWithExtent(
+    detail::ScheduleTree* root,
+    detail::ScheduleTree* tree,
+    size_t pos,
+    MappingIdType id,
+    size_t extent) {
+  auto band = tree->elemAs<detail::ScheduleTreeElemBand>();
+  CHECK(band) << "expected a band, got " << *tree;
+  CHECK_GE(pos, 0u) << "dimension underflow";
+  CHECK_LT(pos, band->nMember()) << "dimension overflow";
+  CHECK_NE(extent, 0u) << "NYI: mapping to 0";
+
+  auto domain = activeDomainPoints(root, tree).universe();
+
+  // Introduce the "mapping" parameter after checking it is not already present
+  // in the schedule space.
+  CHECK(not band->mupa_.involves_param(id));
+
+  // Create mapping filter by equating the newly introduced
+  // parameter "id" to the "pos"-th schedule dimension modulo its extent.
+  auto upa =
+      band->mupa_.get_union_pw_aff(pos).mod_val(isl::val(tree->ctx_, extent));
+  upa = upa.sub(isl::union_pw_aff::param_on_domain(domain, id));
+  auto filter = upa.zero_union_set();
+  auto mapping =
+      detail::ScheduleTree::makeMappingFilter<MappingIdType>(filter, {id});
+  return insertNodeAbove(root, tree, std::move(mapping))->child({0});
+}
 } // namespace
 
 template <typename MappingTypeId>

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -126,6 +126,18 @@ void MappedScop::mapRemaining(detail::ScheduleTree* tree, size_t nMapped) {
   insertNodeAbove(root, tree, std::move(mapping));
 }
 
+detail::ScheduleTree* MappedScop::mapBlocksForward(
+    detail::ScheduleTree* band,
+    size_t nToMap) {
+  auto root = scop_->scheduleRoot();
+  for (size_t i = 0; i < nToMap; ++i) {
+    auto id = mapping::BlockId::makeId(i);
+    band = mapToParameterWithExtent(root, band, i, id, numBlocks.view[i]);
+  }
+  mapRemaining<mapping::BlockId>(band, nToMap);
+  return band;
+}
+
 // Uses as many blockSizes elements as outer coincident dimensions in the
 // outermost band
 void MappedScop::mapToBlocksAndScaleBand(
@@ -142,10 +154,7 @@ void MappedScop::mapToBlocksAndScaleBand(
   // and no more than block dimensions to be mapped
   nBlocksToMap = std::min(nBlocksToMap, numBlocks.view.size());
 
-  for (size_t i = 0; i < nBlocksToMap; ++i) {
-    band = map(band, i, mapping::BlockId::makeId(i));
-  }
-  mapRemaining<mapping::BlockId>(band, nBlocksToMap);
+  mapBlocksForward(band, nBlocksToMap);
   bandScale(band, tileSizes);
 }
 

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -93,14 +93,11 @@ class MappedScop {
   detail::ScheduleTree* mapBlocksForward(
       detail::ScheduleTree* band,
       size_t nToMap);
-  // Map a particular "pos"-th dimension in a _band_ node identified by "tree"
-  // to the thread dimension.  Ancestors or descendants of "tree" must
-  // not have a dimension already mapped to the same thread.
-  inline detail::ScheduleTree*
-  map(detail::ScheduleTree* tree, int pos, const mapping::ThreadId& id) {
-    return mapToParameterWithExtent(
-        scop_->scheduleRoot(), tree, pos, id, id.mappingSize(numThreads));
-  }
+  // Map the final band members of "band"
+  // to successive thread identifiers, with the last member mapped
+  // to thread identifier X.
+  // This function can only be called once in any branch of the tree.
+  detail::ScheduleTree* mapThreadsBackward(detail::ScheduleTree* band);
 
   // Given that "nMapped" identifiers of type "MappingTypeId" have already
   // been mapped, map the remaining ones to zero

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -87,14 +87,15 @@ class MappedScop {
       std::unique_ptr<Scop>&& scopUPtr,
       const CudaMappingOptions& mappingOptions);
 
+  // Map the initial (up to "nToMap") band members of "band"
+  // to successive block identifiers.
+  // This function can only be called once on the entire tree.
+  detail::ScheduleTree* mapBlocksForward(
+      detail::ScheduleTree* band,
+      size_t nToMap);
   // Map a particular "pos"-th dimension in a _band_ node identified by "tree"
-  // to the block or thread dimension.  Ancestors or descendants of "tree" must
-  // not have a dimension already mapped to the same block or thread.
-  inline detail::ScheduleTree*
-  map(detail::ScheduleTree* tree, int pos, const mapping::BlockId& id) {
-    return mapToParameterWithExtent(
-        scop_->scheduleRoot(), tree, pos, id, id.mappingSize(numBlocks));
-  }
+  // to the thread dimension.  Ancestors or descendants of "tree" must
+  // not have a dimension already mapped to the same thread.
   inline detail::ScheduleTree*
   map(detail::ScheduleTree* tree, int pos, const mapping::ThreadId& id) {
     return mapToParameterWithExtent(

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -99,12 +99,6 @@ class MappedScop {
   // This function can only be called once in any branch of the tree.
   detail::ScheduleTree* mapThreadsBackward(detail::ScheduleTree* band);
 
-  // Given that "nMapped" identifiers of type "MappingTypeId" have already
-  // been mapped, map the remaining ones to zero
-  // for all statement instances.
-  template <typename MappingTypeId>
-  void mapRemaining(detail::ScheduleTree* tree, size_t nMapped);
-
   // Fix the values of the specified parameters in the context
   // to the corresponding specified values.
   template <typename T>

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -134,6 +134,14 @@ class MappedScop {
   }
 
  private:
+  // Map the elements in "list" to successive blocks or thread identifiers,
+  // with the first element mapped to identifier X.
+  // Return a pointer to the updated node (below the inserted filter)
+  // for call chaining purposes.
+  template <typename MappingTypeId>
+  detail::ScheduleTree* map(
+      detail::ScheduleTree* tree,
+      isl::union_pw_aff_list list);
   // Map "band" to block identifiers and then scale
   // the band members by "tileSizes".
   void mapToBlocksAndScaleBand(

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -297,15 +297,6 @@ isl::union_set activeDomainPointsBelow(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node);
 
-////////////////////////////////////////////////////////////////////////////////
-// Experimental
-////////////////////////////////////////////////////////////////////////////////
-// Mapping filters are introduced one mapping dimension at a time.
-// This merges consecutive filters.
-detail::ScheduleTree* mergeConsecutiveMappingFilters(
-    detail::ScheduleTree* root,
-    detail::ScheduleTree* node);
-
 } // namespace polyhedral
 } // namespace tc
 

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -114,23 +114,6 @@ detail::ScheduleTree* bandScale(
     detail::ScheduleTree* tree,
     const std::vector<size_t>& scales);
 
-// Map "pos"-th schedule dimension of the band node identified by "tree" to a
-// _new_ parameter identified by "id" and limited by 0 <= id < extent.  The
-// parameter must not be present in the space of partial schedule of "tree" and
-// extent must be non-zero.  The mapping corresponds to inserting a filter
-// node with condition 'dim % extent = id' where dim is "pos"-th
-// schedule dimension.
-//
-// Returns a pointer to the updated band (below the inserted filter)
-// for call chaining purposes.
-template <typename MappingIdType>
-detail::ScheduleTree* mapToParameterWithExtent(
-    detail::ScheduleTree* root,
-    detail::ScheduleTree* tree,
-    size_t pos,
-    MappingIdType id,
-    size_t extent);
-
 // Update the top-level conext node by intersecting it with "context".  The
 // top-level context node must be located directly under the root of the tree.
 // If there is no such node, insert one with universe context first.

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -337,22 +337,6 @@ TEST_F(PolyhedralMapperTest, MergedContexts) {
   ASSERT_TRUE(std::string::npos != res.find(kExpectedMatmul_64_64_64)) << res;
 }
 
-TEST_F(PolyhedralMapperTest, FilterMerge) {
-  auto scop = PrepareAndJoinBands(makeMatmulTc());
-  auto schedule = scop->scheduleRoot();
-
-  // Unit test claims to use scop->globalParameterContext properly
-  auto context = scop->makeContext<int>({{"M", 64}, {"N", 64}, {"K", 64}});
-  auto& globalParameterContext =
-      const_cast<isl::set&>(scop->globalParameterContext);
-  globalParameterContext = globalParameterContext.intersect(context);
-  scop->domain() = scop->domain().intersect(globalParameterContext);
-
-  auto mscop = TileAndMapThreads(std::move(scop), {16, 16}, {32ul, 8ul});
-  mergeConsecutiveMappingFilters(schedule, schedule->child({0}));
-  mscop->codegen(specializedName);
-}
-
 TEST_F(PolyhedralMapperTest, Match1) {
   auto scop = PrepareAndJoinBands(makeMatmulTc());
   auto schedule = scop->scheduleRoot();

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -89,7 +89,7 @@ struct PolyhedralMapperTest : public ::testing::Test {
     USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
     auto ns = detail::ScheduleTree::collectDFSPostorder(
         root, detail::ScheduleTreeType::Band);
-    mscop->map(ns[0], 0, TX);
+    mscop->map(ns[1], 1, TX);
     mscop->map(ns[1], 0, TY);
     mscop->insertMappingContext();
     return mscop;
@@ -316,11 +316,9 @@ constexpr auto kExpectedMatmul_64_64_64 =
   for (int c0 = 0; c0 <= 63; c0 += 16) {
     for (int c1 = 0; c1 <= 63; c1 += 16) {
       for (int c2 = t1; c2 <= 15; c2 += 8) {
-        for (int c3 = 0; c3 <= 15; c3 += 1) {
-          O[(c0 + c2)][(c1 + c3)] = 0.000000f;
-          for (int c4 = t0; c4 <= 63; c4 += 32) {
-            O[(c0 + c2)][(c1 + c3)] = (O[(c0 + c2)][(c1 + c3)] + (A[(c0 + c2)][c4]*B[c4][(c1 + c3)]));
-          }
+        O[(c0 + c2)][(t0 + c1)] = 0.000000f;
+        for (int c4 = 0; c4 <= 63; c4 += 1) {
+          O[(c0 + c2)][(t0 + c1)] = (O[(c0 + c2)][(t0 + c1)] + (A[(c0 + c2)][c4]*B[c4][(t0 + c1)]));
         }
       }
     }
@@ -369,7 +367,7 @@ TEST_F(PolyhedralMapperTest, Match1) {
           filter([](isl::union_set f) {
             return f.get_space().dim(isl::dim_type::param) == 3;
           }),
-          filter(mapping_filter(band()))),
+          filter(band())),
       schedule);
   EXPECT_EQ(1u, f.size());
 }

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -83,10 +83,10 @@ struct PolyhedralMapperTest : public ::testing::Test {
     // Map to blocks (1 single block here)
     auto mscop = MappedScop::makeMappedScop(
         std::move(scop), Grid{1}, Block{blockSizes[0], blockSizes[1]}, 0);
-    USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
-    auto band = mscop->map(root->child({0}), 0, BX);
+    auto band = mscop->mapBlocksForward(root->child({0}), 1);
     bandScale(band, tileSizes);
 
+    USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
     auto ns = detail::ScheduleTree::collectDFSPostorder(
         root, detail::ScheduleTreeType::Band);
     mscop->map(ns[0], 0, TX);
@@ -110,11 +110,10 @@ struct PolyhedralMapperTest : public ::testing::Test {
         0);
 
     // Map to blocks
-    USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
-    auto band = mscop->map(root->child({0}), 0, BX);
-    band = mscop->map(band, 1, BY);
+    auto band = mscop->mapBlocksForward(root->child({0}), 2);
     bandScale(band, tileSizes);
 
+    USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
     band = mscop->map(band->child({0}), 0, TX);
     band = mscop->map(band, 1, TY);
     mscop->insertMappingContext();

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -340,7 +340,7 @@ TEST_F(PolyhedralMapperTest, MergedContexts) {
 
   auto mscop = TileAndMapThreads(std::move(scop), {16, 16}, {32ul, 8ul});
   auto res = std::get<0>(mscop->codegen(specializedName));
-  ASSERT_TRUE(std::string::npos != res.find(kExpectedMatmul_64_64_64));
+  ASSERT_TRUE(std::string::npos != res.find(kExpectedMatmul_64_64_64)) << res;
 }
 
 TEST_F(PolyhedralMapperTest, FilterMerge) {

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -114,8 +114,8 @@ struct PolyhedralMapperTest : public ::testing::Test {
     bandScale(band, tileSizes);
 
     USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
-    band = mscop->map(band->child({0}), 0, TX);
-    band = mscop->map(band, 1, TY);
+    band = mscop->map(band->child({0}), 1, TX);
+    band = mscop->map(band, 0, TY);
     mscop->insertMappingContext();
     return mscop;
   }
@@ -184,8 +184,8 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
   const float32 (*A)[M] = reinterpret_cast<const float32 (*)[M]>(pA);
   const float32 (*B)[M] = reinterpret_cast<const float32 (*)[M]>(pB);
   for (int c1 = 16 * b1; c1 < M; c1 += 4096) {
-    if (M >= t1 + c1 + 1) {
-      C[(t0 + 16 * b0)][(t1 + c1)] = (A[(t0 + 16 * b0)][(t1 + c1)] + B[(t0 + 16 * b0)][(t1 + c1)]);
+    if (M >= t0 + c1 + 1) {
+      C[(t1 + 16 * b0)][(t0 + c1)] = (A[(t1 + 16 * b0)][(t0 + c1)] + B[(t1 + 16 * b0)][(t0 + c1)]);
     }
   }
 }

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -86,11 +86,9 @@ struct PolyhedralMapperTest : public ::testing::Test {
     auto band = mscop->mapBlocksForward(root->child({0}), 1);
     bandScale(band, tileSizes);
 
-    USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
     auto ns = detail::ScheduleTree::collectDFSPostorder(
         root, detail::ScheduleTreeType::Band);
-    mscop->map(ns[1], 1, TX);
-    mscop->map(ns[1], 0, TY);
+    mscop->mapThreadsBackward(ns[1]);
     mscop->insertMappingContext();
     return mscop;
   }
@@ -113,9 +111,7 @@ struct PolyhedralMapperTest : public ::testing::Test {
     auto band = mscop->mapBlocksForward(root->child({0}), 2);
     bandScale(band, tileSizes);
 
-    USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
-    band = mscop->map(band->child({0}), 1, TX);
-    band = mscop->map(band, 0, TY);
+    band = mscop->mapThreadsBackward(band->child({0}));
     mscop->insertMappingContext();
     return mscop;
   }

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -115,7 +115,7 @@ TEST_F(Sum4D, CodeOuterBand) {
       "C[16 * b0 + c4][16 * b1 + c5][c2 + c6][c3 + c7] = _C_0[c4][c5][c6][c7];";
   auto sync = "__syncthreads()";
 
-  auto code = emitCode({256, 128, 192, 224}, {16, 16, 16, 16}, {0, 0, 0, 0});
+  auto code = emitCode({256, 128, 192, 224}, {16, 16, 16, 16}, {0, 0, 0});
   // Order of copies may be arbitrary, but syncs must be inserted before and
   // after
   for (auto d : declarations) {
@@ -162,7 +162,7 @@ TEST_F(Sum4D, CodeAboveThreadMapping) {
       "C[16 * b0 + c4][16 * b1 + c5][c2 + c6][c3 + c7] = _C_0[c4][c5][c6][c7];";
   auto sync = "__syncthreads()";
 
-  auto code = emitCode({256, 128, 192, 224}, {16, 16, 16, 16}, {0, 0, 0, 0});
+  auto code = emitCode({256, 128, 192, 224}, {16, 16, 16, 16}, {0, 0, 0});
 
   // Order of copies may be arbitrary, but syncs must be inserted before and
   // after
@@ -204,8 +204,8 @@ TEST_F(Sum4D, CodeInnerBand) {
       "C[16 * b0 + c4][16 * b1 + c5][c2 + c6][t0 + c3] = _C_0[0][0][0][0];";
   auto sync = "__syncthreads()";
 
-  auto code = emitCode(
-      {256, 128, 192, 224}, {16, 16, 16, 16}, {0, 0, 0, 0, 0, 0, 0, 0});
+  auto code =
+      emitCode({256, 128, 192, 224}, {16, 16, 16, 16}, {0, 0, 0, 0, 0, 0});
   // Order of copies may be arbitrary, but syncs must be inserted before and
   // after
   for (auto d : declarations) {


### PR DESCRIPTION
After these changes, there is only a single call left to `makeMappingFilter`
(in `MappedScop::map`).  This will make it easy to change the representation
of the mapping filter to contain extra information available inside `MappedScop::map`.
The change of the representation itself is left for a later PR.