### PR TITLE
[C++ API] Step 8: Add files for the refactored aten tuner

### DIFF
--- a/tc/aten/aten_autotuner-inl.h
+++ b/tc/aten/aten_autotuner-inl.h
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/autotuner/autotuner.h"
+
+#include <atomic>
+#include <chrono>
+#include <numeric>
+#include <thread>
+
+#include <glog/stl_logging.h>
+
+#include "tc/aten/aten.h"
+#include "tc/aten/aten_compiler.h"
+#include "tc/autotuner/utils.h"
+#include "tc/core/compiler.h"
+#include "tc/core/flags.h"
+#include "tc/core/scope_guard.h"
+#include "tc/core/tensor.h"
+#include "tc/core/utils/math.h"
+#include "tc/lang/canonicalize.h"
+
+namespace tc {
+namespace aten {
+template <typename Backend, typename Search>
+ATenAutotuner<Backend, Search>::ATenAutotuner(const std::string& tc)
+    : tc::autotune::Autotuner<Backend, Search>(tc), tc_(tc) {}
+
+std::vector<at::Tensor> cloneTensors(const std::vector<at::Tensor>& inputs) {
+  std::vector<at::Tensor> copies;
+  copies.reserve(inputs.size());
+  for (const auto& t : inputs) {
+    copies.push_back(t.clone());
+  }
+  return copies;
+}
+
+template <typename Backend, typename Search>
+std::vector<typename Backend::MappingOptionsType>
+ATenAutotuner<Backend, Search>::tune(
+    const std::string& tcName,
+    const std::vector<at::Tensor>& inputs,
+    const typename Backend::MappingOptionsType& baseMapping,
+    const std::string& cacheFileName,
+    const tc::autotune::TuningParameterFixer& fixedParams) {
+  // TODO: some checks that inputs memory lives on the proper Backend device
+
+  // prepare outputs of the proper shape
+  auto outputs = tc::aten::prepareOutputs(tc_, tcName, inputs);
+
+  // first parse the devices
+  auto devices =
+      tc::autotune::detail::parseDevices<Backend>(FLAGS_tuner_devices);
+  // clone the inputs/outputs on each device
+  // TODO: this takes twice the space it should, alternatives are:
+  // 1. enforce inputs and outputs live on the CPU in the first place so we
+  //    don't spuriously run out of device memory (assuming CPU memory is
+  //    infinite for now);
+  // 2. if 1. is not reasonable, detect the device on which each tensor lives
+  //    and point to the raw data for that (device, tensor) pair.
+  std::unordered_map<size_t, std::vector<DLConstTensorUPtr>> inputsPerDevice;
+  std::unordered_map<size_t, std::vector<const DLConstTensor*>>
+      rawInputsPerDevice;
+  std::unordered_map<size_t, std::vector<DLTensorUPtr>> outputsPerDevice;
+  std::unordered_map<size_t, std::vector<const DLTensor*>> rawOutputsPerDevice;
+  for (auto device : devices) {
+    typename Backend::WithDevice wd(device);
+    auto deviceInputs = cloneTensors(inputs);
+    inputsPerDevice.emplace(device, toDLConstTensors(deviceInputs));
+    rawInputsPerDevice.emplace(
+        device, extractRawPtrs(inputsPerDevice.at(device)));
+    auto deviceOutputs = cloneTensors(outputs);
+    outputsPerDevice.emplace(device, makeDLTensors(deviceOutputs));
+    rawOutputsPerDevice.emplace(
+        device, extractRawPtrs(outputsPerDevice.at(device)));
+  }
+  return tc::autotune::Autotuner<Backend, Search>::tune(
+      tcName,
+      rawInputsPerDevice,
+      rawOutputsPerDevice,
+      baseMapping,
+      cacheFileName,
+      fixedParams);
+}
+} // namespace aten
+} // namespace tc

