### PR TITLE
Fix XXXMappingOptionsCppPrinter

### DIFF
--- a/tc/core/cpu/cpu_mapping_options_cpp_printer.cc
+++ b/tc/core/cpu/cpu_mapping_options_cpp_printer.cc
@@ -22,6 +22,7 @@ namespace tc {
 CpuMappingOptionsCppPrinter& operator<<(
     CpuMappingOptionsCppPrinter& prn,
     const CpuMappingOptions& options) {
+  prn.printString("tc::CpuMappingOptions::makeNaiveMappingOptions()");
   prn.print(options.generic);
   prn.endStmt();
   return prn;

--- a/tc/core/cuda/cuda_mapping_options_cpp_printer.cc
+++ b/tc/core/cuda/cuda_mapping_options_cpp_printer.cc
@@ -22,6 +22,7 @@ namespace tc {
 CudaMappingOptionsCppPrinter& operator<<(
     CudaMappingOptionsCppPrinter& prn,
     const CudaMappingOptions& cudaOptions) {
+  prn.printString("tc::CudaMappingOptions::makeNaiveMappingOptions()");
   prn.print(cudaOptions.generic);
   prn.printListOption("mapToThreads", cudaOptions.block.extractVector());
   prn.printListOption("mapToBlocks", cudaOptions.grid.extractVector());

--- a/tc/core/mapping_options_cpp_printer.cc
+++ b/tc/core/mapping_options_cpp_printer.cc
@@ -35,9 +35,7 @@ MappingOptionsCppPrinter& MappingOptionsCppPrinter::printSchedulerOptions(
 
 MappingOptionsCppPrinter& MappingOptionsCppPrinter::print(
     const MappingOptions& options) {
-  printString("tc::MappingOptions::makeNaiveMappingOptions()")
-      .printSchedulerOptions(
-          options.view.outerScheduleOptions, "outerSchedule");
+  printSchedulerOptions(options.view.outerScheduleOptions, "outerSchedule");
   if (options.view.proto.has_intra_tile_schedule_options()) {
     printSchedulerOptions(
         options.view.intraTileScheduleOptions, "intraTileSchedule");

--- a/tc/core/mapping_options_cpp_printer.cc
+++ b/tc/core/mapping_options_cpp_printer.cc
@@ -42,6 +42,9 @@ MappingOptionsCppPrinter& MappingOptionsCppPrinter::print(
     printSchedulerOptions(
         options.view.intraTileScheduleOptions, "intraTileSchedule");
   }
+  printBooleanOption(
+      "fixParametersBeforeScheduling",
+      options.view.proto.fix_parameters_before_scheduling());
   if (options.view.proto.has_tiling()) {
     printListOption("tile", options.view.tiling.extractVector());
   }


### PR DESCRIPTION
Previously the printer would print `tc::MappingOptions::makeNaiveOptions()...`
but this is incorrect because the backend-agnostic MappingOptions does not
have the backend-specific knowledge.
With this commit, each backend-specific printer would print properly like:
`tc::CudaMappingOptions::makeNaiveOptions()...` or
`tc::CpuMappingOptions::makeNaiveOptions()...`