### PR TITLE
Fix compilation errors in fbcode

### DIFF
--- a/tc/autotuner/genetic_tuning_harness.cc
+++ b/tc/autotuner/genetic_tuning_harness.cc
@@ -79,7 +79,7 @@ GeneticTunerHarness::GeneticTunerHarness(
           config.fixParameters(fixedParams);
           return config;
         });
-    tuner_ = make_unique<GeneticSearch>(
+    tuner_ = tc::make_unique<GeneticSearch>(
         configs,
         kMaxPopulationSize,
         kCrossOverRate,

--- a/test/test_tc_mapper_harness-inl.h
+++ b/test/test_tc_mapper_harness-inl.h
@@ -47,7 +47,7 @@ struct TcMapperTest : public ::testing::Test {
     auto handle = atCompl.compile(name, inputs, mappingOptions);
     atCompl.run(name, inputs, outputs, handle);
     checkFun(inputs, outputs);
-    return std::move(outputs);
+    return outputs;
   }
 };
 


### PR DESCRIPTION
This diff is fixing the following compilation errors in fbcode. It is pushed to github by sync script. 


tc/tc/autotuner/genetic_tuning_harness.cc:82:14: error: call to 'make_unique' is ambiguous
    tuner_ = make_unique<GeneticSearch>(
             ^~~~~~~~~~~~~~~~~~~~~~~~~~
third-party-buck/gcc-5-glibc-2.23/build/libgcc/include/c++/trunk/bits/unique_ptr.h:767:5: note: candidate function [with _Tp = tc::autotune::GeneticSearch, _Args = <std::vector<tc::autotune::TuningConfiguration, std::allocator<tc::autotune::TuningConfiguration> > &, const unsigned long &, const unsigned char &, const unsigned char &, const unsigned long &>]
    make_unique(_Args&&... __args)
    ^
tc/tc/core/utils/memory.h:24:20: note: candidate function [with T = tc::autotune::GeneticSearch, Args = <std::vector<tc::autotune::TuningConfiguration, std::allocator<tc::autotune::TuningConfiguration> > &, const unsigned long &, const unsigned char &, const unsigned char &, const unsigned long &>]
std::unique_ptr<T> make_unique(Args&&... args) {
                   ^
1 error generated.
In file included from tc/test/cuda/test_tc_mapper.cc:31:
tc/test/test_tc_mapper_harness-inl.h:50:12: error: moving a local object in a return statement prevents copy elision [-Werror,-Wpessimizing-move]
    return std::move(outputs);
           ^
tc/test/test_tc_mapper_harness-inl.h:50:12: note: remove std::move call here
    return std::move(outputs);
           ^~~~~~~~~~       ~
1 error generated.
Build failed: Command failed with exit code 1.
stderr: In file included from tc/test/cuda/test_tc_mapper.cc:31:
tc/test/test_tc_mapper_harness-inl.h:50:12: error: moving a local object in a return statement prevents copy elision [-Werror,-Wpessimizing-move]
    return std::move(outputs);
           ^
      kKernelName_(std::move(kernelName)),
tc/test/test_tc_mapper_harness-inl.h:50:12: note: remove std::move call here
      kTc_(std::move(tc)),
    return std::move(outputs);

