### PR TITLE
test_cuda_mapper_memory_promotion.cc: drop explicit parameter name setting

### DIFF
--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -263,9 +263,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
     EXPECT_EQ(groups.size(), 3u);
 
     USING_MAPPING_SHORT_NAMES(BX, BY, BZ, TX, TY, TZ);
-    isl::space blockSpace = isl::space(ctx, 2);
-    blockSpace = blockSpace.set_dim_id(isl::dim_type::param, 0, BX)
-                     .set_dim_id(isl::dim_type::param, 1, BY);
+    isl::space blockSpace = isl::space(ctx, 0);
     isl::set blockZero =
         isl::makeSpecializationSet<int>(blockSpace, {{BX, 0}, {BY, 0}});
 


### PR DESCRIPTION
Since ca98a28e (makeSpecializationSet: do not assume parameters have
a fixed position, Fri Apr 6 15:11:17 2018 +0200), it is no longer
required to first add the parameters to the space passed to
isl::makeSpecializationSet.