### PR TITLE
schedule_print.cc: print each map of an extension on a new line

### DIFF
--- a/tc/core/polyhedral/schedule_print.cc
+++ b/tc/core/polyhedral/schedule_print.cc
@@ -185,7 +185,12 @@ std::ostream& ScheduleTreeElemDomain::write(std::ostream& os) const {
 
 std::ostream& ScheduleTreeElemExtension::write(std::ostream& os) const {
   WS w;
-  os << w.tab() << "extension(" << extension_ << ")";
+  os << w.tab() << "extension(";
+  for (const auto& e : extension_.get_map_list()) {
+    WS w2;
+    os << std::endl << w2.tab() << e;
+  }
+  os << ")";
   return os;
 }
 


### PR DESCRIPTION
This was omitted in the original commit in the prehistory that made
union_* members of schedule nodes print members of a union on separate
lines.  Since there is no isl_union_map_get_map_list, wrap the union_map
to obtain a union_set, get the list of sets and unwrap them to get the
maps back.