### PR TITLE
Fixed bug on tiling range in autotuner.

### DIFF
--- a/tc/autotuner/autotuner-inl.h
+++ b/tc/autotuner/autotuner-inl.h
@@ -396,7 +396,7 @@ void setupTuningParameters(
   auto nTilesDim = largestDim(inputs) + 1;
   auto tileRange = range;
   tileRange.push_back(0);
-  configuration.tilingParams.setRange(nTilesDim, range);
+  configuration.tilingParams.setRange(nTilesDim, tileRange);
   configuration.blockParams.setRange(range, "b");
   configuration.gridParams.setRange(range, "g");
   configuration.unrollFactor = RangeParameter({1, 2, 4, 8, 16, 32}, "unroll");


### PR DESCRIPTION
0 is a valid tiling annotation, but wasn't in the autotuner tiling range.

The variable tileRange was already created, but wasn't used.