### PR TITLE
[C++ API] Step 5: add the new TcExecutor implementations

### DIFF
--- a/tc/core/cpu/cpu_tc_executor_new_api.cc
+++ b/tc/core/cpu/cpu_tc_executor_new_api.cc
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/core/cpu/cpu_tc_executor.h"
+
+#include "tc/core/cpu/cpu_mapping_options.h"
+#include "tc/core/cpu/cpu_mapping_options_cpp_printer.h"
+#include "tc/core/halide_utils.h"
+#include "tc/core/tc2halide.h"
+#include "tc/core/tensor.h"
+#include "tc/lang/parser.h"
+#include "tc/lang/sema.h"
+#include "version.h"
+
+namespace tc {
+CpuTcExecutor::CpuTcExecutor(
+    const std::vector<TensorInfo>& inputsInfo,
+    const std::vector<TensorInfo>& outputsInfo,
+    const tc2halide::HalideComponents& halideComponents,
+    const typename CpuBackend::CompilationResultType& compilationResult)
+    : TcExecutor<CpuBackend>(
+          inputsInfo,
+          outputsInfo,
+          halideComponents,
+          compilationResult) {
+  LOG(ERROR) << "NYI: CpuTcExecutor::CpuTcExecutor setup RTC";
+}
+
+CpuCompilationResult CpuBackend::compileWithTcMapper(
+    const std::string& tcName,
+    tc2halide::HalideComponents halideComponents,
+    const std::vector<const DLConstTensor*>& inputs,
+    /* TODO: in the future also pass outputs for stride and alignment info */
+    const CpuMappingOptions& options) {
+  LOG(ERROR) << "NYI: CpuBackend::compileWithTcMapper";
+  return CpuCompilationResult{std::string("source"),
+                              std::string("specializedName"),
+                              std::vector<long>()};
+}
+
+void CpuTcExecutor::uncheckedRun(
+    const std::vector<const void*>& inputs,
+    const std::vector<void*>& outputs) const {
+  LOG(ERROR) << "NYI: CpuTcExecutor::uncheckedRun";
+}
+
+ProfilingInfo CpuTcExecutor::profileUnchecked(
+    const std::vector<const void*>& inputs,
+    const std::vector<void*>& outputs) const {
+  LOG(ERROR) << "NYI: CpuTcExecutor::profileUnchecked";
+  return ProfilingInfo{
+      Duration(std::chrono::microseconds(static_cast<int64_t>(999999999999))),
+      Duration(std::chrono::microseconds(static_cast<int64_t>(999999999999)))};
+}
+} // namespace tc

--- a/tc/core/cpu/cpu_tc_executor_new_api.h
+++ b/tc/core/cpu/cpu_tc_executor_new_api.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "tc/core/cpu/cpu_backend.h"
+#include "tc/core/cpu/cpu_mapping_options.h"
+#include "tc/core/tc_executor.h"
+#include "tc/core/tensor.h"
+
+namespace tc {
+class CpuTcExecutor : public TcExecutor<CpuBackend> {
+ public:
+  CpuTcExecutor(
+      const std::vector<TensorInfo>& inputsInfo,
+      const std::vector<TensorInfo>& outputsInfo,
+      const tc2halide::HalideComponents& halideComponents,
+      const typename CpuBackend::CompilationResultType& compilationResult);
+
+  /// This is the "low-latency" mode in which we just propagate raw pointers to
+  /// data in the address space where kernel is executed.
+  /// No tensor-related information can be checked so it is the user's
+  /// responsibility to ensure that shapes and strides match. If the user
+  /// doesn't then segfault will likely occur.
+  void uncheckedRun(
+      const std::vector<const void*>& inputs,
+      const std::vector<void*>& outputs) const;
+
+  /// Calls uncheckedRun and profiles the cpu overhead and kernel runtime
+  /// (microseconds).
+  /// \returns profiling information
+  ProfilingInfo profileUnchecked(
+      const std::vector<const void*>& inputs,
+      const std::vector<void*>& outputs) const;
+};
+} // namespace tc

