### PR TITLE
[C++ API] Step 7: Add files for the refactored autotuner

### DIFF
--- a/tc/autotuner/autotuner-inl.h
+++ b/tc/autotuner/autotuner-inl.h
@@ -1,0 +1,538 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tc/autotuner/autotuner.h"
+
+#include <atomic>
+#include <chrono>
+#include <numeric>
+#include <thread>
+
+#include <glog/stl_logging.h>
+
+#include "tc/autotuner/utils.h"
+#include "tc/core/compiler.h"
+#include "tc/core/flags.h"
+#include "tc/core/scope_guard.h"
+#include "tc/core/tensor.h"
+#include "tc/core/utils/math.h"
+#include "tc/lang/canonicalize.h"
+
+namespace tc {
+namespace autotune {
+namespace detail {
+template <typename Backend>
+TuningHarness<Backend>::TuningHarness(
+    size_t maxPopulationSize,
+    lang::TreeRef tcTree,
+    const std::unordered_map<size_t, std::vector<const DLConstTensor*>>& inputs,
+    std::unordered_map<size_t, std::vector<const DLTensor*>>& outputs,
+    const typename Backend::MappingOptionsType& baseMapping,
+    const TuningParameterFixer& fixedParams,
+    std::shared_ptr<OptionsCache<Backend>> optionsCache)
+    : stopRequested_(false),
+      currentCompilationJob_(0),
+      numEvaluations_(0),
+      tcTree_(tcTree),
+      kBaseMapping_(baseMapping),
+      kInputs_(inputs),
+      outputs_(outputs),
+      bestTime_(std::numeric_limits<size_t>::max()),
+      bestMappingOptions_(baseMapping),
+      optionsCache_(optionsCache) {}
+
+template <typename Backend>
+template <typename SearchStrategy>
+void TuningHarness<Backend>::run(SearchStrategy& searchStrategy) {
+  // TODO: kNumGenerations -> iterations
+  for (size_t i = 0; i < searchStrategy.kNumGenerations; ++i) {
+    if (not stopRequested_) {
+      runOneIteration(searchStrategy, i);
+    }
+  }
+}
+
+template <typename Backend>
+void TuningHarness<Backend>::stopAfterCurrentIteration() {
+  stopRequested_ = true;
+}
+
+template <typename Backend>
+const typename Backend::MappingOptionsType&
+TuningHarness<Backend>::bestMappingOptions() const {
+  std::lock_guard<std::mutex> lock(bestTimeMutex_);
+  return bestMappingOptions_;
+}
+
+#define LOG_LINE_BY_LINE(GSTREAM, ISTREAM)               \
+  for (std::string line; std::getline(ISTREAM, line);) { \
+    LOG(GSTREAM) << line;                                \
+  }
+
+template <typename Backend>
+template <typename SearchStrategy>
+void TuningHarness<Backend>::doCompile(SearchStrategy& searchStrategy) {
+  // Atomically fetch and add the next job until there are no jobs left
+  while (true) {
+    auto current = currentCompilationJob_.fetch_add(1);
+    if (current >= searchStrategy.population.size()) {
+      break;
+    }
+    std::unique_ptr<typename Backend::ExecutorType> pExecutor(nullptr);
+    auto pConf = searchStrategy.population.at(current).get();
+    auto options = makeOptions<Backend>(kBaseMapping_, *pConf);
+    try {
+      if (FLAGS_debug_tuner) {
+        std::stringstream ssInfo;
+        typename Backend::MappingOptionsCppPrinter infoPrinter(ssInfo);
+        infoPrinter << options;
+        LOG(INFO) << "[COMPILE] Start compilation @:" << current;
+        LOG_LINE_BY_LINE(INFO, ssInfo);
+      }
+      pExecutor =
+          tc::compile<Backend>(tcTree_, kInputs_.begin()->second, options);
+      LOG_IF(INFO, FLAGS_debug_tuner) << "[COMPILE] Done compilation";
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "[TUNER][COMPILE] failed compilation: " << e.what();
+      std::stringstream ssWarning;
+      typename Backend::MappingOptionsCppPrinter warningPrinter(ssWarning);
+      warningPrinter << options;
+      LOG_LINE_BY_LINE(WARNING, ssWarning);
+      pConf->invalid = true;
+    }
+
+    // Emplace pExecutor (nullptr if compilation failed)
+    std::lock_guard<std::mutex> lock(executorsMutex_);
+    executors_.push(std::move(pExecutor));
+    configurations_.push(pConf);
+  }
+}
+
+template <typename Backend>
+void TuningHarness<Backend>::doEvaluate(
+    size_t device,
+    size_t populationSize,
+    Printer& printer) {
+  typename Backend::WithDevice wd(device);
+  CHECK_EQ(1, kInputs_.count(device));
+  auto& inputs = kInputs_.at(device);
+  CHECK_EQ(1, outputs_.count(device));
+  auto& outputs = outputs_.at(device);
+
+  while (true) {
+    auto current = numEvaluations_.load();
+    if (current >= populationSize) {
+      // We have seen enough, exit
+      break;
+    }
+
+    CandidateConfiguration* pConf;
+    std::unique_ptr<typename Backend::ExecutorType> pExecutor;
+    {
+      std::lock_guard<std::mutex> lock(executorsMutex_);
+      if (executors_.size() == 0) {
+        // No executors atm, wait for the queue to populate
+        continue;
+      }
+      pExecutor = std::move(executors_.front());
+      executors_.pop();
+      pConf = configurations_.front();
+      configurations_.pop();
+    }
+
+    // Properly keep track of count, RAII way
+    ScopeGuard sg([this]() { this->numEvaluations_.fetch_add(1); });
+    if (!pExecutor.get()) {
+      // If I popped an empty executor then compilation didn't go as
+      // planned, skip it.
+      CHECK(pConf->invalid);
+      continue;
+    }
+
+    auto options = makeOptions<Backend>(kBaseMapping_, *pConf);
+    if (FLAGS_debug_tuner) {
+      // Always log option to INFO so we can correlate to timing offline
+      std::stringstream ssInfo;
+      ssInfo << "Launch device kernel on device: " << std::to_string(device)
+             << " options:\n"
+             << typename Backend::MappingOptionsAsCpp(options);
+      LOG_LINE_BY_LINE(INFO, ssInfo);
+    }
+
+    std::vector<Duration> runtimes;
+    try {
+      size_t bestTimeSoFar;
+      {
+        std::lock_guard<std::mutex> lock(bestTimeMutex_);
+        bestTimeSoFar = bestTime_;
+      }
+      auto prune = detail::skipExecutionOrWarmup<Backend>(
+          *pExecutor, outputs, inputs, bestTimeSoFar);
+      if (prune) {
+        pConf->invalid = true;
+        continue;
+      } else {
+        /// We don't want the autotuner to take too long evaluating, we just
+        /// need to *rank* the results.
+        constexpr int kReducedBenchmarkIterations = 10;
+        runtimes.reserve(kReducedBenchmarkIterations);
+        for (size_t i = 0; i < kReducedBenchmarkIterations; ++i) {
+          auto timings = pExecutor->profile(inputs, outputs);
+          if (timings.kernelRuntime.count() > 0) {
+            runtimes.push_back(timings.kernelRuntime);
+          }
+        }
+      }
+    } catch (std::exception& e) {
+      LOG(WARNING) << "Runtime error device " << device << ": " << e.what();
+      std::stringstream ssWarning;
+      typename Backend::MappingOptionsCppPrinter warningPrinter(ssWarning);
+      warningPrinter << options;
+      LOG(WARNING) << "Aborted execution on device " << device;
+      LOG_LINE_BY_LINE(WARNING, ssWarning);
+      handleDeviceRuntimeError<Backend>(device, options);
+      pConf->invalid = true;
+      continue;
+    }
+
+    if (runtimes.size() == 0u) {
+      pConf->invalid = true;
+      return;
+    }
+
+    auto prof = median(runtimes);
+    size_t profUs = prof.count();
+
+    LOG_IF(INFO, tc::FLAGS_debug_tuner)
+        << "Run on device " << device << " took: " << profUs << "us";
+    printer.record(prof);
+    pConf->runtime = prof;
+
+    optionsCache_->recordRuntime(
+        lang::canonicalTc(tcTree_),
+        makeTensorInfoVector(inputs),
+        makeTensorInfoVector(outputs),
+        Backend::deviceString(),
+        options,
+        prof);
+
+    // Save best time under lock
+    {
+      std::lock_guard<std::mutex> lock(bestTimeMutex_);
+      if (profUs < bestTime_) {
+        bestTime_ = profUs;
+        bestMappingOptions_ = options;
+      }
+    }
+  } // end while
+}
+
+template <typename Backend>
+template <typename SearchStrategy>
+void TuningHarness<Backend>::runOneIteration(
+    SearchStrategy& searchStrategy,
+    size_t iteration) {
+  // Define tensors per device once globally
+  auto devices = detail::parseDevices<Backend>(FLAGS_tuner_devices);
+  CHECK(executors_.empty());
+  CHECK(configurations_.empty());
+
+  {
+    // Initialize for this round
+    currentCompilationJob_.store(0);
+    numEvaluations_.store(0);
+    Printer printer(
+        iteration,
+        searchStrategy.population.size(),
+        currentCompilationJob_,
+        numEvaluations_);
+    auto logIterations = FLAGS_tuner_gen_log_generations;
+    ScopeGuard sgPrinter([logIterations, &printer]() {
+      printer.stop();
+      if (logIterations) {
+        printer.printAll();
+      }
+    });
+
+    // Just spawn and join new threads for each iteration
+    std::vector<std::thread> cpuCompilationThreads;
+    cpuCompilationThreads.reserve(FLAGS_tuner_threads);
+    ScopeGuard sgCompilationThreads([&cpuCompilationThreads]() {
+      for (auto& cpuCompilationThread : cpuCompilationThreads) {
+        cpuCompilationThread.join();
+      }
+    });
+    for (size_t i = 0; i < FLAGS_tuner_threads; ++i) {
+      cpuCompilationThreads.emplace_back(
+          [this, &searchStrategy]() { this->doCompile(searchStrategy); });
+    }
+
+    // Just spawn and join new threads for each iteration
+    std::vector<std::thread> workerThreads;
+    workerThreads.reserve(devices.size());
+    LOG_IF(INFO, tc::FLAGS_debug_tuner)
+        << "Start evaluation: " << devices.size() << " " << executors_.size()
+        << " " << configurations_.size();
+    ScopeGuard sgDeviceWorkerThreads([&workerThreads]() {
+      for (auto& workerThread : workerThreads) {
+        workerThread.join();
+      }
+    });
+    auto populationSize = searchStrategy.population.size();
+    for (auto device : devices) {
+      workerThreads.emplace_back([this, device, populationSize, &printer]() {
+        this->doEvaluate(device, populationSize, printer);
+      });
+    }
+  }
+
+  // At this point everything is synchronized because out of scope, done
+  if (FLAGS_debug_tuner || FLAGS_tuner_print_best) {
+    LOG(INFO) << "[TUNER][ITERATION LOG] best option so far:";
+    std::stringstream ssInfo;
+    typename Backend::MappingOptionsCppPrinter infoPrinter(ssInfo);
+    infoPrinter << bestMappingOptions();
+    LOG_LINE_BY_LINE(INFO, ssInfo);
+  }
+  searchStrategy.updateParameters();
+}
+} // namespace detail
+
+namespace {
+volatile std::sig_atomic_t sigint_ = 0;
+volatile std::sig_atomic_t sigterm_ = 0;
+
+template <typename Backend>
+std::vector<typename Backend::MappingOptionsType> loadThroughCache(
+    lang::TreeRef tree,
+    std::shared_ptr<OptionsCache<Backend>> optionsCache,
+    const std::string& cacheFileName,
+    const std::vector<const DLConstTensor*>& inputs,
+    const size_t numCandidates) {
+  LOG_IF(INFO, FLAGS_debug_tuner)
+      << "Loading proto from: " << tc::makeOptionsFilename(cacheFileName)
+      << std::endl;
+  if (!cacheFileName.empty()) {
+    optionsCache->loadCacheFromFile(tc::makeOptionsFilename(cacheFileName));
+  }
+  auto outputs = tc::detail::inferOutputTensorInfo(tree, inputs);
+  return optionsCache->getTopKOptions(
+      canonicalTc(tree),
+      makeTensorInfoVector(inputs),
+      outputs,
+      Backend::deviceString(),
+      numCandidates);
+}
+
+template <typename Backend>
+void storeTopKInCache(
+    const std::shared_ptr<OptionsCache<Backend>>& optionsCache,
+    const std::string& cacheFilename) {
+  if (cacheFilename.empty()) {
+    LOG_IF(INFO, FLAGS_debug_tuner)
+        << "No filepath provided, not saving cache" << std::endl;
+  } else {
+    LOG_IF(INFO, FLAGS_debug_tuner)
+        << "Dumping cache to " << tc::makeOptionsFilename(cacheFilename)
+        << std::endl;
+    OptionsCache<Backend> cache(*optionsCache);
+    cache.pruneKeepTopK(tc::FLAGS_tuner_save_best_candidates_count);
+    cache.storeCacheToFile(tc::makeOptionsFilename(cacheFilename));
+  }
+}
+
+void removeDuplicates(std::vector<size_t>& v) {
+  std::sort(v.begin(), v.end());
+  v.erase(std::unique(v.begin(), v.end()), v.end());
+}
+
+std::vector<size_t> inputDivisorsAndPowers2(
+    const std::vector<const DLConstTensor*>& inputs) {
+  std::vector<size_t> sizes;
+  for (const auto& input : inputs) {
+    for (int i = 0; i < input->ndim; i++) {
+      sizes.push_back(input->shape[i]);
+    }
+  }
+  removeDuplicates(sizes);
+  std::vector<size_t> divsAndPows;
+  for (auto size : sizes) {
+    divsAndPows =
+        mergeVectors(std::move(divsAndPows), powers2andCeilDivisors(size));
+  }
+  divsAndPows =
+      mergeVectors(std::move(divsAndPows), powers2andCeilDivisors(256));
+  return divsAndPows;
+}
+
+size_t largestDim(const std::vector<const DLConstTensor*>& inputs) {
+  CHECK_GE(inputs.size(), 1u);
+  auto maxElement = std::max_element(
+      inputs.begin(),
+      inputs.end(),
+      [](const DLConstTensor* a, const DLConstTensor* b) {
+        return a->ndim < b->ndim;
+      });
+  return (*maxElement)->ndim;
+}
+
+// Creates well-chosen parameter sizes to match the input shapes.
+void setupTuningParameters(
+    const std::vector<const DLConstTensor*>& inputs,
+    TuningConfiguration& configuration) {
+  CHECK_GE(inputs.size(), 1);
+  auto range = inputDivisorsAndPowers2(inputs);
+  // 0 is a valid tiling annotation and signals no tiling of that dimension
+  // 0 is not a valid block / grid annotation
+  auto nTilesDim = largestDim(inputs) + 1;
+  auto tileRange = range;
+  tileRange.push_back(0);
+  configuration.tilingParams.setRange(nTilesDim, range);
+  configuration.blockParams.setRange(range, "b");
+  configuration.gridParams.setRange(range, "g");
+  configuration.unrollFactor = RangeParameter({1, 2, 4, 8, 16, 32}, "unroll");
+}
+} // namespace
+
+template <typename Backend, typename SearchStrategy>
+Autotuner<Backend, SearchStrategy>::Autotuner()
+    : optionsCache_(new OptionsCache<Backend>()) {}
+
+template <typename Backend, typename SearchStrategy>
+std::vector<typename Backend::MappingOptionsType>
+Autotuner<Backend, SearchStrategy>::tune(
+    const std::string& tc,
+    const std::string& tcEntryPoint,
+    const std::unordered_map<size_t, std::vector<const DLConstTensor*>>& inputs,
+    std::unordered_map<size_t, std::vector<const DLTensor*>>& outputs,
+    const typename Backend::MappingOptionsType& baseMapping,
+    const std::string& cacheFileName,
+    const TuningParameterFixer& fixedParams) {
+  std::map<std::string, lang::TreeRef> tcEntryPointMap(tc::detail::parse(tc));
+  CHECK_EQ(1, tcEntryPointMap.count(tcEntryPoint))
+      << "Error looking up " << tcEntryPoint;
+
+  // Initialize a model configuration
+  TuningConfiguration modelConfiguration;
+  CHECK_GE(inputs.size(), 1u);
+  setupTuningParameters(inputs.begin()->second, modelConfiguration);
+  modelConfiguration.fixParameters(fixedParams);
+
+  // Build starting points from baseMapping + whatever we recover from cache
+  std::vector<typename Backend::MappingOptionsType> startingPoints{baseMapping};
+  auto restoredCandidates = loadThroughCache<Backend>(
+      tcEntryPointMap.at(tcEntryPoint),
+      optionsCache_,
+      cacheFileName,
+      inputs.begin()->second,
+      FLAGS_tuner_gen_restore_number);
+  if (restoredCandidates.size() > 0) {
+    startingPoints.reserve(1 + restoredCandidates.size());
+    std::move(
+        restoredCandidates.begin(),
+        restoredCandidates.end(),
+        std::back_inserter(startingPoints));
+  }
+
+  // Create initial configs based on options + model configuration
+  std::vector<TuningConfiguration> configs;
+  configs.reserve(startingPoints.size());
+  std::transform(
+      startingPoints.begin(),
+      startingPoints.end(),
+      std::back_inserter(configs),
+      [this, &fixedParams, &modelConfiguration](
+          const typename Backend::MappingOptionsType& options) {
+        auto config = detail::makeTuningConfiguration<Backend>(
+            options, modelConfiguration);
+        config.fixParameters(fixedParams);
+        return config;
+      });
+
+  // searchStrategy is passed to tuningHarness.run()
+  SearchStrategy searchStrategy(
+      configs,
+      FLAGS_tuner_gen_generations,
+      FLAGS_tuner_gen_pop_size,
+      FLAGS_tuner_gen_crossover_rate,
+      FLAGS_tuner_gen_mutation_rate,
+      FLAGS_tuner_gen_number_elites);
+
+  // Create a tuning harness
+  detail::TuningHarness<Backend> tuningHarness(
+      FLAGS_tuner_gen_pop_size,
+      tcEntryPointMap.at(tcEntryPoint),
+      inputs,
+      outputs,
+      baseMapping,
+      fixedParams,
+      optionsCache_);
+
+  // Setup handlers
+  sigterm_ = 0;
+  sigint_ = 0;
+  auto sigtermOrigHandler = std::signal(SIGTERM, [](int) { sigterm_ = 1; });
+  auto sigintOrigHandler = std::signal(SIGINT, [](int) { sigint_ = 1; });
+  ScopeGuard handlersGuard([&]() {
+    std::signal(SIGTERM, sigtermOrigHandler);
+    std::signal(SIGINT, sigintOrigHandler);
+  });
+
+  // Run harness in a separate thread
+  std::atomic_bool tuningHarnessFinished(false);
+  std::exception_ptr tuningHarnessThreadEx = nullptr;
+  std::thread tuningHarnessThread([&]() {
+    try {
+      tuningHarness.run(searchStrategy);
+    } catch (const std::exception& e) {
+      std::cerr << "Exception during autotuning: " << e.what()
+                << "\n dumping cache to "
+                << tc::makeOptionsFilename(cacheFileName) << "/"
+                << Backend::makeDeviceFilename(cacheFileName) << std::endl;
+      storeTopKInCache<Backend>(optionsCache_, cacheFileName);
+      tuningHarnessThreadEx = std::current_exception();
+    }
+    tuningHarnessFinished = true;
+  });
+  while (not tuningHarnessFinished) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (sigint_) {
+      std::cerr
+          << "Autotuning will stop after the current iteration has finished."
+          << std::endl;
+      tuningHarness.stopAfterCurrentIteration();
+      tuningHarnessThread.join();
+      storeTopKInCache<Backend>(optionsCache_, cacheFileName);
+    }
+    if (sigterm_) {
+      std::cerr << "Autotuning aborted." << std::endl;
+      storeTopKInCache<Backend>(optionsCache_, cacheFileName);
+      std::abort();
+    }
+  }
+
+  tuningHarnessThread.join();
+
+  if (tuningHarnessThreadEx) {
+    std::rethrow_exception(tuningHarnessThreadEx);
+  }
+
+  storeTopKInCache<Backend>(optionsCache_, cacheFileName);
+
+  return {tuningHarness.bestMappingOptions()};
+}
+} // namespace autotune
+} // namespace tc

