### PR TITLE
Fix ATen build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -240,7 +240,7 @@ function install_aten() {
       if should_reconfigure .. .build_cache; then
         echo "Reconfiguring ATen"
         export PYTORCH_PYTHON=${PYTHON}
-        ${CMAKE_VERSION} .. -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DHAS_C11_ATOMICS=OFF -DNO_CUDA=${ATEN_NO_CUDA} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC}
+        ${CMAKE_VERSION} .. -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DHAS_C11_ATOMICS=OFF -DNO_CUDA=${ATEN_NO_CUDA} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCUDNN_ROOT_DIR=${CUDNN_ROOT_DIR}
       fi
       make -j $CORES -s || exit 1
 


### PR DESCRIPTION
Add the CUDNN_ROOT_DIR flag to the ATen build, without it ATen performance
may be artifically slow.