--- a/tc/core/cuda/cuda_tc_executor_new_api.cc
+++ b/tc/core/cuda/cuda_tc_executor_new_api.cc
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/core/cuda/cuda_tc_executor.h"
+
+#include "tc/core/cuda/cuda_mapping_options_cpp_printer.h"
+#include "tc/core/halide_utils.h"
+#include "tc/core/polyhedral/cuda/mapped_scop.h"
+#include "tc/core/tc2halide.h"
+#include "tc/core/tensor.h"
+
+#include "tc/lang/parser.h"
+#include "tc/lang/sema.h"
+
+#include <utility>
+
+namespace tc {
+namespace {
+// Append ordered values to the kernel name, separated by "_".
+template <typename T>
+std::string specializeKernelName(
+    const std::string& tcName,
+    std::vector<T> params) {
+  std::stringstream ss;
+  ss << tcName;
+  for (auto i : params) {
+    ss << "_" << i;
+  }
+  return ss.str();
+}
+} // namespace
+
+CudaTcExecutor::CudaTcExecutor(
+    const std::vector<TensorInfo>& inputsInfo,
+    const std::vector<TensorInfo>& outputsInfo,
+    const tc2halide::HalideComponents& halideComponents,
+    const typename CudaBackend::CompilationResultType& compilationResult)
+    : TcExecutor<CudaBackend>(
+          inputsInfo,
+          outputsInfo,
+          halideComponents,
+          compilationResult) {
+  auto t0 = std::chrono::high_resolution_clock::now();
+  // force unloading in case we JIT with the same name/input/outputs with
+  // different options.
+  this->clearRuntimeCompiledFunction();
+  rtcFun_ = CudaRTCFunction::Compile(
+      compilationResult.specializedName, compilationResult.source);
+  grid_ = compilationResult.grid;
+  block_ = compilationResult.block;
+  auto t1 = std::chrono::high_resolution_clock::now();
+  LOG_IF(INFO, FLAGS_debug_tc_mapper)
+      << "[COMPILE] Compiling with host JIT compiler took: "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count()
+      << "ms" << std::endl;
+}
+
+CudaCompilationResult CudaBackend::compileWithTcMapper(
+    const std::string& tcName,
+    tc2halide::HalideComponents halideComponents,
+    const std::vector<const DLConstTensor*>& inputs,
+    /* TODO: in the future also pass outputs for stride and alignment info */
+    const CudaMappingOptions& options) {
+  // A bit chicken-and-eggy, need scop from TC to have the space to build the
+  // context to specialize the scop..
+  auto scop = polyhedral::Scop::makeScop(
+      isl::with_exceptions::globalIslCtx(), halideComponents);
+  auto globalParameterContext = scop->makeContextFromInputs(inputs);
+  scop = polyhedral::Scop::makeSpecializedScop(
+      *scop, globalParameterContext.intersect(scop->globalParameterContext));
+  LOG_IF(INFO, FLAGS_debug_tc_mapper) << options;
+  LOG_IF(INFO, FLAGS_debug_tc_mapper) << "original schedule:\n"
+                                      << *(scop->scheduleRoot());
+
+  // Now we can build stuff
+  auto mappedScop =
+      polyhedral::MappedScop::makeWithOuterBlockInnerThreadStrategy(
+          std::move(scop), options);
+  LOG_IF(INFO, FLAGS_debug_tc_mapper) << "Mapped schedule:" << std::endl
+                                      << *(mappedScop->schedule());
+
+  auto parameters =
+      mappedScop->scop().getParameterValues(globalParameterContext);
+  auto specializedName = specializeKernelName(tcName, parameters);
+
+  // This updates the launch bounds with the actual result from compilation
+  // with tightening of launch_bounds. What you get is not necessarily what
+  // you asked for, the autotuner should adapt to that.
+  std::string source;
+  Grid grid;
+  Block block;
+  std::tie(source, grid, block) = mappedScop->codegen(specializedName);
+  LOG_IF(INFO, FLAGS_dump_cuda) << "generatedCuda: " << source << "\n"
+                                << "grid: " << grid << " block: " << block;
+
+  return CudaCompilationResult{
+      source, specializedName, parameters, grid, block};
+}
+
+void CudaTcExecutor::uncheckedRun(
+    const std::vector<const void*>& inputs,
+    const std::vector<void*>& outputs) const {
+  CHECK(rtcFun_) << "No rtcFun_ attached, cannot launch";
+  cudaStream_t stream = 0;
+  CHECK_NE(grid_.view[0], 0u) << "Grid dims are not set up";
+  CHECK_NE(block_.view[0], 0u) << "Block dims are not set up";
+  rtcFun_->Launch(
+      grid_.view.extractDefaultedArray(),
+      block_.view.extractDefaultedArray(),
+      0,
+      stream,
+      parameters_,
+      outputs,
+      inputs);
+}
+
+ProfilingInfo CudaTcExecutor::profileUnchecked(
+    const std::vector<const void*>& inputs,
+    const std::vector<void*>& outputs) const {
+  auto start = std::chrono::system_clock::now();
+  CHECK(rtcFun_) << "No rtcFun_ attached, cannot launch";
+  cudaStream_t stream = 0;
+  CHECK_NE(grid_.view[0], 0u) << "Grid dims are not set up";
+  CHECK_NE(block_.view[0], 0u) << "Block dims are not set up";
+  Duration kernelRuntime(rtcFun_->Launch(
+      grid_.view.extractDefaultedArray(),
+      block_.view.extractDefaultedArray(),
+      0,
+      stream,
+      parameters_,
+      outputs,
+      inputs,
+      true));
+  // The CPU overhead is the total time minus the (synchronized) kernel runtime
+  auto end = std::chrono::system_clock::now();
+  Duration cpuOverhead(end - start);
+  cpuOverhead = cpuOverhead - kernelRuntime;
+  return ProfilingInfo{cpuOverhead, kernelRuntime};
+}
+} // namespace tc