--- a/tc/autotuner/autotuner.h
+++ b/tc/autotuner/autotuner.h
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <atomic>
+#include <csignal>
+#include <memory>
+#include <queue>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "tc/autotuner/genetic_search.h"
+#include "tc/autotuner/options_cache.h"
+#include "tc/autotuner/parameters.h"
+#include "tc/autotuner/utils.h"
+#include "tc/core/tensor.h"
+#include "tc/core/utils/time.h"
+#include "tc/lang/parser.h"
+
+namespace tc {
+namespace autotune {
+
+namespace detail {
+/**
+ * Internal harness to support multithreaded compilation and evaluation over
+ * various backends for a particular SearchStrategy.
+ * The SearchStrategy is a template parameter passed to the run method.
+ */
+template <typename Backend>
+class TuningHarness {
+ public:
+  using ExecutorType = typename Backend::ExecutorType;
+  using MappingOptionsType = typename Backend::MappingOptionsType;
+  using OptionsCacheType = OptionsCache<Backend>;
+
+  TuningHarness(
+      size_t maxPopulationSize,
+      lang::TreeRef tcTree,
+      const std::unordered_map<size_t, std::vector<const DLConstTensor*>>&
+          inputs,
+      std::unordered_map<size_t, std::vector<const DLTensor*>>& outputs,
+      const MappingOptionsType& baseMapping,
+      const TuningParameterFixer& fixedParams,
+      std::shared_ptr<OptionsCache<Backend>> optionsCache);
+
+  /// Runs a SearchStrategy
+  template <typename SearchStrategy>
+  void run(SearchStrategy& searchStrategy);
+
+  /// Once a signal has been caught, a flag is set and we terminate after the
+  /// current iteration is finished. This is apparently necessary for proper
+  /// python termination.
+  /// TODO: we should detect when we come from python and exit properly in C++.
+  void stopAfterCurrentIteration();
+
+  /// Under lock, returns the best mapping options found so far
+  const MappingOptionsType& bestMappingOptions() const;
+
+ private:
+  /// Traverse one iteration of candidates in parallel and evaluate their
+  /// runtimes
+  template <typename SearchStrategy>
+  void runOneIteration(SearchStrategy& searchStrategy, size_t iteration);
+
+  /// Helper function to delegate compiling on the cpu to different threads
+  template <typename SearchStrategy>
+  void doCompile(SearchStrategy& searchStrategy);
+
+  /// Helper function to delegate running the compiled code to different
+  /// threads. This function must be specialized per Backend
+  void doEvaluate(size_t device, size_t populationSize, Printer& printer);
+
+  /// Synchronization related objects
+  /// The main invariant is that we always try to compile and evaluate
+  /// exactly searchStrategy->population.size() candidates.
+  /// If a candidate fails compilation we still add a null Executor so that
+  /// the invariant holds.
+  /// This way it is easy to implement multi-threaded termination by just
+  /// taking an atomic counter and pushing/popping the queues under lock until
+  /// we have evaluated searchStrategy->population.size() compilation results.
+  mutable std::mutex bestTimeMutex_;
+  std::mutex executorsMutex_;
+  std::atomic_bool stopRequested_;
+  std::atomic_size_t currentCompilationJob_;
+  std::atomic_size_t numEvaluations_;
+  std::queue<std::unique_ptr<ExecutorType>> executors_;
+  std::queue<CandidateConfiguration*> configurations_;
+
+  /// inputs
+  lang::TreeRef tcTree_;
+  const MappingOptionsType kBaseMapping_;
+  /// maps of inputs and outputs per device (represented by a size_t)
+  /// involved in autotuning. The client of the autotuner API must allocate
+  /// these properly on each device where autotuning evaluation needs to run.
+  /// In particular all the inputs and outputs must contain the same values
+  /// across devices for the purpose of running correctness checks during
+  /// tuning (future work).
+  const std::unordered_map<size_t, std::vector<const DLConstTensor*>> kInputs_;
+  std::unordered_map<size_t, std::vector<const DLTensor*>> outputs_;
+
+  // results
+  size_t bestTime_;
+  MappingOptionsType bestMappingOptions_;
+
+  // backing options cache
+  std::shared_ptr<OptionsCache<Backend>> optionsCache_;
+};
+} // namespace detail
+
+/**
+ * An Autotuner provides the basic interface to run a SearchStrategy over a
+ * particular Backend.
+ * Under the hood it instantiates a TuningHarness<Backend> and a
+ * SearchStrategy. The Autotuner then calls TuningHarness<Backend>::run()
+ * on the SearchStrategy.
+ */
+template <typename Backend, typename SearchStrategy>
+class Autotuner {
+ public:
+  using MappingOptionsType = typename Backend::MappingOptionsType;
+  using OptionsCacheType = tc::autotune::OptionsCache<Backend>;
+
+  Autotuner();
+
+  /// Runs autotuning on the TC function tcEntryPoint.
+  /// This assumes input and output tensors of proper sizes have been
+  /// initialized on each device. For now this initialization is left to the
+  /// client of the Autotuner.
+  /// Tuning performs a search of template type SearchStrategy starting from
+  /// baseMapping.
+  ///
+  /// Alternatively an OptionsCache cacheFileName serialized path
+  /// can be specified from which the tuner recovers multiple starting points
+  /// and appends to the baseMapping. This can be useful in a reinforcement
+  /// situation where short tunings are run and their results cached
+  /// iteratively.
+  ///
+  /// Lastly a TuningParameterFixer function can be specified to limit the
+  /// search space (i.e. when certain parameters are known to be good/bad
+  /// independently on a particular TC).
+  ///
+  /// \return a vector MappingOptions that is either empty or contains the
+  /// best options found. If it is empty then tuning did not find a single
+  /// good configuration. Empty return vector should be a very rare occurrence
+  /// but it is possible; in particular if the skipExecutionOrWarmup function
+  /// is too aggressive and the problem size is too small.
+  std::vector<MappingOptionsType> tune(
+      const std::string& tc,
+      const std::string& tcEntryPoint,
+      const std::unordered_map<size_t, std::vector<const DLConstTensor*>>&
+          inputs,
+      std::unordered_map<size_t, std::vector<const DLTensor*>>& outputs,
+      const MappingOptionsType& baseMapping,
+      const std::string& cacheFileName = "",
+      const TuningParameterFixer& fixedParams = TuningParameterFixer());
+
+ private:
+  std::shared_ptr<OptionsCache<Backend>> optionsCache_;
+};
+
+/// Helper functions that need specializing for various backends.
+/// The implementation is not set in stone but just a first approximation to
+/// break the CUDA dependence.
+///
+/// Always worth noting, "specializations don't overload", don't ever overload
+/// but only specialize the following functions. An alternative is to turn
+/// those functions into static methods of the specific Backend type but since
+/// they are only used for autotuning, it is unclear we want them to live in
+/// the backend at this point.
+namespace detail {
+template <typename Backend>
+typename Backend::MappingOptionsType makeOptions(
+    const typename Backend::MappingOptionsType& baseMapping,
+    const CandidateConfiguration& c);
+
+template <typename Backend>
+TuningConfiguration makeTuningConfiguration(
+    const typename Backend::MappingOptionsType& options,
+    const TuningConfiguration& configuration);
+
+template <typename Backend>
+void handleDeviceRuntimeError(
+    size_t device,
+    typename Backend::MappingOptionsType& options);
+
+/// Helper function to get a kernel into benchmark-able state.
+/// Some compiled kernels may result in catastrophically bad performance
+/// (e.g. when there are too few total threads in the case of CUDA).
+/// Information from polyhedral-JIT time can help detect some cases early.
+/// This function is an opportunity to take advantage of this information
+/// and it must be specialized for each Backend.
+///
+/// \return true if the execution should be skipped. If the function returns
+/// false then warmup has occured for the kernel and it is ready to be
+/// benchmarked.
+template <typename Backend>
+bool skipExecutionOrWarmup(
+    typename Backend::ExecutorType& executor,
+    const std::vector<const DLTensor*>& outputs,
+    const std::vector<const DLConstTensor*>& inputs,
+    size_t bestTimeSoFar);
+
+template <typename Backend>
+std::vector<size_t> parseDevices(const std::string& devices);
+} // namespace detail
+} // namespace autotune
+} // namespace tc
+
+#include "tc/autotuner/autotuner-inl.h"

