### PR TITLE
MappedScop::detectReductions: check that member exists before accessing it

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -203,9 +203,11 @@ bool MappedScop::detectReductions(detail::ScheduleTree* tree) {
   }
 
   // For now, only support reductions with a sufficient number
-  // of coincident outer band members for the remaining thread identifiers.
+  // of coincident outer band members for the remaining thread identifiers and
+  // at least one non-coincident member.
   auto nCoincident = band->nOuterCoincident();
-  if (nCoincident < numThreads.view.size() - 1) {
+  auto nMember = band->nMember();
+  if (nCoincident < numThreads.view.size() - 1 || nCoincident >= nMember) {
     return found;
   }
 


### PR DESCRIPTION
If all members in the band are coincident, then the member
that gets checked for being a reduction lies beyond the band.
It is not clear if this can happen in practice in the current code base
because the band has already been checked for not containing
anything beyond a single update statement and optionally
the corresponding init statement.  However, these restrictions
may get relaxed at some point and there is no point in continuing
if all member are coincident.