### PR TITLE
Scop::makeScop: drop renaming of band partial schedules

### DIFF
--- a/tc/core/constants.h
+++ b/tc/core/constants.h
@@ -22,7 +22,6 @@ namespace polyhedral {
 // General constants to avoid hardcoding
 //
 constexpr auto kStatementLabel = "S_";
-constexpr auto kPartialScheduleLabel = "L_";
 
 constexpr auto kAstNodeIdPrefix = "__node_";
 

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -67,17 +67,6 @@ ScopUPtr Scop::makeScop(
   scop->halide.reductions = halide2isl::findReductions(components.stmt);
   scop->halide.iterators = std::move(tree.iterators);
 
-  // Set partial schedule tuples for proper comparison with ISL
-  // schedules (needs DFSPreorder numbering). Just for testing.
-  auto bands = ScheduleTree::collectDFSPreorder(
-      scop->scheduleRoot(), detail::ScheduleTreeType::Band);
-  for (size_t i = 0; i < bands.size(); ++i) {
-    auto b = bands[i]->elemAs<ScheduleTreeElemBand>();
-    CHECK(b);
-    b->mupa_ = b->mupa_.set_tuple_name(
-        isl::dim_type::set, kPartialScheduleLabel + std::to_string(i));
-  }
-
   return scop;
 }
 


### PR DESCRIPTION
The renaming was presumably meant to be able to compare against pet
(rather than isl as the comment claims) and the use of pet has been
removed in prehistory.  The renaming therefore no longer serves any
purpose.