--- a/tc/autotuner/cpu/autotuner.cc
+++ b/tc/autotuner/cpu/autotuner.cc
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tc/autotuner/autotuner.h"
+
+#include <atomic>
+#include <chrono>
+#include <numeric>
+#include <thread>
+
+#include <glog/stl_logging.h>
+
+#include "tc/autotuner/utils.h"
+#include "tc/core/compiler.h"
+#include "tc/core/cpu/cpu_mapping_options_cpp_printer.h"
+#include "tc/core/cpu/cpu_tc_executor.h"
+#include "tc/core/flags.h"
+#include "tc/core/scope_guard.h"
+#include "tc/core/tensor.h"
+#include "tc/core/utils/math.h"
+#include "tc/lang/canonicalize.h"
+
+namespace tc {
+namespace autotune {
+namespace detail {
+template <>
+typename CpuBackend::MappingOptionsType makeOptions<CpuBackend>(
+    const typename CpuBackend::MappingOptionsType& baseMapping,
+    const CandidateConfiguration& c) {
+  auto options = baseMapping;
+  c.configuration.applyToCpuMappingOptions(options);
+  return options;
+}
+
+template <>
+TuningConfiguration makeTuningConfiguration<CpuBackend>(
+    const typename CpuBackend::MappingOptionsType& options,
+    const TuningConfiguration& configuration) {
+  TuningConfiguration conf = configuration;
+  conf.fromCpuMappingOptions(options);
+  return conf;
+}
+
+template <>
+bool skipExecutionOrWarmup<CpuBackend>(
+    typename CpuBackend::ExecutorType& executor,
+    const std::vector<const DLTensor*>& outputs,
+    const std::vector<const DLConstTensor*>& inputs,
+    size_t bestTimeSoFar) {
+  LOG(ERROR) << "NYI: skipExecutionOrWarmup<CpuBackend>";
+  return false;
+}
+
+template <>
+void handleDeviceRuntimeError<CpuBackend>(
+    size_t device,
+    typename CpuBackend::MappingOptionsType& options) {
+  LOG(ERROR) << "NYI: handleDeviceRuntimeError<CpuBackend>";
+}
+
+template <>
+std::vector<size_t> parseDevices<CpuBackend>(const std::string& devices) {
+  LOG(ERROR) << "NYI: handleDeviceRuntimeError<CpuBackend>";
+  return {};
+}
+} // namespace detail
+} // namespace autotune
+} // namespace tc

