### PR TITLE
[C++ API] Step 3: add refactored tensor API files

### DIFF
--- a/tc/core/tensor-inl.h
+++ b/tc/core/tensor-inl.h
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <sstream>
+
+#include <glog/logging.h>
+#include <google/protobuf/text_format.h>
+
+#include "tc/proto/compcache.pb.h"
+
+namespace tc {
+template <typename T>
+std::vector<T> makeStridesFromSizes(const std::vector<T>& sizes) {
+  auto ndim = sizes.size();
+  if (ndim == 0) {
+    return std::vector<T>();
+  }
+  std::vector<T> strides(sizes.size(), 0);
+  strides[ndim - 1] = 1;
+  for (int i = ndim - 2; i >= 0; --i) {
+    strides[i] = strides[i + 1] * sizes[i + 1];
+  }
+  return strides;
+}
+
+inline DLContext getCPUDLContext() {
+  DLContext res;
+  res.device_id = 0;
+  res.device_type = DLDeviceType::kDLCPU;
+  return res;
+}
+
+inline DLContext getGPUDLContext(int device_id) {
+  DLContext res;
+  res.device_id = device_id;
+  res.device_type = DLDeviceType::kDLGPU;
+  return res;
+}
+
+template <typename DLTensorType>
+void DLTensorDeleter::operator()(const DLTensorType* t) {
+  if (t->shape) {
+    delete[] t->shape;
+  }
+  if (t->strides) {
+    delete[] t->strides;
+  }
+  delete t;
+};
+
+namespace detail {
+template <typename DLTensorType, typename T>
+inline std::unique_ptr<DLTensorType, DLTensorDeleter> makeDLTensor(
+    DLContext ctx,
+    DLDataType dtype,
+    const std::vector<T>& sizes,
+    const std::vector<T>& strides = std::vector<T>(),
+    decltype(DLTensorType().data) data = nullptr,
+    uint64_t byteOffset = 0) {
+  static_assert(
+      std::is_convertible<T, int64_t>::value,
+      "Template type not convertible to int64_t");
+  std::unique_ptr<DLTensorType, DLTensorDeleter> res(new DLTensorType);
+  res->data = data;
+  res->ctx = ctx;
+  auto ndim = sizes.size();
+  res->ndim = ndim;
+  res->dtype = dtype;
+  res->shape = new int64_t[ndim];
+  for (size_t i = 0; i < ndim; ++i) {
+    res->shape[i] = sizes[i];
+  }
+  res->strides = new int64_t[ndim];
+  std::vector<T> st(strides);
+  if (st.size() == 0) {
+    st = makeStridesFromSizes(sizes);
+  }
+  for (size_t i = 0; i < ndim; ++i) {
+    res->strides[i] = st[i];
+  }
+  res->byte_offset = byteOffset;
+  return res;
+}
+
+template <typename DLTensorType>
+inline std::unique_ptr<DLTensorType, DLTensorDeleter> makeDLTensorHelper(
+    const DLTensor* ptr) {
+  std::vector<int64_t> sizes(ptr->ndim, 0);
+  std::copy(ptr->shape, ptr->shape + ptr->ndim, sizes.begin());
+  std::vector<int64_t> strides(ptr->ndim, 0);
+  std::copy(ptr->strides, ptr->strides + ptr->ndim, strides.begin());
+  return makeDLTensor<DLTensorType>(
+      ptr->ctx, ptr->dtype, sizes, strides, ptr->data, ptr->byte_offset);
+}
+} // namespace detail
+
+inline DLTensorUPtr makeDLTensor(const DLTensor* ptr) {
+  return detail::makeDLTensorHelper<DLTensor>(ptr);
+}
+
+inline DLTensorUPtr makeDLTensor(const TensorInfo& tensor) {
+  return detail::makeDLTensor<DLTensor>(
+      DLContext{kDLCPU, 0},
+      tensor.dtype,
+      tensor.shape,
+      tensor.strides,
+      nullptr,
+      tensor.alignment);
+}
+
+template <typename T>
+inline DLTensorUPtr makeDLTensor(
+    DLContext ctx,
+    DLDataType dtype,
+    const std::vector<T>& sizes,
+    const std::vector<T>& strides,
+    void* data,
+    uint64_t byteOffset) {
+  return detail::makeDLTensor<DLTensor>(
+      ctx, dtype, sizes, strides, data, byteOffset);
+}
+
+template <typename DLTensorType>
+inline DLConstTensorUPtr makeDLConstTensor(const DLTensorType* ptr) {
+  return detail::makeDLTensorHelper<DLConstTensor>(ptr);
+}
+
+inline DLConstTensorUPtr makeDLConstTensor(const TensorInfo& tensor) {
+  return detail::makeDLTensor<DLConstTensor>(
+      DLContext{kDLCPU, 0},
+      tensor.dtype,
+      tensor.shape,
+      tensor.strides,
+      nullptr,
+      tensor.alignment);
+}
+
+template <typename T>
+inline DLConstTensorUPtr makeDLConstTensor(
+    DLContext ctx,
+    DLDataType dtype,
+    const std::vector<T>& sizes,
+    const std::vector<T>& strides,
+    const void* data,
+    uint64_t byteOffset) {
+  return detail::makeDLTensor<DLConstTensor>(
+      ctx, dtype, sizes, strides, data, byteOffset);
+}
+
+// Specializes for const DLTensor*, const DLConstTensor* and TensorInfo
+template <typename T>
+std::vector<DLTensorUPtr> makeDLTensorVector(const std::vector<T>& ptrs) {
+  std::vector<DLTensorUPtr> res;
+  for (auto p : ptrs) {
+    res.push_back(makeDLTensor(p));
+  }
+  return res;
+}
+
+template <typename T>
+std::vector<DLConstTensorUPtr> makeDLConstTensorVector(
+    const std::vector<T>& ptrs) {
+  std::vector<DLConstTensorUPtr> res;
+  res.reserve(ptrs.size());
+  for (auto p : ptrs) {
+    res.push_back(makeDLConstTensor(p));
+  }
+  return res;
+}
+
+template <typename DLTensorPtrType>
+std::vector<TensorInfo> makeTensorInfoVector(
+    const std::vector<DLTensorPtrType>& ts) {
+  std::vector<TensorInfo> res;
+  res.reserve(ts.size());
+  std::transform(
+      ts.begin(), ts.end(), std::back_inserter(res), [](DLTensorPtrType t) {
+        return TensorInfo(t);
+      });
+  return res;
+}
+
+inline std::vector<const DLTensor*> extractRawPtrs(
+    const std::vector<DLTensorUPtr>& uptrs) {
+  std::vector<const DLTensor*> res(uptrs.size(), nullptr);
+  for (size_t i = 0; i < uptrs.size(); ++i) {
+    res[i] = uptrs[i].get();
+  }
+  return res;
+}
+
+inline std::vector<const DLConstTensor*> extractRawPtrs(
+    const std::vector<DLConstTensorUPtr>& uptrs) {
+  std::vector<const DLConstTensor*> res(uptrs.size(), nullptr);
+  for (size_t i = 0; i < uptrs.size(); ++i) {
+    res[i] = uptrs[i].get();
+  }
+  return res;
+}
+
+inline std::string toString(const DLDataType& t) {
+  if (t.lanes != 1) {
+    CHECK(false) << "NYI: toString for >1 lanes";
+  }
+  switch (t.code) {
+    case DLDataTypeCode::kDLFloat:
+      switch (t.bits) {
+        case 16:
+          return "Half";
+        case 32:
+          return "float";
+        case 64:
+          return "double";
+      }
+      break;
+    case DLDataTypeCode::kDLInt:
+      switch (t.bits) {
+        case 8:
+          return "int8_t";
+        case 16:
+          return "int16_t";
+        case 32:
+          return "int";
+        case 64:
+          return "int64_t";
+      }
+      break;
+    case DLDataTypeCode::kDLUInt:
+      switch (t.bits) {
+        case 8:
+          return "uint8_t";
+      }
+      break;
+  }
+  CHECK(false) << "NYI: toString for type: " << t.code << ", bits: " << t.bits;
+  return "";
+}
+
+inline std::string toString(const DLTensor& t) {
+  std::stringstream ss;
+  ss << "DLTensor@" << t.data << ":\n";
+  std::string res;
+  google::protobuf::TextFormat::PrintToString(
+      TensorInfo(&t).toProtobuf(), &res);
+  ss << res;
+  return ss.str();
+}
+} // namespace tc

