### PR TITLE
do not build tc_caffe2_test_harness when WITH_CUDA=0 is set

### DIFF
--- a/test/caffe2/CMakeLists.txt
+++ b/test/caffe2/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_library(tc_caffe2_test_harness SHARED test_harness.cc)
-target_link_libraries(tc_caffe2_test_harness tc_c2)
-install(TARGETS tc_caffe2_test_harness DESTINATION lib)
-
 if (WITH_CUDA)
+  add_library(tc_caffe2_test_harness SHARED test_harness.cc)
+  target_link_libraries(tc_caffe2_test_harness tc_c2)
+  install(TARGETS tc_caffe2_test_harness DESTINATION lib)
+
   add_subdirectory(cuda)
 endif()


### PR DESCRIPTION
tc_caffe2_test_harness depends on CUDA:

    In file included from /home/skimo/git/c2isl/tc/c2/tc_op.h:24:0,
		     from /home/skimo/git/c2isl/test/caffe2/test_harness.h:31,
		     from /home/skimo/git/c2isl/test/caffe2/test_harness.cc:16:
    /home/skimo/git/c2isl/tc/core/cuda/cuda.h:19:2: error: #error "CUDA_HOME must be defined"
     #error "CUDA_HOME must be defined"
      ^~~~~
    /home/skimo/git/c2isl/tc/core/cuda/cuda.h:23:2: error: #error "CUB_HOME must be defined"
     #error "CUB_HOME must be defined"
      ^~~~~
This issue was introduced in 66a10a05 (Start extracting
a tc_caffe2_test_harness library, Sat May 5 20:47:42 2018 -0600).