--- a/tc/core/cuda/cuda_tc_executor_new_api.h
+++ b/tc/core/cuda/cuda_tc_executor_new_api.h
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "tc/core/cuda/cuda_backend.h"
+#include "tc/core/cuda/cuda_mapping_options.h"
+#include "tc/core/tc_executor.h"
+#include "tc/core/tensor.h"
+
+namespace tc {
+class CudaTcExecutor : public TcExecutor<CudaBackend> {
+ public:
+  CudaTcExecutor(
+      const std::vector<TensorInfo>& inputsInfo,
+      const std::vector<TensorInfo>& outputsInfo,
+      const tc2halide::HalideComponents& halideComponents,
+      const typename CudaBackend::CompilationResultType& compilationResult);
+
+  /// This is the "low-latency" mode in which we just propagate raw pointers to
+  /// data in the address space where kernel is executed.
+  /// No tensor-related information can be checked so it is the user's
+  /// responsibility to ensure that shapes and strides match. If the user
+  /// doesn't then segfault will likely occur.
+  void uncheckedRun(
+      const std::vector<const void*>& inputs,
+      const std::vector<void*>& outputs) const;
+
+  /// Calls uncheckedRun and profiles the cpu overhead and kernel runtime
+  /// (microseconds).
+  /// \returns profiling information (see: tc/core/utils/time.h)
+  ProfilingInfo profileUnchecked(
+      const std::vector<const void*>& inputs,
+      const std::vector<void*>& outputs) const;
+
+  const Grid& grid() const {
+    return grid_;
+  }
+
+  const Block& block() const {
+    return block_;
+  }
+
+ private:
+  // GPU-specific results of compilation
+  Grid grid_;
+  Block block_;
+};
+} // namespace tc

