### PR TITLE
further restrict line size in commit messages

### DIFF
--- a/CodingConventions.md
+++ b/CodingConventions.md
@@ -593,7 +593,7 @@ Each commit should have a proper commit message.
 A commit message consists of a one-line summary, followed by an empty line and
 the main body with more details focusing on the motivation of the change.
 Both the one-line summary and the lines in the main body
-should not exceed 80 characters.
+should not exceed 72 characters.
 The commit message should contain all the information that is needed
 to understand the change within the git repository.
 The main body can only be omitted if the motivation is completely obvious


### PR DESCRIPTION
Tools like "git log" shift the commit messages by 4 characters,
so to stay within a total of 80 characters, it is best
to use no more than 76 characters in the commit messages themselves.
In fact, it is common practice to only use up to 72 characters.