### PR TITLE
[C++ API] Step 4: add the new ATen compiler files

### DIFF
--- a/tc/aten/aten_compiler_new_api-inl.h
+++ b/tc/aten/aten_compiler_new_api-inl.h
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/aten/aten_compiler.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "tc/aten/aten.h"
+#include "tc/core/compiler.h"
+#include "tc/core/tc_executor.h"
+#include "tc/core/tensor.h"
+
+namespace tc {
+namespace aten {
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<at::Tensor>& inputs,
+    const typename Backend::MappingOptionsType& options) {
+  auto inputDLTensors = makeDLConstTensors(inputs);
+  return tc::compile<Backend>(
+      tc, entryPoint, extractRawPtrs(inputDLTensors), options);
+}
+
+template <typename Executor>
+void run(
+    const Executor& executor,
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs) {
+  auto inputDLTensors = makeDLConstTensors(inputs);
+  auto outputDLTensors = makeDLTensors(outputs);
+  return executor.run(
+      extractRawPtrs(inputDLTensors), extractRawPtrs(outputDLTensors));
+}
+
+template <typename Executor>
+ProfilingInfo profile(
+    const Executor& executor,
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs) {
+  auto start = std::chrono::system_clock::now();
+  auto inputDLTensors = makeDLConstTensors(inputs);
+  auto outputDLTensors = makeDLTensors(outputs);
+  ProfilingInfo pi(executor.profile(
+      extractRawPtrs(inputDLTensors), extractRawPtrs(outputDLTensors)));
+
+  // The total CPU overhead is the total time minus the (synchronized) kernel
+  // runtime
+  auto end = std::chrono::system_clock::now();
+  Duration cpuOverhead(end - start);
+  cpuOverhead = cpuOverhead - pi.kernelRuntime;
+  return ProfilingInfo{cpuOverhead, pi.kernelRuntime};
+}
+
+template <typename Executor>
+void uncheckedRun(
+    const Executor& executor,
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs) {
+  CHECK_GE(outputs.size(), 1u);
+  std::vector<const void*> rawInputs(inputs.size(), nullptr);
+  std::vector<void*> rawOutputs(outputs.size(), nullptr);
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    rawInputs[i] = inputs[i].data_ptr();
+  }
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    rawOutputs[i] = outputs[i].data_ptr();
+  }
+  return executor.uncheckedRun(rawInputs, rawOutputs);
+}
+} // namespace aten
+} // namespace tc

--- a/tc/aten/aten_compiler_new_api.cc
+++ b/tc/aten/aten_compiler_new_api.cc
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/aten/aten_compiler.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "tc/aten/aten.h"
+#include "tc/core/compiler.h"
+#include "tc/core/tc_executor.h"
+#include "tc/core/tensor.h"
+
+namespace tc {
+namespace aten {
+std::vector<tc::DLTensorUPtr> inferOutputTensorInfo(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<at::Tensor>& inputs) {
+  auto parsedTcs = tc::detail::parse(tc);
+  if (parsedTcs.count(entryPoint) != 1u) {
+    CHECK_GE(parsedTcs.size(), 1u)
+        << "No TC was parsed, should have thrown earlier";
+    throw lang::ErrorReport(parsedTcs.begin()->second)
+        << "\nattempting to access undefined entryPoint: " << entryPoint;
+  }
+  auto inputDLTensors = makeDLConstTensors(inputs);
+  return makeDLTensorVector(detail::inferOutputTensorInfo(
+      parsedTcs.at(entryPoint), extractRawPtrs(inputDLTensors)));
+}
+
+std::vector<at::Tensor> prepareOutputs(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<at::Tensor>& inputs) {
+  std::vector<at::Tensor> outputs;
+  auto outTensorInfo = inferOutputTensorInfo(tc, entryPoint, inputs);
+  if (outTensorInfo.size() == 0) {
+    return outputs;
+  }
+  CHECK_GE(inputs.size(), 1u)
+      << "NYI: Need >= 1 input tensors to determine "
+      << "backend and prepare ATen outputs. Add an overload with just an ATen "
+      << "backend";
+  auto atenBackend = inputs[0].type().backend();
+  for (size_t i = 0; i < outTensorInfo.size(); ++i) {
+    TensorInfo info(outTensorInfo[i]);
+    auto stype = at::toScalarType(info.dtype);
+    outputs.push_back(
+        at::getType(atenBackend, stype).tensor(at::IntList(info.shape)));
+  }
+  return outputs;
+}
+} // namespace aten
+} // namespace tc

