### PR TITLE
halide2isl: findReductions: support multiple reductions on the same tensor

### DIFF
--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -529,11 +529,10 @@ std::vector<Reduction> findReductions(const Stmt& s) {
           }
         }
         if (dims.size() > 0) {
-          auto& p = reductions[op->name];
-          CHECK(!p.update.defined())
-              << "Multiple reduction updates not yet implemented";
+          Reduction p;
           p.update = op;
           p.dims = dims;
+          reductions.emplace_back(p);
         }
       }
     }
@@ -543,15 +542,11 @@ std::vector<Reduction> findReductions(const Stmt& s) {
     std::unordered_set<std::string> reductionVars;
     // The names of the outer For nodes, outermost to innermost.
     std::vector<std::string> vars;
-    std::map<std::string, Reduction> reductions;
+    std::vector<Reduction> reductions;
   } finder;
   s.accept(&finder);
 
-  std::vector<Reduction> result;
-  for (auto p : finder.reductions) {
-    result.push_back(p.second);
-  }
-  return result;
+  return finder.reductions;
 }
 
 } // namespace halide2isl


### PR DESCRIPTION
The tensor name was being used as a key in a map that was used
to match init and update nodes and to store the results.
Since 33a3bb65 (halide2isl: do not require init statement
for reduction detection, Sun May 27 12:04:46 2018 +0200),
these init statements are no longer considered, so the map
is no longer needed.
Collect the reductions directly in a vector instead.

Closes #455