### PR TITLE
finish handling of single node schedule trees

### DIFF
--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -332,8 +332,6 @@ isl::schedule_constraints makeScheduleConstraints(
     const Scop& scop,
     const SchedulerOptionsView& schedulerOptions,
     isl::union_set restrictDomain = isl::union_set()) {
-  auto firstChildNode = scop.scheduleRoot()->child({0});
-
   auto constraints = isl::schedule_constraints::on_domain(scop.domain())
                          .set_validity(scop.dependences)
                          .set_proximity(scop.dependences)
@@ -341,9 +339,12 @@ isl::schedule_constraints makeScheduleConstraints(
   if (restrictDomain) {
     constraints = constraints.intersect_domain(restrictDomain);
   }
-  if (auto contextNode =
-          firstChildNode->elemAs<detail::ScheduleTreeElemContext>()) {
-    constraints = constraints.set_context(contextNode->context_);
+  auto root = scop.scheduleRoot();
+  if (root->numChildren() > 0) {
+    if (auto contextNode =
+            root->child({0})->elemAs<detail::ScheduleTreeElemContext>()) {
+      constraints = constraints.set_context(contextNode->context_);
+    }
   }
 
   // Set up "add_schedule_constraints" and "merge_callback"

--- a/test/cuda/test_corner_cases.cc
+++ b/test/cuda/test_corner_cases.cc
@@ -85,8 +85,8 @@ TEST(TestCornerCases, E2) {
   Succeed("def f(float(1) a) -> (b) { b(i) = a(i) }", {F(1)}, {F(1)});
 }
 
-// free(): invalid next size (fast): 0x000000003b2d6230 ***
-TEST(TestCornerCases, DISABLED_E4) {
+// Schedule tree that only consists of domain node
+TEST(TestCornerCases, E4) {
   Succeed("def f(float a) -> (b) { b = a }", {F()}, {F()});
 }
 


### PR DESCRIPTION
Prior to 653ecbb0 (halide2isl::makeScheduleTree: use isl::schedule
for constructing tree, Thu Mar 22 11:32:03 2018 +0100),
makeScheduleTree refused to construct a schedule tree
that consists of a single (domain) node.
Since then, inputs that result in such a tree are handled
by makeScheduleTree, but makeScheduleConstraints still
assumed that a tree contains at least two nodes.
Remove that assumption, allowing TestCornerCases.E4
to be enabled.