### PR TITLE
isPromotableToRegisterBelowThreads: directly use relevant parts of schedule

### DIFF
--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -450,8 +450,9 @@ ostream& operator<<(ostream& os, const vector<Args...>& v) {
 }
 } // namespace
 
-isl::multi_union_pw_aff prefixScheduleMupa(
+isl::multi_union_pw_aff infixScheduleMupa(
     const ScheduleTree* root,
+    const ScheduleTree* relativeRoot,
     const ScheduleTree* tree) {
   auto domainElem = root->elemAs<ScheduleTreeElemDomain>();
   CHECK(domainElem);
@@ -461,13 +462,19 @@ isl::multi_union_pw_aff prefixScheduleMupa(
   // Work around bug in isl.
   prefix = prefix.intersect_domain(domain);
   prefix = foldl(
-      filterType<ScheduleTreeElemBand>(tree->ancestors(root)),
+      filterType<ScheduleTreeElemBand>(tree->ancestors(relativeRoot)),
       [](const ScheduleTree* st, isl::multi_union_pw_aff prefix) {
         auto mupa = st->elemAs<ScheduleTreeElemBand>()->mupa_;
         return prefix.flat_range_product(mupa);
       },
       prefix);
   return prefix;
+}
+
+isl::multi_union_pw_aff prefixScheduleMupa(
+    const ScheduleTree* root,
+    const ScheduleTree* tree) {
+  return infixScheduleMupa(root, root, tree);
 }
 
 isl::multi_union_pw_aff partialScheduleMupa(

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -458,6 +458,8 @@ isl::multi_union_pw_aff prefixScheduleMupa(
   auto domain = domainElem->domain_.universe();
   auto zero = isl::multi_val::zero(domain.get_space().set_from_params());
   auto prefix = isl::multi_union_pw_aff(domain, zero);
+  // Work around bug in isl.
+  prefix = prefix.intersect_domain(domain);
   prefix = foldl(
       filterType<ScheduleTreeElemBand>(tree->ancestors(root)),
       [](const ScheduleTree* st, isl::multi_union_pw_aff prefix) {

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -264,6 +264,18 @@ isl::union_map prefixSchedule(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node);
 
+// Return the concatenation of all band node partial schedules
+// from "relativeRoot" (inclusive) to "tree" (exclusive)
+// within a tree rooted at "root".
+// If there are no intermediate band nodes, then return a zero-dimensional
+// function on the universe domain of the schedule tree.
+// Note that this function does not take into account
+// any intermediate filter nodes.
+isl::multi_union_pw_aff infixScheduleMupa(
+    const detail::ScheduleTree* root,
+    const detail::ScheduleTree* relativeRoot,
+    const detail::ScheduleTree* tree);
+
 // Return the concatenation of all outer band node partial schedules.
 // If there are no outer band nodes, then return a zero-dimensional
 // function on the universe domain of the schedule tree.


### PR DESCRIPTION
The original code would start off from a "full schedule" and
then project out the bits that aren't actually needed.
Directly use the relevant parts of the schedule instead.
This greatly simplifies the code.