--- a/tc/core/tc_executor_new_api-inl.h
+++ b/tc/core/tc_executor_new_api-inl.h
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/core/tc_executor.h"
+
+#include <sstream>
+#include <string>
+
+#include "tc/core/compiler.h"
+#include "tc/core/flags.h"
+#include "tc/core/tensor.h"
+#include "tc/lang/canonicalize.h"
+
+namespace tc {
+namespace {
+int toTypeToken(DLDataType dtype) {
+  return lang::TypeInfo(lang::TypeInfo::Code(dtype.code), dtype.bits)
+      .toScalarToken();
+}
+
+template <typename DLTensorType, typename ParamType>
+void checkSizesAndStridesAreCompliant(
+    const std::vector<const DLTensorType*>& actualVec,
+    const std::vector<TensorInfo>& expectedVec,
+    const ParamType& dbg) {
+  if (actualVec.size() != expectedVec.size()) {
+    throw lang::ErrorReport(dbg)
+        << "expected " << expectedVec.size() << " parameters but found "
+        << actualVec.size() << " parameters";
+  }
+
+  for (size_t i = 0; i < actualVec.size(); ++i) {
+    auto actual = actualVec[i];
+    auto expected = expectedVec[i];
+    if (static_cast<size_t>(actual->ndim) != expected.shape.size()) {
+      throw lang::ErrorReport(dbg) << "expected " << expected.shape.size()
+                                   << " dimensions but found tensor with "
+                                   << actual->ndim << " dimensions";
+    }
+    auto atype = toTypeToken(actual->dtype);
+    auto etype = toTypeToken(expected.dtype);
+    if (atype != etype) {
+      throw lang::ErrorReport(dbg)
+          << "expected " << lang::kindToString(etype) << " for dim " << i
+          << " but found " << lang::kindToString(atype);
+    }
+    for (int ii = 0; ii < actual->ndim; ++ii) {
+      if (actual->shape[ii] != expected.shape[ii]) {
+        throw lang::ErrorReport(dbg)
+            << "expected size " << expected.shape[ii] << " for dim " << ii
+            << " but found " << actual->shape[ii];
+      }
+    }
+  }
+}
+} // namespace
+
+template <typename Backend>
+TcExecutor<Backend>::TcExecutor(
+    const std::vector<TensorInfo>& inputsInfo,
+    const std::vector<TensorInfo>& outputsInfo,
+    const tc2halide::HalideComponents& halideComponents,
+    const typename Backend::CompilationResultType& compilationResult)
+    : compiledSource(compilationResult.source),
+      inputsInfo_(inputsInfo),
+      outputsInfo_(outputsInfo),
+      halideComponents_(halideComponents),
+      // Parameters (currently) depend on compileWithTcMapper but are
+      // not backend-specific, so we store them in the executor
+      // TODO: revisit this later once we have strides and parametric kernels
+      // with more legitimate uses of parameters.
+      parameters_(compilationResult.parameters) {}
+
+namespace detail {
+inline std::pair<std::vector<const void*>, std::vector<void*>> prepareRun(
+    const std::vector<const DLConstTensor*>& inputs,
+    const std::vector<const DLTensor*>& outputs,
+    const std::vector<TensorInfo>& inputsInfo,
+    const std::vector<TensorInfo>& outputsInfo,
+    const tc2halide::HalideComponents& halideComponents) {
+  std::vector<const void*> rawInputs;
+  std::vector<void*> rawOutputs;
+  checkSizesAndStridesAreCompliant(
+      inputs, inputsInfo, halideComponents.getDef().params());
+  checkSizesAndStridesAreCompliant(
+      outputs, outputsInfo, halideComponents.getDef().returns());
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    rawInputs.push_back(inputs[i]->data);
+  }
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    rawOutputs.push_back(outputs[i]->data);
+  }
+  return std::make_pair(rawInputs, rawOutputs);
+}
+} // namespace detail
+
+template <typename Backend>
+void TcExecutor<Backend>::run(
+    const std::vector<const DLConstTensor*>& inputs,
+    const std::vector<const DLTensor*>& outputs) const {
+  std::vector<const void*> rawInputs;
+  std::vector<void*> rawOutputs;
+  std::tie(rawInputs, rawOutputs) = detail::prepareRun(
+      inputs, outputs, inputsInfo_, outputsInfo_, halideComponents_);
+
+  // Static dispatch instead of virtual functions requires this cast.
+  static_cast<const typename Backend::ExecutorType&>(*this).uncheckedRun(
+      rawInputs, rawOutputs);
+}
+
+template <typename Backend>
+ProfilingInfo TcExecutor<Backend>::profile(
+    const std::vector<const DLConstTensor*>& inputs,
+    const std::vector<const DLTensor*>& outputs) const {
+  auto start = std::chrono::system_clock::now();
+  std::vector<const void*> rawInputs;
+  std::vector<void*> rawOutputs;
+  std::tie(rawInputs, rawOutputs) = detail::prepareRun(
+      inputs, outputs, inputsInfo_, outputsInfo_, halideComponents_);
+
+  // Launch kernel and get **the kernel** time (without CPU overhead)
+  ProfilingInfo pi(
+      // Static dispatch instead of virtual functions requires this cast.
+      static_cast<const typename Backend::ExecutorType&>(*this)
+          .profileUnchecked(rawInputs, rawOutputs));
+
+  // The total CPU overhead is the total time minus the (synchronized) kernel
+  // runtime
+  auto end = std::chrono::system_clock::now();
+  Duration cpuOverhead(end - start);
+  cpuOverhead = cpuOverhead - pi.kernelRuntime;
+  return ProfilingInfo{cpuOverhead, pi.kernelRuntime};
+}
+
+template <typename Backend>
+void TcExecutor<Backend>::clearRuntimeCompiledFunction() {
+  if (!rtcFun_.get()) {
+    return;
+  }
+  rtcFun_->clear();
+  rtcFun_ = nullptr;
+}
+} // namespace tc

