### PR TITLE
Cleanup cache .cuda artifacts and more fixes to python test

### DIFF
--- a/docs/source/framework/pytorch_integration/autograd_with_tc.rst
+++ b/docs/source/framework/pytorch_integration/autograd_with_tc.rst
@@ -114,8 +114,8 @@ Let's see how to cache options to file when we tune a training layer.
      out = convolution(I, W)
      out[0].sum().backward()
 
-You will find two cache files created: :code:`convolution_train.cuda/options` has
-options for the forward layer and :code:`convolution_train_backward.cuda/options` file
+You will find a cache file created: :code:`convolution_train.options` has
+options for the forward layer and :code:`convolution_train_backward.options` file
 has options for the grad layer.
 
 Reordering grad outputs

--- a/docs/source/framework/pytorch_integration/autotuning_layers.rst
+++ b/docs/source/framework/pytorch_integration/autotuning_layers.rst
@@ -219,7 +219,7 @@ For example:
 tc.decode
 ---------
 
-When you save the autotuner cache, two files are created ending in :code:`.cuda/.options`.
+When you save the autotuner cache, one file is created ending in :code:`.options`.
 The :code:`.options` file contains the encoded kernel options. If you are curious
 about what those options look like, you can decode the options by calling :code:`tc.decode`
 

--- a/tc/autotuner/genetic_autotuner.cc
+++ b/tc/autotuner/genetic_autotuner.cc
@@ -53,8 +53,7 @@ void GeneticAutotuner::storeCaches(const std::string& filename) {
   if (filename.empty()) {
     std::cout << "No filepath provided, not saving cache" << std::endl;
   } else {
-    std::cout << "Dumping cache to " << filename << ".cuda/options"
-              << std::endl;
+    std::cout << "Dumping cache to " << filename << ".options" << std::endl;
     tc::OptionsCache::getCache()->keepOnlyBestCandidates(
         tc::FLAGS_tuner_save_best_candidates_count);
     tc::OptionsCache::dumpCacheToProtobuf(tc::makeOptionsFilename(filename));
@@ -69,7 +68,7 @@ std::vector<CudaMappingOptions> GeneticAutotuner::load(
     const std::vector<const DLTensor*>& inputs,
     const size_t numCandidates) {
   std::cout << "Loading proto from: " << tc::makeOptionsFilename(cacheFileName)
-            << " and " << tc::makeCudaFilename(cacheFileName) << std::endl;
+            << std::endl;
   enableOrLoadCache(cacheFileName);
   tc::FLAGS_tuner_gen_restore_number =
       std::min(numCandidates, size_t(FLAGS_tuner_gen_pop_size) - 1);
@@ -141,7 +140,7 @@ llvm::Optional<CudaMappingOptions> GeneticAutotuner::tune(
       tuner.run(FLAGS_tuner_gen_generations);
     } catch (const std::exception& e) {
       std::cerr << "Exception during autotuning: " << e.what()
-                << "\n dumping cache to " << cacheFileName << ".cuda/options"
+                << "\n dumping cache to " << cacheFileName << ".options"
                 << std::endl;
       storeCaches(cacheFileName);
       tunerThreadEx = std::current_exception();

--- a/tc/benchmarks/benchmark_fixture.h
+++ b/tc/benchmarks/benchmark_fixture.h
@@ -255,8 +255,7 @@ struct Benchmark : public ::testing::Test {
         return true;
       }) {
     std::cout << "Validating proto from: "
-              << tc::makeOptionsFilename(cacheFilename) << "and "
-              << tc::makeCudaFilename(cacheFilename) << std::endl;
+              << tc::makeOptionsFilename(cacheFilename) << std::endl;
 
     tc::OptionsCache::enableCache();
     tc::OptionsCache::loadCacheFromProtobuf(cacheFilename + ".options");

--- a/tc/core/compilation_cache.h
+++ b/tc/core/compilation_cache.h
@@ -101,7 +101,4 @@ inline std::string makeOptionsFilename(const std::string& filename) {
   return filename + ".options";
 }
 
-inline std::string makeCudaFilename(const std::string& filename) {
-  return filename + ".cuda";
-}
 } // namespace tc

--- a/test_python/layers/test_autotuner.py
+++ b/test_python/layers/test_autotuner.py
@@ -105,7 +105,7 @@ class TestAutotuner(unittest.TestCase):
     def test_autotuner_cachefile_load(self):
         lang = MATMUL_LANG
         cache_file = "{}/matmul_100_400_500".format(PATH_PREFIX)    # use argparse if input from command line
-        assert os.path.isfile("{}.cuda".format(cache_file)), "looks like the cache_file doesn't exist"
+        assert os.path.isfile("{}.options".format(cache_file)), "looks like the cache_file doesn't exist"
 
         matmul = tc.define(lang, name="matmul")
         mat1, mat2 = torch.randn(100, 400).cuda(), torch.randn(400, 500).cuda()


### PR DESCRIPTION
cleaning up more cache .cuda artifacts left in codebase and docs. Also fixing python test more. I stumbled upon these while debugging CI more. Hopefully these are last set of changes to help bring back CI

partially helps #338 