### PR TITLE
tc2halide: properly tag reduction updates

### DIFF
--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -482,14 +482,6 @@ std::vector<Reduction> findReductions(const Stmt& s) {
   class FindReductions : public IRVisitor {
     using IRVisitor::visit;
 
-    bool isReductionInit(const Provide* op) {
-      if (const Call* call = op->values[0].as<Call>()) {
-        return call->is_intrinsic(tc2halide::kReductionInit);
-      } else {
-        return false;
-      }
-    }
-
     bool isReductionUpdate(const Provide* op) {
       if (const Call* call = op->values[0].as<Call>()) {
         return call->is_intrinsic(tc2halide::kReductionUpdate);

--- a/tc/core/halide_utils.cc
+++ b/tc/core/halide_utils.cc
@@ -123,8 +123,7 @@ std::string halideCodegenC(const Stmt& stmt) {
     using IRPrinter::visit;
 
     void visit(const Call* op) override {
-      if (op->is_intrinsic(tc2halide::kReductionInit) ||
-          op->is_intrinsic(tc2halide::kReductionUpdate)) {
+      if (op->is_intrinsic(tc2halide::kReductionUpdate)) {
         op->args[0].accept(this);
       } else if (
           op->call_type == Call::Halide || op->call_type == Call::Image) {

--- a/tc/core/polyhedral/codegen_llvm.cc
+++ b/tc/core/polyhedral/codegen_llvm.cc
@@ -234,9 +234,7 @@ class CodeGen_TC : public Halide::Internal::CodeGen_X86 {
       auto addr = builder->CreateInBoundsGEP(baseAddr, args);
       value = builder->CreateLoad(addr);
       return;
-    } else if (
-        call->is_intrinsic(tc2halide::kReductionInit) ||
-        call->is_intrinsic(tc2halide::kReductionUpdate)) {
+    } else if (call->is_intrinsic(tc2halide::kReductionUpdate)) {
       call->args[0].accept(this);
       return;
     } else {

--- a/tc/core/polyhedral/cuda/codegen.cc
+++ b/tc/core/polyhedral/cuda/codegen.cc
@@ -550,9 +550,7 @@ void emitHalideExpr(
           op->call_type == Halide::Internal::Call::CallType::Image) {
         tc::polyhedral::detail::emitMappedTensorAccess(
             op->name, op, op->args, context);
-      } else if (
-          op->is_intrinsic(tc2halide::kReductionInit) ||
-          op->is_intrinsic(tc2halide::kReductionUpdate)) {
+      } else if (op->is_intrinsic(tc2halide::kReductionUpdate)) {
         op->args[0].accept(this);
       } else {
         IRPrinter::visit(op);

--- a/tc/core/tc2halide.cc
+++ b/tc/core/tc2halide.cc
@@ -484,10 +484,6 @@ void forwardBoundsInference(
   }
 }
 
-Expr reductionInit(Expr e) {
-  return Call::make(e.type(), kReductionInit, {e}, Call::Intrinsic);
-}
-
 Expr reductionUpdate(Expr e) {
   return Call::make(e.type(), kReductionUpdate, {e}, Call::Intrinsic);
 }
@@ -819,8 +815,7 @@ HalideComponents translateDef(const lang::Def& def, bool throwWarnings) {
                 op->name, {reductionUpdate(op->values[0])}, op->args);
           } else {
             found_init = true;
-            return Provide::make(
-                op->name, {reductionInit(op->values[0])}, op->args);
+            return op;
           }
         } else {
           return op;

--- a/tc/core/tc2halide.h
+++ b/tc/core/tc2halide.h
@@ -40,8 +40,7 @@ struct HalideComponents {
 };
 
 // For TC reductions, the right-hand-sides of the corresponding
-// Provide nodes are tagged with intrinsics with the following names.
-Halide::Internal::Call::ConstString kReductionInit = "ReductionInit";
+// Provide nodes are tagged with intrinsics with the following name.
 Halide::Internal::Call::ConstString kReductionUpdate = "ReductionUpdate";
 
 // Translate a TC parse tree into equivalent Halide imperative IR with


### PR DESCRIPTION
In particular, only tag reduction updates and only tag them once.
The original code would tag any non-initial write to a tensor
involved in a reduction and it would tag it possibly several times,
once for each reduction on that tensor.
Tag the reduction updates immediately to ensure that
only reduction updates get tagged and that they get tagged exactly once.

Multiply tagged expressions cause confusion in TC.
In particular, isSupportedReduction would fail to detect
the reduction and the code generation also assumes
that a reduction update is only tagged once.