### PR TITLE
[C++ API] Rename makeXXXCudaMappingOptions -> makeXXXMappingOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ def tensordot(float(N, C1, C2, H, W) I0,
   at::Tensor I1 = at::CUDA(at::kFloat).rand({32, 16, 2, 17, 25});
 
   // 3. Run autotuning with evolutionary search starting from a naive option.
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   tc::autotune::GeneticAutotunerATen geneticAutotuneATen(tc);
   auto bestOption = geneticAutotuneATen.tune(
     "/tmp/save_results", "tensordot", {I0, I1}, options);

--- a/tc/autotuner/genetic_search.cc
+++ b/tc/autotuner/genetic_search.cc
@@ -304,7 +304,7 @@ void GeneticSearch::updateParameters() {
       population.size() > 0 ? population.front()->configuration : lastBestConf;
   if (FLAGS_tuner_print_best) {
     CudaMappingOptions options(
-        CudaMappingOptions::makeSingleThreadCudaMappingOptions());
+        CudaMappingOptions::makeSingleThreadMappingOptions());
     lastBestConf.applyToCudaMappingOptions(options);
     LOG(INFO) << "Best so far:\n" << options;
   }

--- a/tc/benchmarks/MLP_model.cc
+++ b/tc/benchmarks/MLP_model.cc
@@ -520,7 +520,7 @@ TEST_F(ProductionModel, 1LUT) {
   auto D = FLAGS_D;
   auto L1 = FLAGS_L1;
   auto E1 = FLAGS_E1;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .tile(1, 32)
                      .mapToThreads({1, 32})
                      .mapToBlocks({128, 128})
@@ -534,7 +534,7 @@ TEST_F(ProductionModel, 1LUT_P100_autotuned_B_128_D_64_L1_50_E1_10000000) {
   uint32_t L1 = 50;
   uint32_t E1 = 10000000;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .fixParametersBeforeScheduling(true)
           .tile(1)
@@ -551,7 +551,7 @@ TEST_F(ProductionModel, 1LUT_P100_autotuned_B_16_D_64_L1_50_E1_10000000) {
   uint32_t L1 = 50;
   uint32_t E1 = 10000000;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .fixParametersBeforeScheduling(false)
           .tile(1, 32)
@@ -597,7 +597,7 @@ TEST_F(ProductionModel, 2LUT) {
   auto L2 = FLAGS_L2;
   auto E1 = FLAGS_E1;
   auto E2 = FLAGS_E2;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .tile(1, 32)
                      .mapToThreads({1, 32})
                      .mapToBlocks({128, 128})
@@ -615,7 +615,7 @@ TEST_F(
   uint32_t L2 = 50;
   uint32_t E2 = 10000000;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .fixParametersBeforeScheduling(false)
           .tile(1, 256, 1250000)
@@ -636,7 +636,7 @@ TEST_F(
   uint32_t L2 = 50;
   uint32_t E2 = 10000000;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .fixParametersBeforeScheduling(false)
           .tile(1, 64)
@@ -686,7 +686,7 @@ TEST_F(ProductionModel, C3) {
   auto B = FLAGS_B;
   auto WX = FLAGS_WX;
   auto WY = FLAGS_WY;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .fixParametersBeforeScheduling(true)
                      .tile(32, 32, 32)
                      .mapToThreads({4, 32})
@@ -702,7 +702,7 @@ TEST_F(ProductionModel, C3_P100_autotuned_B_128_WX_1000_WY_1024) {
   uint32_t B = 128;
   uint32_t WX = 1000;
   uint32_t WY = 1024;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -725,7 +725,7 @@ TEST_F(ProductionModel, C3_P100_autotuned_B_16_WX_1000_WY_1024) {
   uint32_t B = 16;
   uint32_t WX = 1000;
   uint32_t WY = 1024;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -781,7 +781,7 @@ TEST_F(ProductionModel, MLP1) {
   auto B = FLAGS_B;
   auto N = FLAGS_N;
   auto M = FLAGS_M;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .fixParametersBeforeScheduling(true)
                      .tile(16, 16, 128)
                      .mapToThreads({16, 16})
@@ -797,7 +797,7 @@ TEST_F(ProductionModel, MLP1_P100_autotuned_B_128_M_2000_N_128) {
   uint32_t M = 2000;
   uint32_t N = 128;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -821,7 +821,7 @@ TEST_F(ProductionModel, MLP1_P100_autotuned_B_16_M_2000_N_128) {
   uint32_t M = 2000;
   uint32_t N = 128;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -880,7 +880,7 @@ TEST_F(ProductionModel, MLP3) {
   auto O = FLAGS_O;
   auto P = FLAGS_P;
   auto Q = FLAGS_Q;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .fixParametersBeforeScheduling(true)
                      .tile(16, 16, 128)
                      .mapToThreads({16, 16})
@@ -897,7 +897,7 @@ TEST_F(ProductionModel, MLP3_P100_autotuned_B_128_N_128_O_64_P_32_Q_2) {
   auto O = 64;
   auto P = 32;
   auto Q = 2;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -923,7 +923,7 @@ TEST_F(ProductionModel, MLP3_P100_autotuned_B_16_M_2000_N_128_Q_2) {
   auto O = 64;
   auto P = 32;
   auto Q = 2;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)

--- a/tc/benchmarks/batchmatmul.cc
+++ b/tc/benchmarks/batchmatmul.cc
@@ -116,7 +116,7 @@ TEST_F(BatchMatMul, TransposedBatchMatMul) {
   auto N = FLAGS_N;
   auto M = FLAGS_M;
   auto K = FLAGS_K;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .tile(1)
                      .mapToThreads({128})
                      .mapToBlocks({B})
@@ -131,7 +131,7 @@ TEST_F(BatchMatMul, TransposedBatchMatMul_P100_autotuned_B_500_K_26_M_72_N_26) {
   uint32_t K = 26;
   uint32_t M = 72;
   uint32_t N = 26;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)

--- a/tc/benchmarks/group_convolution.cc
+++ b/tc/benchmarks/group_convolution.cc
@@ -176,7 +176,7 @@ TEST_F(GroupConvolution, GroupConvolution) {
   // If num threads is too small just get some better default
   auto threads = (W >= 10) ? std::vector<size_t>{W / 4, H / 2}
                            : std::vector<size_t>{4, 8, 4};
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .tile(1, 1, 1)
                      .mapToThreads(threads)
                      .mapToBlocks({32, 32})
@@ -199,7 +199,7 @@ TEST_F(
   uint32_t KW = 3;
   uint32_t KH = 3;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .useSharedMemory(true)
           .usePrivateMemory(true)
           .unrollCopyShared(true)
@@ -225,7 +225,7 @@ TEST_F(
   uint32_t KW = 3;
   uint32_t KH = 3;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -257,7 +257,7 @@ TEST_F(
   uint32_t KW = 3;
   uint32_t KH = 3;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -288,7 +288,7 @@ TEST_F(
   uint32_t H = 28;
   uint32_t KW = 3;
   uint32_t KH = 3;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)

--- a/tc/benchmarks/tmm.cc
+++ b/tc/benchmarks/tmm.cc
@@ -109,7 +109,7 @@ TEST_F(TransposedMatMul, TransposedMatMul) {
   auto N = FLAGS_N;
   auto M = FLAGS_M;
   auto K = FLAGS_K;
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .fixParametersBeforeScheduling(true)
                      .tile(32, 32, 32)
                      .mapToThreads({32, 32})
@@ -125,7 +125,7 @@ TEST_F(TransposedMatMul, TransposedMatMul_P100_autotuned_M_128_N_1024_K_1024) {
   uint32_t N = 1024;
   uint32_t K = 1024;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -150,7 +150,7 @@ TEST_F(TransposedMatMul, TransposedMatMul_P100_autotuned_M_128_N_256_K_32) {
   uint32_t N = 256;
   uint32_t K = 32;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -175,7 +175,7 @@ TEST_F(TransposedMatMul, TransposedMatMul_P100_autotuned_M_128_N_16384_K_4096) {
   uint32_t N = 16384;
   uint32_t K = 4096;
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)

--- a/tc/c2/2fcrelu_op.h
+++ b/tc/c2/2fcrelu_op.h
@@ -38,8 +38,7 @@ class Tc2FCReluOp : public TcOp<T, Context, Engine> {
 
  protected:
   void setupNaiveCudaMappingOptions() {
-    this->cudaMappingOptions_ =
-        tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+    this->cudaMappingOptions_ = tc::CudaMappingOptions::makeMlpMappingOptions();
   }
 };
 } // namespace caffe2

--- a/tc/c2/3fcrelu_op.h
+++ b/tc/c2/3fcrelu_op.h
@@ -38,8 +38,7 @@ class Tc3FCReluOp : public TcOp<T, Context, Engine> {
 
  protected:
   void setupNaiveCudaMappingOptions() override {
-    this->cudaMappingOptions_ =
-        tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+    this->cudaMappingOptions_ = tc::CudaMappingOptions::makeMlpMappingOptions();
   }
 };
 } // namespace caffe2

--- a/tc/c2/4fcrelu_op.h
+++ b/tc/c2/4fcrelu_op.h
@@ -38,8 +38,7 @@ class Tc4FCReluOp : public TcOp<T, Context, Engine> {
 
  protected:
   void setupNaiveCudaMappingOptions() override {
-    this->cudaMappingOptions_ =
-        tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+    this->cudaMappingOptions_ = tc::CudaMappingOptions::makeMlpMappingOptions();
   }
 };
 } // namespace caffe2

--- a/tc/c2/convolution_op.h
+++ b/tc/c2/convolution_op.h
@@ -72,9 +72,9 @@ class TcConvolutionOp : public TcOp<T, Context, Engine> {
  protected:
   void setupNaiveCudaMappingOptions() override {
     this->cudaMappingOptions_ =
-        tc::CudaMappingOptions::makeConvolutionCudaMappingOptions();
+        tc::CudaMappingOptions::makeConvolutionMappingOptions();
     this->gradCudaMappingOptions_ =
-        tc::CudaMappingOptions::makeConvolutionCudaMappingOptions();
+        tc::CudaMappingOptions::makeConvolutionMappingOptions();
   }
 };
 } // namespace caffe2

--- a/tc/c2/copy_op.h
+++ b/tc/c2/copy_op.h
@@ -44,13 +44,13 @@ class TcCopyOp : public TcOp<T, Context, Engine> {
  protected:
   void setupNaiveCudaMappingOptions() override {
     this->cudaMappingOptions_ =
-        tc::CudaMappingOptions::makePointwiseCudaMappingOptions()
+        tc::CudaMappingOptions::makePointwiseMappingOptions()
             .tile(4, 8, 8)
             .mapToThreads({32, 4, 4})
             .mapToBlocks({100, 100, 100})
             .unroll(128);
     this->gradCudaMappingOptions_ =
-        tc::CudaMappingOptions::makePointwiseCudaMappingOptions();
+        tc::CudaMappingOptions::makePointwiseMappingOptions();
   }
 };
 } // namespace caffe2

--- a/tc/c2/fcrelu_op.h
+++ b/tc/c2/fcrelu_op.h
@@ -38,8 +38,7 @@ class TcFCReluOp : public TcOp<T, Context, Engine> {
 
  protected:
   void setupNaiveCudaMappingOptions() override {
-    this->cudaMappingOptions_ =
-        tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+    this->cudaMappingOptions_ = tc::CudaMappingOptions::makeMlpMappingOptions();
   }
 };
 } // namespace caffe2

--- a/tc/c2/group_convolution_op.h
+++ b/tc/c2/group_convolution_op.h
@@ -79,9 +79,9 @@ class TcGroupConvolutionOp : public TcOp<T, Context, Engine> {
  protected:
   void setupNaiveCudaMappingOptions() override {
     this->cudaMappingOptions_ =
-        tc::CudaMappingOptions::makeGroupConvolutionCudaMappingOptions();
+        tc::CudaMappingOptions::makeGroupConvolutionMappingOptions();
     this->gradCudaMappingOptions_ =
-        tc::CudaMappingOptions::makeGroupConvolutionCudaMappingOptions();
+        tc::CudaMappingOptions::makeGroupConvolutionMappingOptions();
   }
 };
 } // namespace caffe2

--- a/tc/c2/tc_op.h
+++ b/tc/c2/tc_op.h
@@ -41,10 +41,9 @@ class TcOp : public Operator<Context> {
         tc_(OperatorBase::GetSingleArgument<std::string>("tcDef", "ERROR")),
         tcName_(
             OperatorBase::GetSingleArgument<std::string>("tcName", "ERROR")),
-        cudaMappingOptions_(
-            tc::CudaMappingOptions::makeNaiveCudaMappingOptions()),
+        cudaMappingOptions_(tc::CudaMappingOptions::makeNaiveMappingOptions()),
         gradCudaMappingOptions_(
-            tc::CudaMappingOptions::makeNaiveCudaMappingOptions()) {
+            tc::CudaMappingOptions::makeNaiveMappingOptions()) {
     gradTc_ =
         OperatorBase::GetSingleArgument<std::string>("tcGradDef", "ERROR");
     gradTcName_ =

--- a/tc/core/cuda/cuda_mapping_options.cc
+++ b/tc/core/cuda/cuda_mapping_options.cc
@@ -101,7 +101,7 @@ CudaMappingOptions& CudaMappingOptions::mapToBlocks(
 //
 // Predefined strategies
 //
-CudaMappingOptions CudaMappingOptions::makeUnmappedCudaMappingOptions() {
+CudaMappingOptions CudaMappingOptions::makeUnmappedMappingOptions() {
   CudaMappingOptions mo;
   mo.genericMappingOptions(MappingOptions::makeUnmappedMappingOptions())
       .useSharedMemory(false)
@@ -110,32 +110,32 @@ CudaMappingOptions CudaMappingOptions::makeUnmappedCudaMappingOptions() {
   return mo;
 }
 
-CudaMappingOptions CudaMappingOptions::makeNaiveCudaMappingOptions() {
-  return makeUnmappedCudaMappingOptions()
+CudaMappingOptions CudaMappingOptions::makeNaiveMappingOptions() {
+  return makeUnmappedMappingOptions()
       .tile(32, 32, 32)
       .mapToThreads(32, 8)
       .mapToBlocks(256, 256)
       .unroll(1);
 }
 
-CudaMappingOptions CudaMappingOptions::makeSingleThreadCudaMappingOptions() {
-  return makeUnmappedCudaMappingOptions()
+CudaMappingOptions CudaMappingOptions::makeSingleThreadMappingOptions() {
+  return makeUnmappedMappingOptions()
       .tile(1)
       .mapToThreads(1)
       .mapToBlocks(1)
       .unroll(1);
 }
 
-CudaMappingOptions CudaMappingOptions::makePointwiseCudaMappingOptions() {
-  return makeUnmappedCudaMappingOptions()
+CudaMappingOptions CudaMappingOptions::makePointwiseMappingOptions() {
+  return makeUnmappedMappingOptions()
       .tile(32, 32, 32)
       .mapToThreads(32, 4, 4)
       .mapToBlocks(100, 100, 100)
       .unroll(128);
 }
 
-CudaMappingOptions CudaMappingOptions::makeMlpCudaMappingOptions() {
-  return makeUnmappedCudaMappingOptions()
+CudaMappingOptions CudaMappingOptions::makeMlpMappingOptions() {
+  return makeUnmappedMappingOptions()
       .outerScheduleFusionStrategy(FusionStrategy::Max)
       .tile(1)
       .mapToThreads(128)
@@ -143,17 +143,16 @@ CudaMappingOptions CudaMappingOptions::makeMlpCudaMappingOptions() {
       .unroll(1);
 }
 
-CudaMappingOptions CudaMappingOptions::makeConvolutionCudaMappingOptions() {
-  return makeUnmappedCudaMappingOptions()
+CudaMappingOptions CudaMappingOptions::makeConvolutionMappingOptions() {
+  return makeUnmappedMappingOptions()
       .tile(4, 8, 8, 8)
       .mapToThreads(4, 16, 4)
       .mapToBlocks(256, 256, 256)
       .unroll(1);
 }
 
-CudaMappingOptions
-CudaMappingOptions::makeGroupConvolutionCudaMappingOptions() {
-  return makeUnmappedCudaMappingOptions()
+CudaMappingOptions CudaMappingOptions::makeGroupConvolutionMappingOptions() {
+  return makeUnmappedMappingOptions()
       .tile(1, 1)
       .mapToThreads(4, 16, 4)
       .mapToBlocks(256, 256)

--- a/tc/core/cuda/cuda_mapping_options.h
+++ b/tc/core/cuda/cuda_mapping_options.h
@@ -145,7 +145,7 @@ class Grid : public CudaDim {
 class CudaMappingOptions {
  private:
   inline CudaMappingOptions();
-  static CudaMappingOptions makeUnmappedCudaMappingOptions();
+  static CudaMappingOptions makeUnmappedMappingOptions();
 
  public:
   /// Construct a deep copy of the options.
@@ -201,12 +201,12 @@ class CudaMappingOptions {
 
   /// Static constructors for predefined strategies.
   ///@{
-  static CudaMappingOptions makeNaiveCudaMappingOptions();
-  static CudaMappingOptions makeSingleThreadCudaMappingOptions();
-  static CudaMappingOptions makePointwiseCudaMappingOptions();
-  static CudaMappingOptions makeMlpCudaMappingOptions();
-  static CudaMappingOptions makeConvolutionCudaMappingOptions();
-  static CudaMappingOptions makeGroupConvolutionCudaMappingOptions();
+  static CudaMappingOptions makeNaiveMappingOptions();
+  static CudaMappingOptions makeSingleThreadMappingOptions();
+  static CudaMappingOptions makePointwiseMappingOptions();
+  static CudaMappingOptions makeMlpMappingOptions();
+  static CudaMappingOptions makeConvolutionMappingOptions();
+  static CudaMappingOptions makeGroupConvolutionMappingOptions();
   ///@}
 
   const CudaMappingOptionsProto& proto() const {

--- a/tc/examples/blockdiagperm.cc
+++ b/tc/examples/blockdiagperm.cc
@@ -74,7 +74,7 @@ def blockdiagperm2dfissioned_2(float(B, N) I, int32(N) Idx) -> (O) {
   // 1. Allocate and autotune
   at::Tensor I = at::CUDA(at::kFloat).rand({128, 10, 50});
   at::Tensor W = at::CUDA(at::kFloat).rand({10, 50, 50});
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   tc::autotune::GeneticAutotunerATen geneticAutotuneATen(tc);
   auto bestOption = geneticAutotuneATen.tune(
       FLAGS_proto_path, "blockdiagperm2dfissioned_1", {I, W}, options);

--- a/tc/examples/tensordot.cc
+++ b/tc/examples/tensordot.cc
@@ -50,7 +50,7 @@ def tensordot(float(N, C1, C2, H, W) I0,
   at::Tensor I1 = at::CUDA(at::kFloat).rand({16, 16, 2, 17, 25});
 
   // 3. Run autotuning with evolutionary search starting from a naive option.
-  auto naiveOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto naiveOptions = tc::CudaMappingOptions::makeNaiveMappingOptions();
   tc::autotune::GeneticAutotunerATen geneticAutotuneATen(tc);
   auto bestOption = geneticAutotuneATen.tune(
       FLAGS_proto_path, "tensordot", {I0, I1}, naiveOptions);

--- a/tc/examples/wavenet.cc
+++ b/tc/examples/wavenet.cc
@@ -104,7 +104,7 @@ def wavenet2layers(
   at::Tensor skip_bias1 = at::CUDA(at::kFloat).rand({256});
 
   // 3. Run autotuning with evolutionary search starting from a naive option.
-  auto naiveOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto naiveOptions = tc::CudaMappingOptions::makeNaiveMappingOptions();
   tc::autotune::GeneticAutotunerATen geneticAutotuneATen(tc);
   std::vector<at::Tensor> tensors = {weight0,
                                      bias0,

--- a/tensor_comprehensions/pybinds/pybind_options.cc
+++ b/tensor_comprehensions/pybinds/pybind_options.cc
@@ -35,25 +35,23 @@ PYBIND11_MODULE(mapping_options, m) {
       .def(
           py::init([](std::string type) {
             if (type == "naive") {
-              return tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+              return tc::CudaMappingOptions::makeNaiveMappingOptions();
             }
             if (type == "single_thread") {
-              return tc::CudaMappingOptions::
-                  makeSingleThreadCudaMappingOptions();
+              return tc::CudaMappingOptions::makeSingleThreadMappingOptions();
             }
             if (type == "pointwise") {
-              return tc::CudaMappingOptions::makePointwiseCudaMappingOptions();
+              return tc::CudaMappingOptions::makePointwiseMappingOptions();
             }
             if (type == "mlp") {
-              return tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+              return tc::CudaMappingOptions::makeMlpMappingOptions();
             }
             if (type == "conv") {
-              return tc::CudaMappingOptions::
-                  makeConvolutionCudaMappingOptions();
+              return tc::CudaMappingOptions::makeConvolutionMappingOptions();
             }
             if (type == "group_conv") {
               return tc::CudaMappingOptions::
-                  makeGroupConvolutionCudaMappingOptions();
+                  makeGroupConvolutionMappingOptions();
             }
             throw std::runtime_error("Invalid option passed");
           }),

--- a/test/cuda/test_autotuner.cc
+++ b/test/cuda/test_autotuner.cc
@@ -105,7 +105,7 @@ def layernorm(float(T, B, C) I) -> (O, mean, centered, var) {
       O(t, b, c) =  centered(t, b, c) / rsqrt(var(t, b))
 }
   )TC";
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   auto name = "layernorm";
 
   std::string cacheFilename = "";
@@ -124,7 +124,7 @@ def matmul(float(M,N) A, float(N,K) B) -> (output) {
   output(m, k) +=! A(m, r_n) * B(r_n, k)
 }
   )TC";
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   auto name = "matmul";
 
   std::string cacheFilename = "";
@@ -143,7 +143,7 @@ def matmul(float(M,N) A, float(N,K) B) -> (output) {
   output(m, k) +=! A(m, r_n) * B(r_n, k)
 }
   )TC";
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   auto name = "matmul";
 
   std::string cacheFilename = "";
@@ -162,7 +162,7 @@ def matmul(float(M,N) A, float(N,K) B) -> (output) {
   output(m, k) +=! A(m, r_n) * B(r_n, k)
 }
   )TC";
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   auto name = "matmul";
 
   std::string cacheFilename = "";
@@ -181,7 +181,7 @@ def tensordot(float(N, C1, C2, H, W) I0, float(N, C2, C3, H, W) I1) -> (O) {
   O(n, c1, c3, h, w) +=! I0(n, c1, r_c2, h, w) * I1(n, r_c2, c3, h, w)
 }
   )TC";
-  auto options = tc::CudaMappingOptions::makeConvolutionCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeConvolutionMappingOptions();
   auto name = "tensordot";
   Check(TC, name, options, inputs, outputs);
   benchmarkKernelOptions(TC, name, inputs, options);

--- a/test/cuda/test_autotuner_utility.cc
+++ b/test/cuda/test_autotuner_utility.cc
@@ -94,7 +94,7 @@ TEST(RestoreCandidates, NoRuntimeRecorded) {
   tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
   atCompl.define(tc_);
   tc::CudaMappingOptions options =
-      tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+      tc::CudaMappingOptions::makeMlpMappingOptions();
   std::vector<at::Tensor> outputs_;
   auto handle = atCompl.compile("matmul", inputs, options);
   atCompl.run("matmul", inputs, outputs_, handle);
@@ -111,12 +111,12 @@ TEST(RestoreCandidates, Hit) {
   tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
   atCompl.define(tc_);
   tc::CudaMappingOptions options =
-      tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+      tc::CudaMappingOptions::makeMlpMappingOptions();
   std::vector<at::Tensor> outputs_;
   auto handle = atCompl.compile("matmul", inputs, options);
   atCompl.run("matmul", inputs, outputs_, handle, true);
 
-  options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   handle = atCompl.compile("matmul", inputs, options);
   atCompl.run("matmul", inputs, outputs_, handle, true);
 

--- a/test/cuda/test_compilation_cache.cc
+++ b/test/cuda/test_compilation_cache.cc
@@ -70,7 +70,7 @@ class OptionsCacheTest : public ::testing::Test {
 };
 
 TEST_F(OptionsCacheTest, DifferentIDs) {
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   auto inputPtrs = InputPtrs();
   auto outputPtrs = InputPtrs();
 
@@ -108,8 +108,8 @@ TEST_F(OptionsCacheTest, DifferentIDs) {
 }
 
 TEST_F(OptionsCacheTest, DifferentOptions) {
-  auto options0 = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
-  auto options1 = tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+  auto options0 = tc::CudaMappingOptions::makeNaiveMappingOptions();
+  auto options1 = tc::CudaMappingOptions::makeMlpMappingOptions();
   auto inputPtrs = InputPtrs();
   auto outputPtrs = InputPtrs();
 
@@ -137,7 +137,7 @@ TEST_F(OptionsCacheTest, DifferentOptions) {
 }
 
 TEST_F(OptionsCacheTest, DifferentInputs) {
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   auto inputPtrs = InputPtrs();
   auto outputPtrs = InputPtrs();
 
@@ -149,8 +149,7 @@ TEST_F(OptionsCacheTest, DifferentInputs) {
   auto s = inputs[0].shape[0];
   inputs[0].shape[0] = 42;
 
-  auto options_ =
-      tc::CudaMappingOptions::makeGroupConvolutionCudaMappingOptions();
+  auto options_ = tc::CudaMappingOptions::makeGroupConvolutionMappingOptions();
   tc::OptionsCache::getCache()->recordRuntime(
       "kernel", options_, inputPtrs, outputPtrs, std::chrono::microseconds(3));
 
@@ -187,11 +186,11 @@ TEST_F(OptionsCacheTest, DifferentInputs) {
 
 TEST_F(OptionsCacheTest, RetrieveBest) {
   auto options0 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({1});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({1});
   auto options1 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({2});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({2});
   auto options2 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({3});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({3});
 
   auto inputPtrs = InputPtrs();
   auto outputPtrs = InputPtrs();
@@ -221,15 +220,15 @@ TEST_F(OptionsCacheTest, RetrieveBest) {
 
 TEST_F(OptionsCacheTest, RetrieveTopK) {
   auto options0 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({1});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({1});
   auto options1 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({2});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({2});
   auto options2 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({3});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({3});
   auto options3 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({4});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({4});
   auto options4 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({5});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({5});
 
   auto inputPtrs = InputPtrs();
   auto outputPtrs = InputPtrs();
@@ -274,15 +273,15 @@ TEST_F(OptionsCacheTest, RetrieveTopK) {
 
 TEST_F(OptionsCacheTest, KeepOnlyBestCandidates) {
   auto options0 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({1});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({1});
   auto options1 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({2});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({2});
   auto options2 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({3});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({3});
   auto options3 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({4});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({4});
   auto options4 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({5});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({5});
 
   auto inputPtrs = InputPtrs();
   auto outputPtrs = InputPtrs();
@@ -346,9 +345,9 @@ TEST_F(OptionsCacheTest, KeepOnlyBestCandidates) {
 
 TEST_F(OptionsCacheTest, RetrieveBestMedianTime) {
   auto options0 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({1});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({1});
   auto options1 =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions().mapToBlocks({2});
+      tc::CudaMappingOptions::makeNaiveMappingOptions().mapToBlocks({2});
 
   auto inputPtrs = InputPtrs();
   auto outputPtrs = InputPtrs();
@@ -380,8 +379,8 @@ TEST_F(OptionsCacheTest, RetrieveBestMedianTime) {
 }
 
 TEST_F(OptionsCacheTest, Serialization) {
-  auto options0 = tc::CudaMappingOptions::makeNaiveCudaMappingOptions().tile(0);
-  auto options1 = tc::CudaMappingOptions::makeNaiveCudaMappingOptions().tile(1);
+  auto options0 = tc::CudaMappingOptions::makeNaiveMappingOptions().tile(0);
+  auto options1 = tc::CudaMappingOptions::makeNaiveMappingOptions().tile(1);
   auto inputPtrs = InputPtrs();
   auto outputPtrs = InputPtrs();
 
@@ -454,7 +453,7 @@ TEST_F(OptionsCacheTest, Serialization) {
  *        "fcrelu",
  *        inputs_,
  *        outputs_,
- *        tc::CudaMappingOptions::makeMlpCudaMappingOptions(), true);
+ *        tc::CudaMappingOptions::makeMlpMappingOptions(), true);
  *    at::Tensor diff =
  *        outputs_[0].sub(inputs_[0].mm(inputs_[1]).add(inputs_[2]).clamp_min(0));
  *    checkRtol(diff, inputs_, M);
@@ -480,7 +479,7 @@ class MatMulTester {
         M{M} {}
   void Run(
       tc::CudaMappingOptions options =
-          tc::CudaMappingOptions::makeMlpCudaMappingOptions()) {
+          tc::CudaMappingOptions::makeMlpMappingOptions()) {
     tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
     atCompl.define(tc_);
     std::vector<at::Tensor> outputs_;
@@ -510,7 +509,7 @@ class ConvolutionTester {
         KW{KW} {}
   void Run(
       tc::CudaMappingOptions options =
-          tc::CudaMappingOptions::makeConvolutionCudaMappingOptions()) {
+          tc::CudaMappingOptions::makeConvolutionMappingOptions()) {
     tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
     atCompl.define(tc_);
     std::vector<at::Tensor> outputs_;
@@ -665,7 +664,7 @@ TEST_F(CompilationCacheTest, ModifyIslOptions) {
   // test0.Run();
 
   MatMulTester test1{8, 32, 16};
-  auto options = tc::CudaMappingOptions::makeMlpCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeMlpMappingOptions()
                      .tile(1, 1, 1)
                      .mapToThreads(2, 2, 2)
                      .mapToBlocks(1, 1, 1)
@@ -673,7 +672,7 @@ TEST_F(CompilationCacheTest, ModifyIslOptions) {
   test1.Run(options);
 
   ConvolutionTester test2{1, 1, 1, 2, 2, 1, 1};
-  options = tc::CudaMappingOptions::makeConvolutionCudaMappingOptions()
+  options = tc::CudaMappingOptions::makeConvolutionMappingOptions()
                 .tile(2, 2, 2)
                 .mapToThreads(1, 1, 1)
                 .mapToBlocks(1, 1)
@@ -697,7 +696,7 @@ TEST_F(CompilationCacheTest, ModifyIslOptionsConcurrent) {
 
   auto fut1 = std::async(std::launch::async, []() {
     MatMulTester test1{8, 32, 16};
-    auto options = tc::CudaMappingOptions::makeMlpCudaMappingOptions()
+    auto options = tc::CudaMappingOptions::makeMlpMappingOptions()
                        .tile(1, 1, 1)
                        .mapToThreads(2, 2, 2)
                        .mapToBlocks(1, 1, 1)
@@ -707,7 +706,7 @@ TEST_F(CompilationCacheTest, ModifyIslOptionsConcurrent) {
 
   auto fut2 = std::async(std::launch::async, []() {
     ConvolutionTester test2{1, 1, 1, 2, 2, 1, 1};
-    auto options = tc::CudaMappingOptions::makeConvolutionCudaMappingOptions()
+    auto options = tc::CudaMappingOptions::makeConvolutionMappingOptions()
                        .tile(2, 2, 2)
                        .mapToThreads(1, 1, 1)
                        .mapToBlocks(1, 1)
@@ -769,7 +768,7 @@ def add(float(N) A, float(N) B) -> (output) {
                                  at::CUDA(at::kFloat).rand({100})};
 
   tc::CudaMappingOptions options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+      tc::CudaMappingOptions::makeNaiveMappingOptions();
 
   auto tensorsPair = tc::toConstDlpackTensors(inputs);
   tc::ScopeGuard g([&]() { tc::deleteDlmTensors(tensorsPair.second); });

--- a/test/cuda/test_corner_cases.cc
+++ b/test/cuda/test_corner_cases.cc
@@ -59,8 +59,8 @@ static void Succeed(
     std::string fn = "f") {
   tc::ATenCompilationUnit<tc::CudaTcExecutor> cu;
   cu.define(str);
-  auto handle = cu.compile(
-      fn, inputs, tc::CudaMappingOptions::makeNaiveCudaMappingOptions());
+  auto handle =
+      cu.compile(fn, inputs, tc::CudaMappingOptions::makeNaiveMappingOptions());
   cu.run("f", inputs, outputs, handle);
 }
 

--- a/test/cuda/test_execution_engine.cc
+++ b/test/cuda/test_execution_engine.cc
@@ -62,7 +62,7 @@ def softmax(float(N, D) I) -> (O, tmp) {
 }
     )",
       "softmax",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       inputs,
       outputs);
 }
@@ -83,7 +83,7 @@ def softmax(float(N, D) I) -> (O, tmp) {
 }
     )",
       "softmax",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       inputs,
       outputs);
 }
@@ -102,7 +102,7 @@ def softmax(float(N, D) I) -> (O, expsum, maxVal) {
 }
     )",
       "softmax",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       inputs,
       outputs);
 }
@@ -122,7 +122,7 @@ def softmax(float(N, D) I) -> (O, maxVal, expDistance, expSum) {
 }
     )",
       "softmax",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       inputs,
       outputs);
 }
@@ -140,7 +140,7 @@ def concat(float(M, N) A, float(M, N) B) -> (O1) {
 }
     )",
       "concat",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       inputs,
       outputs);
 }
@@ -158,7 +158,7 @@ def indexing(float(H, W) input, int32(L) index) -> (output) {
 }
     )",
       "indexing",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       inputs,
       outputs);
 }
@@ -176,7 +176,7 @@ def matmul(float(M,N) A, float(N,K) B) -> (output) {
 }
     )",
       "matmul",
-      tc::CudaMappingOptions::makeMlpCudaMappingOptions(),
+      tc::CudaMappingOptions::makeMlpMappingOptions(),
       inputs,
       outputs);
 
@@ -199,7 +199,7 @@ def matmul(float(M,N) A, float(N,K) B) -> (output) {
 }
     )",
       "matmul",
-      tc::CudaMappingOptions::makeMlpCudaMappingOptions(),
+      tc::CudaMappingOptions::makeMlpMappingOptions(),
       inputs,
       outputs);
 
@@ -226,7 +226,7 @@ def convolution(float(N,C,H,W) I, float(O,C,KH,KW) W1, float(O) B)
 }
     )",
       "convolution",
-      tc::CudaMappingOptions::makeConvolutionCudaMappingOptions(),
+      tc::CudaMappingOptions::makeConvolutionMappingOptions(),
       inputs,
       outputs);
 
@@ -258,7 +258,7 @@ def convolutionStrided(float(N,C,H,W) I, float(O,C,KH,KW) W1, float(O) B)
   Check(
       tcStr,
       "convolutionStrided",
-      tc::CudaMappingOptions::makeConvolutionCudaMappingOptions(),
+      tc::CudaMappingOptions::makeConvolutionMappingOptions(),
       inputs,
       outputs);
 
@@ -283,7 +283,7 @@ def cast(float(M,N) A, int32 four) -> (int32(M,N) output) {
 }
     )",
       "cast",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       {a, b},
       outputs);
   auto r = outputs[0].sub(at::CUDA(at::kInt).ones({2, 4}) + 4).max().toCFloat();

--- a/test/cuda/test_execution_engine_cache.cc
+++ b/test/cuda/test_execution_engine_cache.cc
@@ -47,7 +47,7 @@ def matmul(float(M,K) A, float(K,N) B) -> (output) {
   std::vector<at::Tensor> inputs = {a, b};
   std::vector<at::Tensor> outputs;
 
-  auto mappingOptions = tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+  auto mappingOptions = tc::CudaMappingOptions::makeMlpMappingOptions();
   auto handle = atCompl.compile("matmul", inputs, mappingOptions);
   atCompl.run("matmul", inputs, outputs, handle);
   at::Tensor diff = outputs[0].sub(a.mm(b));

--- a/test/cuda/test_execution_engine_db.cc
+++ b/test/cuda/test_execution_engine_db.cc
@@ -52,7 +52,7 @@ def convolution(float(N,C,H,W) I, float(O,C,KH,KW) W1, float(O) B)
   at::Tensor b = at::CUDA(at::kFloat).rand({4, 5});
   std::vector<at::Tensor> inputs = {a, b};
   std::vector<at::Tensor> outputs;
-  auto mappingOptions = tc::CudaMappingOptions::makeMlpCudaMappingOptions();
+  auto mappingOptions = tc::CudaMappingOptions::makeMlpMappingOptions();
   auto handle = atCompl.compile("matmul", inputs, mappingOptions);
   atCompl.run("matmul", inputs, outputs, handle);
   at::Tensor diff = outputs[0].sub(a.mm(b));
@@ -65,8 +65,7 @@ def convolution(float(N,C,H,W) I, float(O,C,KH,KW) W1, float(O) B)
   at::Tensor B = at::CUDA(at::kFloat).rand({O});
   std::vector<at::Tensor> inputs1 = {I, W1, B};
   std::vector<at::Tensor> outputs1;
-  mappingOptions =
-      tc::CudaMappingOptions::makeGroupConvolutionCudaMappingOptions();
+  mappingOptions = tc::CudaMappingOptions::makeGroupConvolutionMappingOptions();
   handle = atCompl.compile("convolution", inputs1, mappingOptions);
   atCompl.run("convolution", inputs1, outputs1, handle);
   at::Tensor expected = at::conv2d(I, W1, B);

--- a/test/cuda/test_tc_mapper.cc
+++ b/test/cuda/test_tc_mapper.cc
@@ -43,7 +43,7 @@ using TcCudaMapperBatchMatmulTest = TcMapperBatchMatmulTest<tc::CudaTcExecutor>;
 //   C +=! A(r_m)
 ///////////////////////////////////////////////////////////////////////////////
 TEST_F(TcCudaMapper1DReductionTest, DISABLED_Reduction1Dv0) {
-  auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(0)
                             .mapToBlocks({})
                             .mapToThreads({16});
@@ -52,7 +52,7 @@ TEST_F(TcCudaMapper1DReductionTest, DISABLED_Reduction1Dv0) {
 }
 
 TEST_F(TcCudaMapper1DReductionTest, Reduction1Dv1) {
-  auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(0)
                             .mapToBlocks({1})
                             .mapToThreads({16});
@@ -61,7 +61,7 @@ TEST_F(TcCudaMapper1DReductionTest, Reduction1Dv1) {
 }
 
 TEST_F(TcCudaMapper1DReductionTest, Reduction1Dv2) {
-  auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(0)
                             .mapToBlocks({1})
                             .mapToThreads({16});
@@ -70,7 +70,7 @@ TEST_F(TcCudaMapper1DReductionTest, Reduction1Dv2) {
 }
 
 TEST_F(TcCudaMapper1DReductionTest, Reduction1Dv3) {
-  auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(0)
                             .mapToBlocks({1})
                             .mapToThreads({16});
@@ -83,7 +83,7 @@ TEST_F(TcCudaMapper1DReductionTest, Reduction1Dv3) {
 //   C(m) +=! A(m, r_n)
 ///////////////////////////////////////////////////////////////////////////////
 TEST_F(TcCudaMapper2DReductionTest, Reduction2D1) {
-  auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(32, 32)
                             .mapToBlocks({1, 1})
                             .mapToThreads({32})
@@ -104,7 +104,7 @@ struct TcCudaMapper2DReductionStressTest : public TcCudaMapper2DReductionTest {
   Check(size_t tix, size_t tiy, bool skipCheck = false, bool ones = false) {
     M = tiy;
     N = tix;
-    auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+    auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                               .tile(tiy, tix)
                               .mapToBlocks({1})
                               .mapToThreads({tix, tiy})
@@ -167,7 +167,7 @@ TEST_F(TcCudaMapper2DReductionStressTest, Iterate) {
 //   C(m, n) +=! A(m, r_k) * B(r_k, n)
 ///////////////////////////////////////////////////////////////////////////////
 TEST_F(TcCudaMapperMatmulTest, Matmul1DSchedule) {
-  auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                             .fixParametersBeforeScheduling(true)
                             .tile(1, 1, K)
                             .mapToBlocks({M, N})
@@ -182,7 +182,7 @@ TEST_F(TcCudaMapperMatmulTest, Matmul1DScheduleMultipleOccurrence) {
   // Without full specialization, AST generator will duplicate the first
   // statement C[i][j] = 0.0f (for K > 0 and K < 0).  The codegen must be able
   // to handle the same statement appearing in different contexts.
-  auto mappingOptions = tc::CudaMappingOptions::makeMlpCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeMlpMappingOptions()
                             .fixParametersBeforeScheduling(false)
                             .tile(32, 32, 32)
                             .mapToBlocks({8})
@@ -194,7 +194,7 @@ TEST_F(TcCudaMapperMatmulTest, Matmul1DScheduleMultipleOccurrence) {
 }
 
 TEST_F(TcCudaMapperMatmulTest, Matmul3DSchedule) {
-  auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                             .fixParametersBeforeScheduling(true)
                             .mapToBlocks({1, 1, 1})
                             .mapToThreads({4, 1, 1});
@@ -205,7 +205,7 @@ TEST_F(TcCudaMapperMatmulTest, Matmul3DSchedule) {
 }
 
 TEST_F(TcCudaMapperMatmulTest, Matmul3DScheduleMultipleOccurrence) {
-  auto mappingOptions = tc::CudaMappingOptions::makeMlpCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeMlpMappingOptions()
                             .tile(32, 32, 32)
                             .mapToBlocks({8})
                             .mapToThreads({16})
@@ -220,7 +220,7 @@ TEST_F(TcCudaMapperMatmulTest, Matmul3DScheduleMultipleOccurrence) {
 //   Z(b, n, k) +=! X(b, n, r_m) * Y(b, r_m, k)
 ///////////////////////////////////////////////////////////////////////////////
 TEST_F(TcCudaMapperBatchMatmulTest, BatchMatmul) {
-  auto mappingOptions = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(1)
                             .mapToThreads({123})
                             .mapToBlocks({50})
@@ -257,7 +257,7 @@ def batch_triple_hadamard(float(B, D) U, float(B, D) V, float(B, D) W) -> (Z) {
   Check(
       TC,
       "batch_triple_hadamard",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       inputs,
       checkFun);
 }
@@ -281,7 +281,7 @@ def tensordot(float(N, C1, C2, H, W) I0, float(N, C2, C3, H, W) I1) -> (O) {
   // No defaults for this case
   auto checkFun = [](const std::vector<at::Tensor>& inputs,
                      std::vector<at::Tensor>& outputs) { return true; };
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   auto name = "tensordot";
   Check(TC, name, options, inputs, checkFun);
   ::benchmarkKernelOptions(TC, name, inputs, options);
@@ -330,7 +330,7 @@ def fun(float(B, R) LUT, int32(B, N) I) -> (O) {
   Check(
       TC,
       "fun",
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions(),
+      tc::CudaMappingOptions::makeNaiveMappingOptions(),
       inputs,
       checkFun);
 }
@@ -393,7 +393,7 @@ def spatial_batch_norm(
   };
 
   auto name = "spatial_batch_norm";
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .intraTileScheduleFusionStrategy(tc::FusionStrategy::Min)
                      .tile(0)

--- a/test/cuda/test_tc_mapper_bugs.cc
+++ b/test/cuda/test_tc_mapper_bugs.cc
@@ -74,8 +74,7 @@ def tensordot_naive(float(N, C1, C2, H, W) I0, float(N, C2, C3, H, W) I1) -> (O)
     // If running cuda-gdb only run on test code, not reference: things are
     // slow in this mode
     if (!FLAGS_debug_cuda) {
-      auto mappingOptions =
-          tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+      auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions();
       tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
       atCompl.define(TC);
       auto handle = atCompl.compile("tensordot_naive", inputs, mappingOptions);
@@ -111,7 +110,7 @@ def tensordot_naive(float(N, C1, C2, H, W) I0, float(N, C2, C3, H, W) I1) -> (O)
 };
 
 TEST_F(TensorDot_32_512_8_2_28_28, BaseCorrect) {
-  auto options = tc::CudaMappingOptions::makeConvolutionCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeConvolutionMappingOptions();
   Init();
   Check(options);
 }
@@ -120,7 +119,7 @@ TEST_F(TensorDot_32_512_8_2_28_28, BaseCorrect) {
 TEST_F(TensorDot_32_512_8_2_28_28, ReductionUnroll) {
   Init();
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -151,7 +150,7 @@ TEST_F(TensorDot_32_512_8_2_28_28, ReductionUnroll) {
 TEST_F(TensorDot_32_512_8_2_28_28, Reduction1) {
   Init();
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -177,7 +176,7 @@ TEST_F(TensorDot_32_512_8_2_28_28, Reduction1) {
 TEST_F(TensorDot_32_512_8_2_28_28, Reduction2) {
   Init();
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -203,7 +202,7 @@ TEST_F(TensorDot_32_512_8_2_28_28, Reduction2) {
 TEST_F(TensorDot_32_512_8_2_28_28, Reduction3) {
   Init();
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -229,7 +228,7 @@ TEST_F(TensorDot_32_512_8_2_28_28, Reduction3) {
 TEST_F(TensorDot_32_512_8_2_28_28, FormerSharedIllegalAddress) {
   Init();
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -251,7 +250,7 @@ TEST_F(TensorDot_32_512_8_2_28_28, FormerSharedIllegalAddress) {
 TEST_F(TensorDot_32_512_8_2_28_28, NoUnroll) {
   Init();
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -274,7 +273,7 @@ TEST_F(TensorDot_32_512_8_2_28_28, NoUnroll) {
 // statement.  Tightening was choking on such empty filters.
 TEST_F(TensorDot_32_512_8_2_28_28, EmptyLeaf) {
   Init();
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Min)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -298,7 +297,7 @@ TEST_F(TensorDot_32_512_8_2_28_28, EmptyLeaf) {
 TEST_F(TensorDot_32_512_8_2_28_28, FormerIllegalAccess) {
   Init();
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -352,8 +351,7 @@ def group_convolution_naive(float(N,G,C,H,W) I, float(G,F,C,KH,KW) W_, float(G,F
     // If running cuda-gdb only run on test code, not reference: things are
     // slow in this mode
     if (!FLAGS_debug_cuda) {
-      auto mappingOptions =
-          tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+      auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions();
       tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
       atCompl.define(TC);
       auto handle =
@@ -393,7 +391,7 @@ def group_convolution_naive(float(N,G,C,H,W) I, float(G,F,C,KH,KW) W_, float(G,F
 
 TEST_F(GroupConvolution_32_32_4_4_56_56_3_3, FormerSharedIllegalAddress) {
   Init();
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -418,7 +416,7 @@ TEST_F(
     GroupConvolution_32_32_4_4_56_56_3_3,
     FakeIslSchedulerUnableToCarryDependences) {
   Init();
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -467,8 +465,7 @@ def _C3_naive(float(B,WX) I, float(WY, WX) W) -> (C3) {
     // If running cuda-gdb only run on test code, not reference: things are
     // slow in this mode
     if (!FLAGS_debug_cuda) {
-      auto mappingOptions =
-          tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+      auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions();
       tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
       atCompl.define(TC);
       auto handle = atCompl.compile("_C3_naive", inputs, mappingOptions);
@@ -506,7 +503,7 @@ def _C3_naive(float(B,WX) I, float(WY, WX) W) -> (C3) {
 // with shared memory.
 TEST_F(C3_128_1000_1024, InvalidPtx) {
   Init();
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -527,7 +524,7 @@ TEST_F(C3_128_1000_1024, InvalidPtx) {
 
 TEST_F(C3_128_1000_1024, IllegalAccess) {
   Init();
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -583,8 +580,7 @@ def tmm_naive(float(B, X) I, float(Y, X) W) -> (O) {
     // If running cuda-gdb only run on test code, not reference: things are
     // slow in this mode
     if (!FLAGS_debug_cuda) {
-      auto mappingOptions =
-          tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+      auto mappingOptions = tc::CudaMappingOptions::makeNaiveMappingOptions();
       tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
       atCompl.define(TC);
       auto handle = atCompl.compile("tmm_naive", inputs, mappingOptions);
@@ -620,7 +616,7 @@ def tmm_naive(float(B, X) I, float(Y, X) W) -> (O) {
 // For this one we need to relax the precision to 1e-6
 TEST_F(TMM_128_1024_1024, TooStrictPrecisionAfterTuner) {
   Init();
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -642,7 +638,7 @@ TEST_F(TMM_128_1024_1024, TooStrictPrecisionAfterTuner) {
 // This exercises a former MappingFilter leaf with a union_set of > 1 spaces
 TEST_F(TMM_128_1024_1024, Tightening) {
   Init();
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -676,7 +672,7 @@ def layernorm(float(T, B, C) I) -> (O, mean, centered, var) {
     O(t, b, c) =  centered(t, b, c) / rsqrt(var(t, b))
 }
   )TC";
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()
                      .outerScheduleFusionStrategy(tc::FusionStrategy::Max)
                      .outerScheduleAllowSkewing(false)
                      .outerSchedulePositiveOrthant(true)
@@ -718,7 +714,7 @@ def tmm_naive(float(B, X) I, float(Y, X) W) -> (O) {
 }
 )TC");
   auto options =
-      tc::CudaMappingOptions::makeNaiveCudaMappingOptions()
+      tc::CudaMappingOptions::makeNaiveMappingOptions()
           .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
           .outerScheduleAllowSkewing(false)
           .outerSchedulePositiveOrthant(true)
@@ -753,7 +749,7 @@ def graph2(float(N, C, H, W) I, float(N, C, R, T) J, float(KH, KW) W1) -> (O, Ou
     Out(c0, c1)     +=! I(n, c0,        h,        w) *  O(   n,   c1, h, w)
 }
   )TC";
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
 
   tc::ATenCompilationUnit<tc::CudaTcExecutor> atCompl;
   atCompl.define(TC);
@@ -783,7 +779,7 @@ TEST(Convolution, NestedExpressions) {
   std::vector<at::Tensor> outputs;
   tc::ATenCompilationUnit<tc::CudaTcExecutor> cu;
   cu.define(TC);
-  auto options = tc::CudaMappingOptions::makeNaiveCudaMappingOptions();
+  auto options = tc::CudaMappingOptions::makeNaiveMappingOptions();
   auto handle = cu.compile(convolution, inputs, options);
   cu.run(convolution, inputs, outputs, handle);
   auto B = outputs[0];

--- a/test/isl_cli_strategy.h
+++ b/test/isl_cli_strategy.h
@@ -78,7 +78,7 @@ tc::CudaMappingOptions makeBaseCliStrategy() {
   tc::FusionStrategy fs;
   CHECK(tc::FusionStrategy_Parse(DEFAULT_FUSION_STRATEGY, &fs));
   CudaMappingOptions options =
-      CudaMappingOptions::makeNaiveCudaMappingOptions()
+      CudaMappingOptions::makeNaiveMappingOptions()
           .mapToThreads(DEFAULT_BLOCK)
           .mapToBlocks(DEFAULT_GRID)
           .useSharedMemory(DEFAULT_USE_SHARED_MEMORY)

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -70,7 +70,7 @@ struct PolyhedralMapperTest : public ::testing::Test {
   }
 
   static CudaMappingOptions DefaultOptions() {
-    return CudaMappingOptions::makeNaiveCudaMappingOptions();
+    return CudaMappingOptions::makeNaiveMappingOptions();
   }
 
   std::unique_ptr<MappedScop> TileAndMapThreads(
@@ -631,7 +631,7 @@ TEST_F(PolyhedralMapperTest, Unroll2D) {
 }
 
 /*
- * Map 1D code to 2D grid (set up by makeNaiveCudaMappingOptions()) and
+ * Map 1D code to 2D grid (set up by makeNaiveMappingOptions()) and
  * check that the code is pinned to one particular value of
  * block identifier b1 and thread identifier t1.
  */

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -63,7 +63,7 @@ class MapperMemoryPromotion2DHelper : public TestMapper {
       std::unordered_map<std::string, size_t> problemSizes,
       std::vector<size_t> tileSizes) {
     auto mappingOptions =
-        CudaMappingOptions::makeNaiveCudaMappingOptions()
+        CudaMappingOptions::makeNaiveMappingOptions()
             .tile(tileSizes) // passing more tiling values triggers a check...
             .useSharedMemory(false) // do not auto-promote
             .usePrivateMemory(false);
@@ -83,7 +83,7 @@ def fun(float(N,M,K,L) A, float(N,M,K,L) B) -> (C) {
 }
 )TC";
 
-    auto mappingOptions = CudaMappingOptions::makeNaiveCudaMappingOptions()
+    auto mappingOptions = CudaMappingOptions::makeNaiveMappingOptions()
                               .tile(tileSizes)
                               .useSharedMemory(false) // do not autopromote
                               .usePrivateMemory(false);
@@ -458,7 +458,7 @@ def fun(float(N,K) A, float(K,M) B, float(N,M) C) -> (O) {
 };
 
 TEST_F(MatMulBias, RegisterPromotion) {
-  auto mappingOptions = CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(32, 32, 32)
                             .useSharedMemory(false)
                             .usePrivateMemory(true);
@@ -489,7 +489,7 @@ TEST_F(MatMulBias, RegisterPromotion) {
 }
 
 TEST_F(MatMulBias, RegisterPromotionSharedPreference) {
-  auto mappingOptions = CudaMappingOptions::makeNaiveCudaMappingOptions()
+  auto mappingOptions = CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(32, 32, 32)
                             .maxSharedMemory(32768)
                             .useSharedMemory(true)


### PR DESCRIPTION
This changeset introduces a renaming that will help reduce the delta for
the C++ API refactoring. In particular makeXXXMappingOptions will exist for
different types of mapping options (CPU, CUDA, OpenCL).

The Backend specific MappingOptions functions become generic and not named
after a particular backend.

They can later be used with template types in the overall refactoring.