--- a/tc/core/tc_executor_new_api.h
+++ b/tc/core/tc_executor_new_api.h
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "tc/core/tc2halide.h"
+#include "tc/core/tensor.h"
+#include "tc/core/utils/time.h"
+#include "tc/lang/tree.h"
+
+namespace tc {
+/**
+ * TcExecutor is a backend-agnostic abstraction that provides the base
+ * functionality for an object returned by compilation to run.
+ * TcExecutor is templated by the Backend type.
+ * When a derived executor inherits from TcExecutor<Backend>, it
+ * provides support for running a compiled TC on the particular backend.
+ *
+ * A TcExecutor mixes templating and inheritance:
+ *   1. templating is necessary because we want type-safety with proper
+ *      dependent types (e.g. Backend::CompilationResultType)
+ *   2. inheritance is necessary because executors require common partial
+ *      information (e.g. inputsInfo and outputsInfo for shape checks) as well
+ *      as specific additional information for running on different backends
+ *      (e.g. Grid/Block for CUDA)
+ *   3. virtual functions combined with templates seem to be more confusing to
+ *      people so we don't use them here. Still derived classes of
+ *      TcExecutor<Backend> **must** implement the following functions (or
+ *      errors will occur at **all call sites**):
+ *
+ *      void uncheckedRun(
+ *          const std::vector<const void*>& inputs,
+ *          const std::vector<void*>& outputs) const;
+ *
+ *      ProfilingInfo profileUnchecked(
+ *          const std::vector<const void*>& inputs,
+ *          const std::vector<void*>& outputs) const;
+ *
+ * As a reminder: for each backend, the specific Backend type lives in
+ *   core/backendname/backendname_backend.h and declares all the required
+ *   dependent **derived** types.
+ * For example:
+ *   CudaBackend is declared in core/cuda/cuda_backend.h
+ *
+ * struct CudaBackend {
+ *   using ExecutorType = CudaTcExecutor;
+ *   using MappingOptionsType = CudaMappingOptions;
+ *   using CompilationResultType = CudaCompilationResult;
+ *   using RTCFunctionType = CudaRTCFunction;
+ * };
+ *
+ * The correspondence is 1 TcExecutor for 1 compiled
+ *   tuple<TC function, input shapes, Backend::MappingOptions>.
+ */
+template <typename Backend>
+class TcExecutor {
+ protected:
+  TcExecutor(
+      const std::vector<TensorInfo>& inputsInfo,
+      const std::vector<TensorInfo>& outputsInfo,
+      const tc2halide::HalideComponents& halideComponents,
+      const typename Backend::CompilationResultType& compilationResult);
+
+ public:
+  TcExecutor(TcExecutor&&) = delete;
+  TcExecutor& operator=(TcExecutor&&) = delete;
+  TcExecutor(const TcExecutor&) = delete;
+  TcExecutor& operator=(const TcExecutor&) = delete;
+
+  /// Run can be called multiple times on an executor, inputs are allowed
+  /// to change in that their data pointer is allowed to change.
+  /// Sizes and strides must remain constant otherwise this is an error.
+  /// The only thing that is allowed to change across runs is the input
+  /// and output pointers base address.
+  /// It is the caller's responsibility to ensure proper non-aliasing (or
+  /// advanced aliasing) properties of the input and output tensors.
+  void run(
+      const std::vector<const DLConstTensor*>& inputs,
+      const std::vector<const DLTensor*>& outputs) const;
+
+  /// Calls run and profiles the cpu overhead and kernel runtime (microseconds).
+  /// \returns profiling information
+  ProfilingInfo profile(
+      const std::vector<const DLConstTensor*>& inputs,
+      const std::vector<const DLTensor*>& outputs) const;
+
+  /// It may be necessary to clear the RTC manually because it can throw and
+  /// we can't have that in the RTC destructor.
+  void clearRuntimeCompiledFunction();
+
+ public:
+  // For inspection purposes
+  const std::string compiledSource;
+
+ protected:
+  /// Used to check proper metadata when calling run
+  ///@{
+  std::vector<TensorInfo> inputsInfo_;
+  std::vector<TensorInfo> outputsInfo_;
+  tc2halide::HalideComponents halideComponents_;
+  ///@}
+
+  /// The following are initialized as a result of compilation with the TcMapper
+  ///@{
+  std::vector<long> parameters_;
+  std::unique_ptr<typename Backend::RTCFunctionType> rtcFun_;
+  ///@}
+};
+} // namespace tc
+
+#include "tc/core/tc_executor-inl.h"