--- a/tc/core/tensor.cc
+++ b/tc/core/tensor.cc
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <version.h>
+
+#include <cstdint>
+#include <fstream>
+#include <numeric>
+#include <tuple>
+
+#include "tc/core/tensor.h"
+#include "tc/core/utils/math.h"
+
+namespace tc {
+namespace detail {
+template <typename DLTensorType>
+uint64_t getDLTensorAlignment(const DLTensorType* t) {
+  return (reinterpret_cast<std::uintptr_t>(t->data) + t->byte_offset) % 256;
+}
+
+std::vector<int64_t> toIntVector(const int64_t* ptr, size_t ndim) {
+  if (!ptr) {
+    return {};
+  }
+  std::vector<int64_t> res;
+  res.reserve(ndim);
+  std::copy(ptr, ptr + ndim, std::back_inserter(res));
+  return res;
+}
+} // namespace detail
+
+TensorInfo::TensorInfo(
+    DLDataType t,
+    uint64_t align,
+    const std::vector<int64_t>& sz,
+    const std::vector<int64_t>& st)
+    : dtype(t), alignment(align), shape(sz), strides(st) {}
+
+TensorInfo::TensorInfo(const DLTensor* t)
+    : TensorInfo(
+          t->dtype,
+          detail::getDLTensorAlignment(t),
+          detail::toIntVector(t->shape, t->ndim),
+          detail::toIntVector(t->strides, t->ndim)) {}
+
+TensorInfo::TensorInfo(const DLTensorUPtr& ptr) : TensorInfo(ptr.get()) {}
+
+TensorInfo::TensorInfo(const DLConstTensor* t)
+    : TensorInfo(
+          t->dtype,
+          detail::getDLTensorAlignment(t),
+          detail::toIntVector(t->shape, t->ndim),
+          detail::toIntVector(t->strides, t->ndim)) {}
+
+TensorInfo::TensorInfo(const DLConstTensorUPtr& ptr) : TensorInfo(ptr.get()) {}
+
+TensorInfo::TensorInfo(const TensorInfoProto& buf)
+    : dtype{static_cast<uint8_t>(buf.dtype().code()),
+            static_cast<uint8_t>(buf.dtype().bits()),
+            static_cast<uint16_t>(buf.dtype().lanes())},
+      alignment{buf.alignment()},
+      shape{buf.shape().begin(), buf.shape().end()},
+      strides{buf.strides().begin(), buf.strides().end()} {}
+
+TensorInfoProto TensorInfo::toProtobuf() const {
+  TensorInfoProto buf;
+  buf.mutable_shape()->Reserve(shape.size());
+  std::copy(
+      shape.begin(),
+      shape.end(),
+      google::protobuf::RepeatedFieldBackInserter(buf.mutable_shape()));
+  buf.mutable_strides()->Reserve(strides.size());
+  std::copy(
+      strides.begin(),
+      strides.end(),
+      google::protobuf::RepeatedFieldBackInserter(buf.mutable_strides()));
+  buf.set_alignment(alignment);
+  buf.mutable_dtype()->set_code(dtype.code);
+  buf.mutable_dtype()->set_bits(dtype.bits);
+  buf.mutable_dtype()->set_lanes(dtype.lanes);
+  return buf;
+}
+
+bool operator==(const DLDataType& a, const DLDataType& b) {
+  return a.code == b.code and a.bits == b.bits and a.lanes == b.lanes;
+}
+
+bool TensorInfo::operator==(const TensorInfo& t) const {
+  return alignment == t.alignment and dtype == t.dtype and shape == t.shape and
+      strides == t.strides;
+}
+
+std::vector<TensorInfo> makeTensorInfoVector(
+    const google::protobuf::RepeatedPtrField<TensorInfoProto>& buf) {
+  std::vector<TensorInfo> iis;
+  iis.reserve(buf.size());
+  std::transform(
+      buf.begin(),
+      buf.end(),
+      std::back_inserter(iis),
+      [](const TensorInfoProto& iip) { return TensorInfo{iip}; });
+  return iis;
+}
+} // namespace tc

