### PR TITLE
use ScheduleTreeElemBand::nMember

### DIFF
--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -293,8 +293,8 @@ ScheduleTree*
 bandSplitOut(ScheduleTree* relativeRoot, ScheduleTree* tree, size_t pos) {
   auto band = tree->elemAs<ScheduleTreeElemBand>();
   CHECK(band);
-  auto schedule = band->mupa_;
-  if (pos != schedule.dim(isl::dim_type::set) - 1) {
+  auto size = band->nMember();
+  if (pos != size - 1) {
     tree = bandSplit(relativeRoot, tree, pos + 1);
   }
   if (pos != 0) {

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -192,7 +192,7 @@ size_t ScheduleTree::scheduleDepth(const ScheduleTree* relativeRoot) const {
     if (!bandElem) {
       continue;
     }
-    depth += bandElem->mupa_.dim(isl::dim_type::set);
+    depth += bandElem->nMember();
   }
   return depth;
 }

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -193,8 +193,8 @@ bool ScheduleTreeElemBand::operator==(const ScheduleTreeElemBand& other) const {
   // further comparison.  Compare its explicit domains instead.  Note that
   // .domain() returns a zero-dimensional union set (in purely parameter space)
   // if there is no explicit domain.
-  bool mupaIs0D = mupa_.dim(isl::dim_type::set) == 0;
-  bool otherMupaIs0D = other.mupa_.dim(isl::dim_type::set) == 0;
+  bool mupaIs0D = nMember() == 0;
+  bool otherMupaIs0D = other.nMember() == 0;
   if (mupaIs0D ^ otherMupaIs0D) {
     return false;
   }


### PR DESCRIPTION
This is the canonical way of determining the number of
scheduling dimensions in a band.