### PR DESCRIPTION
This PR adds the files implementing the TcExecutor API (#323) on
top of the new compiler API (#322). The ExecutionEngine has been retired
and the TcExecutor reflects this.

TcExecutor is a backend-agnostic abstraction that is the result of compilation
(see #322). When a concrete executor specializes TcExecutor it provides support
for running a compiled TC on the particular backend.

Specializing a TcExecutor consists in implementing (not overriding) 2 methods:
1. uncheckedRun provides the low-latency path on void* data
2. setupRuntimeCompiledFunction takes the result of compileWithTcMapper to:
  a. save backend-specific information required at runtime (e.g. grid and block
     sizes for the CUDA backend)
  b. create the in-memory object resulting from JIT-compilation that implements
     the TC

Note that the CPU implementation is currently just a stub that only forcibly
prints to screen. This allows a simple sanity check in the branch
`pr/big-refactor` that compiles without CUDA and prints the proper steps.
Implementation for the CPU will come once the refactoring has landed.

The reason the consensus went for implementing (and not overriding) in #323 is
that mixing CRTP at a distance via the Backend type with inheritance was
confusing. More specifically:

```
Since people may get confused by mixing CRTP and virtual functions I am fine
using the type of static dispatch @ftynse propose in order to remove virtual
functions:

static_cast<Backend::ExecutorType*>(this)->uncheckedRun();

The tradeoff is that one will get error at the call sites with much more
complex error messages than with virtual functions.
I am personally more favorable to virtual functions (original proposal)
because error messages will pop up at the definition site in the abstract
base class but I can also see that mixing the two makes it more difficult
to understand what happens.
```

As part of the bigger refactoring, these files are not yet activated
(or even compiled) therefore the changeset cannot be tested independently.
This new implementation will be switched in as part of the last commit of the global refactoring.