--- a/tc/core/tensor.h
+++ b/tc/core/tensor.h
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <dlpack/dlpack.h>
+
+#include "tc/proto/compcache.pb.h"
+
+/**
+ * Various tensor utilities used in the Tensor Comprehensions compiler.
+ * At a high-level we use the DLTensor type from dlpack and we add a
+ * DLConstTensor to propagate const-correctness.
+ * DLTensor is used as an ML-framework and backend-agnostic representation to
+ * interact with user-level tensors.
+ * DLTensorUPtr and DLConstTensorUPtr are used as metadata-owning pointers.
+ * The underlying concrete device pointer is borrowed when calling
+ * ExecutionEngine::compile and ExecutionEngine::run.
+ *
+ * Internally, TC uses TensorInfo for compiling and interacting with the
+ * compilation caches. TensorInfo is backed by protobuf and stored directly in
+ * the caches.
+ */
+
+/**
+ * DLPack is missing a ConstTensor. Add it here for now.
+ * In the future, this would be contributed back to dlpack/include/dlpack.h.
+ */
+typedef struct {
+  const void* data;
+  DLContext ctx;
+  int ndim;
+  DLDataType dtype;
+  int64_t* shape;
+  int64_t* strides;
+  uint64_t byte_offset;
+} DLConstTensor;
+
+namespace tc {
+/**
+ * C++ unique_ptr abstraction on top of DLTensor/DLConstTensor
+ */
+struct DLTensorDeleter {
+  template <typename DLTensorType>
+  void operator()(const DLTensorType* t);
+};
+using DLTensorUPtr = std::unique_ptr<DLTensor, DLTensorDeleter>;
+using DLConstTensorUPtr = std::unique_ptr<DLConstTensor, DLTensorDeleter>;
+
+// Return non-owning raw pointers to DLTensor from metadata-owning DLTensorUPtr
+std::vector<const DLConstTensor*> extractRawPtrs(
+    const std::vector<DLConstTensorUPtr>& uptrs);
+std::vector<const DLTensor*> extractRawPtrs(
+    const std::vector<DLTensorUPtr>& uptrs);
+
+/**
+ * TensorInfo wraps the necessary tensor information to compile TCs and
+ * interact with the various caches.
+ * Notably, it contains alignment information but no underlying data pointer.
+ * It is serializable to protobuf and stored directly in the cache.
+ */
+struct TensorInfo {
+  DLDataType dtype;
+  uint64_t alignment;
+  std::vector<int64_t> shape;
+  std::vector<int64_t> strides;
+
+  TensorInfo(
+      DLDataType dtype,
+      uint64_t alignment,
+      const std::vector<int64_t>& shape,
+      const std::vector<int64_t>& strides);
+  explicit TensorInfo(const DLTensor* t);
+  explicit TensorInfo(const DLConstTensor* t);
+  explicit TensorInfo(const DLTensorUPtr& t);
+  explicit TensorInfo(const DLConstTensorUPtr& t);
+  explicit TensorInfo(const TensorInfoProto& buf);
+
+  bool operator==(const TensorInfo& t) const;
+  TensorInfoProto toProtobuf() const;
+};
+
+/// Given sizes, this returns strides that can be used to construct a
+/// tensor with a contiguous memory-layout (Torch7 nomenclature).
+/// A contiguous tensor is on which indexing with an ordered multi-dimensional
+/// index ranging from (0, ..., 0) to sizes results in a strictly monotonic
+/// traversal of the underlying memory, without holes.
+/// For instance, given sizes=[3, 4, 5], the strides compatible with a
+/// contiguous memory layout are [20, 5, 1].
+/// Note that general stride expressions can result in multiple different
+/// behavior (e.g. stride 0 along a certain dimension will traverse the same
+/// values multiple times).
+template <typename T>
+std::vector<T> makeStridesFromSizes(const std::vector<T>& sizes);
+
+// Specializes for DLTensor, DLConstTensor
+template <typename DLTensorPtrType>
+std::vector<TensorInfo> makeTensorInfoVector(
+    const std::vector<DLTensorPtrType>& ts);
+std::vector<TensorInfo> makeTensorInfoVector(
+    const google::protobuf::RepeatedPtrField<TensorInfoProto>& buf);
+
+// Basic support functions for DLTensors
+DLContext getCPUDLContext();
+DLContext getGPUDLContext(int device_id = 0);
+bool operator==(const DLDataType& t1, const DLDataType& t2);
+
+// Print the metadata for DLDataType and DLTensor
+std::string toString(const DLDataType& t);
+std::ostream& operator<<(std::ostream& os, const DLDataType& t);
+std::ostream& operator<<(std::ostream& os, const DLTensor& t);
+
+// Basic metadata-owning DLTensor, only copies the underlying raw pointer.
+DLTensorUPtr makeDLTensor(const DLTensor* ptr);
+template <typename DLTensorType>
+DLConstTensorUPtr makeDLConstTensor(const DLTensorType* ptr);
+template <typename T>
+inline DLTensorUPtr makeDLTensor(
+    DLContext ctx,
+    DLDataType dtype,
+    const std::vector<T>& sizes,
+    const std::vector<T>& strides = std::vector<T>(),
+    const void* data = nullptr,
+    uint64_t byteOffset = 0);
+template <typename T>
+inline DLConstTensorUPtr makeDLConstTensor(
+    DLContext ctx,
+    DLDataType dtype,
+    const std::vector<T>& sizes,
+    const std::vector<T>& strides = std::vector<T>(),
+    const void* data = nullptr,
+    uint64_t byteOffset = 0);
+// A metadata-owning DLTensor reconstructed from TensorInfo does not have a
+// meaningful pointer or DLContext: pointer is  nullptr and ctx is kDLCPU.
+DLTensorUPtr makeDLTensor(const TensorInfo& tensor);
+DLConstTensorUPtr makeDLConstTensor(const TensorInfo& tensor);
+
+// Specializes for const DLTensor*, const DLConstTensor* and TensorInfo
+template <typename T>
+std::vector<DLTensorUPtr> makeDLTensorVector(const std::vector<T>& ptrs);
+template <typename T>
+std::vector<DLConstTensorUPtr> makeDLConstTensorVector(
+    const std::vector<T>& ptrs);
+} // namespace tc
+
+#include "tc/core/tensor-inl.h"


### PR DESCRIPTION
This PR adds the files refactoring the tensor API #313.

In particular this:
1. adds a DLConstTensor for proper const correctness propagation + proper
overloads and specializations
2. uniformizes tensor related functions and put them in the same location
3. makes TensorInfo more visible as the tensor representation on which
compilation and cache interaction occur cleanup unused functions
4. makes this file the only place that includes <dlpack/dlpack.h>

As part of the bigger refactoring, these files are not yet activated
(or even compiled) therefore the changeset cannot be tested independently.
This new implementation will be switched in as part of the last commit of the
the global refactoring.