### PR TITLE
MappedScop::detectReductions: order away statements that depend on updates

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -166,6 +166,8 @@ void MappedScop::mapToBlocksAndScaleBand(
   bandScale(band, tileSizes);
 }
 
+namespace {
+
 /*
  * Given a node in the schedule tree of a mapped scop,
  * insert a mapping filter underneath (if needed) that fixes
@@ -185,6 +187,8 @@ void fixThreadsBelow(
   auto bandTree = insertNodeBelow(tree, std::move(band));
   mscop.mapThreadsBackward(bandTree);
 }
+
+} // namespace
 
 bool MappedScop::detectReductions(detail::ScheduleTree* tree) {
   bool found = false;

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -241,6 +241,14 @@ bool canOrderBefore(
     detail::ScheduleTree* tree,
     isl::union_set filter,
     isl::union_map dependences);
+// Is it possible to order the elements in the given filter
+// after the other active elements without violating
+// any of the given dependences?
+bool canOrderAfter(
+    detail::ScheduleTree* root,
+    detail::ScheduleTree* tree,
+    isl::union_set filter,
+    isl::union_map dependences);
 
 // Insert a sequence to ensure that the active domain elements
 // in the given filter are executed before the other active domain elements.

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -867,7 +867,8 @@ struct ReductionTest : public PolyhedralMapperTest {
         .outerScheduleFusionStrategy(tc::FusionStrategy::Preserve3Coincident)
         .outerScheduleAllowSkewing(false)
         .outerSchedulePositiveOrthant(true)
-        .intraTileScheduleFusionStrategy(tc::FusionStrategy::Min)
+        .intraTileScheduleFusionStrategy(
+            tc::FusionStrategy::Preserve3Coincident)
         .intraTileScheduleAllowSkewing(false)
         .intraTileSchedulePositiveOrthant(true)
         .fixParametersBeforeScheduling(false)


### PR DESCRIPTION
Commit ceef5c3a (MappedScop::detectReductions: use dependences to check
validity of ordering, Fri May 25 12:43:39 2018 +0200) extended
the scope of MappedScop::detectReductions by also considering statements
other than explicitly marked reduction initialization statements
for ordering in front of the reduction update statements.
Some statements that are originally coscheduled with the update statements
may, however, depend on those update statements and can therefore
not be ordered before the update statements.  Try and order them
after the update statements.

Closes #454