--- a/tc/autotuner/cuda/autotuner.cc
+++ b/tc/autotuner/cuda/autotuner.cc
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tc/autotuner/autotuner.h"
+
+#include <atomic>
+#include <chrono>
+#include <numeric>
+#include <thread>
+
+#include <cuda_runtime_api.h>
+#include <glog/stl_logging.h>
+
+#include "tc/autotuner/utils.h"
+#include "tc/core/compiler.h"
+#include "tc/core/cuda/cuda.h"
+#include "tc/core/cuda/cuda_mapping_options_cpp_printer.h"
+#include "tc/core/cuda/cuda_tc_executor.h"
+#include "tc/core/flags.h"
+#include "tc/core/polyhedral/cuda/mapping_types.h"
+#include "tc/core/scope_guard.h"
+#include "tc/core/tensor.h"
+#include "tc/core/utils/math.h"
+#include "tc/lang/canonicalize.h"
+
+namespace tc {
+namespace autotune {
+namespace detail {
+
+using CudaTuningHarness = class TuningHarness<tc::CudaBackend>;
+
+template <>
+typename CudaBackend::MappingOptionsType makeOptions<CudaBackend>(
+    const typename CudaBackend::MappingOptionsType& baseMapping,
+    const CandidateConfiguration& c) {
+  auto options = baseMapping;
+  c.configuration.applyToCudaMappingOptions(options);
+  return options;
+}
+
+template <>
+TuningConfiguration makeTuningConfiguration<CudaBackend>(
+    const typename CudaBackend::MappingOptionsType& options,
+    const TuningConfiguration& configuration) {
+  TuningConfiguration conf = configuration;
+  conf.fromCudaMappingOptions(options);
+  return conf;
+}
+
+// This function is ran on a single pre-determined GPU, in a single thread
+// It takes the input/output DLTensor objects that reside on that GPU
+//
+// We pass the bestTimeSoFar as an option to avoid taking locks in this
+// function. This trades off a bit of conservativeness for code sanity.
+//
+// The function returns true if purning is possible and we can skip poorly
+// performing versions early.
+template <>
+bool skipExecutionOrWarmup<CudaBackend>(
+    typename CudaBackend::ExecutorType& executor,
+    const std::vector<const DLTensor*>& outputs,
+    const std::vector<const DLConstTensor*>& inputs,
+    size_t bestTimeSoFar) {
+  // 1. Prune based on the number of threads: if you don't hit at least k warps
+  // (default k = 8; 256 total threads, controlled by
+  // FLAGS_tuner_min_launch_total_threads) then it's likely the kernel is not
+  // performing great.
+  // This may be completely off but is a good first initial rule of thumb
+  // for stress-testing autotuning.
+  auto debugTuner = FLAGS_debug_tuner;
+  auto minThreads = FLAGS_tuner_min_launch_total_threads;
+  USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
+  auto block = executor.block();
+  auto nThreads =
+      mappingSize(TX, block) * mappingSize(TY, block) * mappingSize(TZ, block);
+  auto grid = executor.grid();
+  auto nBlocks =
+      mappingSize(BX, grid) * mappingSize(BY, grid) * mappingSize(BZ, grid);
+  if (nBlocks * nThreads < minThreads) {
+    LOG_IF(INFO, debugTuner)
+        << "Skip configuration: too few threads " << grid << " / " << block;
+    return true;
+  } else {
+    LOG_IF(INFO, debugTuner)
+        << "Run configuration launch bounds blocks: " << grid
+        << " and threads: " << block << "\n";
+  }
+
+  // 2. Perform a first run which may have one of 2 behaviors:
+  //   2.a. return a very slow first execution time, we should stop
+  //     early. This is akin to pruning but in this case we have run once,
+  //   2.b. return a reasonable execution time, in which case we proceed with
+  //     warmup.
+  auto timings = executor.profile(inputs, outputs);
+  // 2.a.
+  constexpr size_t kCatastrophicPerfFactor = 100;
+  if (bestTimeSoFar < std::numeric_limits<size_t>::max() and
+      timings.kernelRuntime >= std::chrono::microseconds(
+                                   (kCatastrophicPerfFactor * bestTimeSoFar))) {
+    return true;
+  }
+  // 2.b. during autotuning we don't want to spend too much time executing,
+  // use a reduced number of iterations for warmup.
+  constexpr int kReducedWarmupIterations = 2;
+  for (size_t i = 1; i < kReducedWarmupIterations - 1; ++i) {
+    executor.profile(inputs, outputs);
+  }
+
+  // 3. After reasonable warmup, look at the performance and prune if
+  // catastrophically bad.
+  constexpr int kEarlyPruneFactor = 5;
+  timings = executor.profile(inputs, outputs);
+  if (bestTimeSoFar < std::numeric_limits<size_t>::max() and
+      timings.kernelRuntime >=
+          std::chrono::microseconds((kEarlyPruneFactor * bestTimeSoFar))) {
+    return true;
+  }
+
+  // 4. If we get here then the kernel is good to be benchmarked
+  return false;
+}
+
+template <>
+void handleDeviceRuntimeError<CudaBackend>(
+    size_t device,
+    typename CudaBackend::MappingOptionsType& options) {
+  while (cudaGetLastError() != cudaSuccess) {
+    // In case of errors in the generated, we cannot rely on deviceReset to
+    // set the device in a clean state. So instead we just pop and discard
+    // all the errors accumulated on the device until we get to a clean
+    // state (i.e. cudaSuccess).
+    ;
+  }
+  try {
+    // Some errors, such as illegal memory access, cannot be recovered from
+    // without a cudaDeviceReset (i.e. because user protection)
+    // In those cases we have no choice than to fail hard.
+    TC_CUDA_RUNTIMEAPI_ENFORCE(cudaDeviceSynchronize());
+  } catch (const std::exception& e) {
+    LOG(FATAL) << "[FATAL] cuda error on device " << device << ": " << e.what()
+               << "\n"
+               << CudaBackend::MappingOptionsAsCpp(options);
+  }
+}
+
+template <>
+std::vector<size_t> parseDevices<CudaBackend>(const std::string& devices) {
+  std::stringstream ss(devices);
+  size_t device;
+  std::vector<size_t> res;
+  while (ss >> device) {
+    res.push_back(device);
+    if (ss.peek() == ',') {
+      ss.ignore();
+    }
+  }
+  return res;
+}
+} // namespace detail
+} // namespace autotune
+} // namespace tc


### PR DESCRIPTION
This PR adds the files implementing the refactored autotuner API (#342).

This PR makes the following changes to the autotuner:
1. since we don't have ExecutionEngine anymore, the tuning harness owns
the TcExecutor resulting from compilation. This results in significantly
simpler concurrency implementation and allows the pruning function to not
leak into the executor;
2. the autotuner and the harness are now templated by the backend type;
3. the autotuner is also templated by the search type;
4. the autotuner can only be created from a TC string and only exposes the
function tune;
5. anything related to multiple starting points was premature and disappears.
A good smell check is that all (almost all) calls to the tune function pass
both an options and an {options} parameter. We can make always turn baseMapping
into a vector in the future if we want to;
6. backing options caches are loaded and stored automatically if a filename
is passed;

As part of the bigger refactoring, these files are not yet activated
(or even compiled) therefore the changeset cannot be tested independently.
This new implementation will be switched in as part of the last commit of the
the global refactoring.