--- a/tc/aten/aten_compiler_new_api.h
+++ b/tc/aten/aten_compiler_new_api.h
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "tc/aten/aten.h"
+#include "tc/core/tensor.h"
+#include "tc/core/utils/time.h"
+
+namespace tc {
+namespace aten {
+/// Given a TC string with multiple functions defined and a TC function name
+/// entryPoint, this runs inference, applied to the specified input shapes.
+/// This is used for manual processing of output metadata on the ATen user
+/// side.
+/// \returns the (contiguous) output tensor shapes as a metadata-owning
+/// DLTensorUPtr.
+std::vector<tc::DLTensorUPtr> inferOutputTensorInfo(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<at::Tensor>& inputs);
+
+/// Given a TC string with multiple functions defined and a TC function name
+/// entryPoint, this runs inference, applied to the specified input shapes and
+/// allocates fresh new output tensors.
+/// If one wants inplace/resize behavior, one can implement it using
+/// inferOutputTensorInfo.
+/// \returns the (contiguous) output tensors with properly inferred sizes.
+std::vector<at::Tensor> prepareOutputs(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<at::Tensor>& inputs);
+
+/// Given a TC string with multiple functions defined and a TC function name
+/// entryPoint, compile the TC for the specified input shapes with the
+/// prescribed options.
+/// \returns an Executor for the specified backend with an underlying
+/// JIT-compiled callable function.
+template <typename Backend>
+std::unique_ptr<typename Backend::ExecutorType> compile(
+    const std::string& tc,
+    const std::string& entryPoint,
+    const std::vector<at::Tensor>& inputs,
+    const typename Backend::MappingOptionsType& options);
+
+/// Given an executor resulting from compiling a TC, run the TC and fill the
+/// outputs vector with the results. The output vector must have as many
+/// tensors as the number of outputs in the TC. These must be preallocated and
+/// of the proper shapes.
+/// Preallocation may be done, for instance, by using prepareOutputs.
+template <typename Executor>
+void run(
+    const Executor& executor,
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs);
+
+/// Given an executor resulting from compiling a TC, run the TC and fill the
+/// outputs vector with the results.
+/// \returns ProfilingInfo (which contains cpuOverhead and kernelRuntime) in
+/// microseconds.
+template <typename Executor>
+ProfilingInfo profile(
+    const Executor& executor,
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs);
+
+/// This is the "low-latency" mode in which we just propagate ATen tensors
+/// Sizes are not checked and it is the user's responsibility to ensure that
+/// they match. If the user doesn't then segfault will likely occur.
+template <typename Executor>
+void uncheckedRun(
+    const Executor& executor,
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs);
+} // namespace aten
+} // namespace tc
+
+#include "tc/aten/aten_compiler-inl.h"


### PR DESCRIPTION
This PR adds the files implementing the ATen user-facing part (#324) on
top of the new compiler API (#322). The ExecutionEngine has been retired
and the user-facing API reflects this.

This provides a minimal API to wrap ```tc/core/compiler.h``` under a tensor
library like ATen. In particular this gets rid of the ```ATenCompilationUnit```
class which kept state about parsed TCs.

Tinkering with the underlying TreeRef memoization is penny-wise and pound
foolish: parsing overhead never matters and it adds cognitive overhead to the
API. Therefore this API only provides functionality operating on TC strings.

To guard against overhead, the executors themselves should be memoized and
reused.

As part of the bigger refactoring, these files are not yet activated
(or even compiled) therefore the changeset cannot be tested independently.
This new implementation will be switched in as part of the last commit of the
the global refactoring.