--- a/tc/aten/aten_autotuner.h
+++ b/tc/aten/aten_autotuner.h
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "tc/aten/aten.h"
+#include "tc/autotuner/autotuner.h"
+
+namespace tc {
+namespace aten {
+/**
+ * An Autotuner provides the basic interface to run a SearchStrategy over a
+ * particular Backend.
+ *
+ * Possible usage:
+ *    using namespace tc::aten;
+ *    std::string tc("...");
+ *    ATenAutotuner<tc::CudaBackend, tc::autotune::GeneticSearch> tuner(tc);
+ *    std::string cacheFn("/tmp/some_file");
+ *    auto best = tuner.tune("tc_function_name", inputs, baseOption, cacheFn)
+ *
+ * The best options may then be used to compile an executor and run.
+ *    CHECK_GT(best.size(), 0);
+ *    auto pExecutor = compile(tc, "tc_function_name", inputs, best[0]);
+ *    auto outputs = prepareOutputs(tc, "tc_function_name", inputs);
+ *    // memoize the executor and outputs if needed
+ *    run(*pExecutor, inputs, outputs);
+ */
+template <typename Backend, typename SearchStrategy>
+class ATenAutotuner : public tc::autotune::Autotuner<Backend, SearchStrategy> {
+ public:
+  using BackendType = Backend;
+  using MappingOptionsType = typename BackendType::MappingOptionsType;
+
+  /// An ATenAutotuner is built from a TC string which contains multiple TC
+  /// functions on which tuning can be run independently.
+  ATenAutotuner(const std::string& tc);
+
+  /// Runs autotuning on the TC function tcEntryPoint.
+  /// Proper output shapes are inferred automatically from the input shapes.
+  ///
+  /// Optionally an OptionsCache cacheFileName serialized path
+  /// can be specified to which the tuner will save the best options found for
+  /// later offline reuse, in the proper protobuf format.
+  ///
+  /// Additionally, if such a cacheFileName is specified and if it contains a
+  /// previously saved protobuf then the autotuner will load it. In that case
+  /// the tuner recovers multiple starting points and appends them to the
+  /// baseMapping. This can be useful in a reinforcement situation where short
+  /// tunings are run and their results cached iteratively. The best options
+  /// are still saved at the end of tuning, altering that previously saved
+  /// protobuf file.
+  ///
+  /// Lastly a TuningParameterFixer function can be specified to limit the
+  /// search space (i.e. when certain parameters are known to be good/bad
+  /// independently on a particular TC).
+  ///
+  /// \return a vector MappingOptions, if it is empty then tuning did not find
+  /// a single good configuration. This should be a very rare occurrence but
+  /// it is possible in particular if the skipExecutionOrWarmup function is too
+  /// aggressive and the problem size is too small. If the vector is not empty
+  /// it contains the best performing options for the particular Backend,
+  /// ranked by execution speed, where result[0] is the fastest.
+  std::vector<MappingOptionsType> tune(
+      const std::string& tcEntryPoint,
+      const std::vector<at::Tensor>& inputs,
+      const MappingOptionsType& baseMapping,
+      const std::string& cacheFileName = "",
+      const tc::autotune::TuningParameterFixer& fixedParams = {});
+
+ private:
+  /// The TC string is stored internally so we can tune independent TC
+  /// functions on demand.
+  const std::string tc_;
+};
+} // namespace aten
+} // namespace tc
+
+#include "tc/aten/aten_autotuner-inl.h"


### PR DESCRIPTION
This PR adds the files implementing the refactored AtenAutotuner API (#345).

This refactoring essentially:
1. makes the tuner future-proof by templating by backend type and search strategy
2. drops the user-exposed load function which retrieves options from a
3. serialized proto cache: the tuner has no business providing this functionality.
If one wants to query the options cache one can do so explicitly
4. drops the owning pointer to a genetic autotuner: an ATenAutotuner is a
Autotuner<Backend, SearchStrategy> that operates on ATen tensors.
5. adds documentation and example of usage

As part of the bigger refactoring, these files are not yet activated
(or even compiled) therefore the changeset cannot be tested independently.
This new implementation will be switched in as part of the last commit of the
the global refactoring.