### PR TITLE
ScheduleTreeElemBand::drop: do not preserve tuple identifier

### DIFF
--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -158,11 +158,7 @@ void ScheduleTreeElemBand::drop(size_t pos, size_t n) {
   CHECK_GE(nMember(), pos + n) << "range out of bounds";
   auto nBegin = nMember();
 
-  if (mupa_.has_tuple_id(isl::dim_type::set)) {
-    mupa_ = dropDimsPreserveTuple(mupa_, isl::dim_type::set, pos, n);
-  } else {
-    mupa_ = mupa_.drop_dims(isl::dim_type::set, pos, n);
-  }
+  mupa_ = mupa_.drop_dims(isl::dim_type::set, pos, n);
 
   std::copy(
       coincident_.begin() + pos + n,

--- a/tc/external/detail/islpp.h
+++ b/tc/external/detail/islpp.h
@@ -275,13 +275,6 @@ inline bool operator!=(const isl::id& id1, const isl::id& id2) {
 ///////////////////////////////////////////////////////////////////////////////
 // Helper functions
 ///////////////////////////////////////////////////////////////////////////////
-template <typename T>
-inline T dropDimsPreserveTuple(T t, isl::dim_type type, int from, int length) {
-  auto id = t.get_tuple_id(type);
-  t = t.drop_dims(type, from, length);
-  return t.set_tuple_id(type, id);
-}
-
 // Given a space and a list of values, this returns the corresponding multi_val.
 template <typename T>
 isl::multi_val makeMultiVal(isl::space s, const std::vector<T>& vals) {


### PR DESCRIPTION
When some dimensions get removed from a space, then it is clearly
not the same space anymore, so it is dangerous to try and pretend
that it is.  It is also fairly arbitrary to try and save the identifier,
but not the internal structure of the space.
There may be specific situations where a user is changing the space
and where the tuple identifier should be preserved, but this should
then be the done by the caller and not by a generic method such as
ScheduleTreeElemBand::drop.