### PR TITLE
emitCudaKernel: store parameter values in specialized scop and take them from there

### DIFF
--- a/tc/core/cuda/cuda_tc_executor.cc
+++ b/tc/core/cuda/cuda_tc_executor.cc
@@ -91,8 +91,7 @@ CudaCompilationResult CudaBackend::compileWithTcMapper(
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << "Mapped schedule:" << std::endl
                                       << *(mappedScop->schedule());
 
-  auto parameters =
-      mappedScop->scop().getParameterValues(globalParameterContext);
+  auto parameters = mappedScop->scop().getParameterValues(pvm);
   auto specializedName = specializeKernelName(tcName, parameters);
 
   // This updates the launch bounds with the actual result from compilation

--- a/tc/core/cuda/cuda_tc_executor.cc
+++ b/tc/core/cuda/cuda_tc_executor.cc
@@ -78,8 +78,7 @@ CudaCompilationResult CudaBackend::compileWithTcMapper(
   auto scop = polyhedral::Scop::makeScop(
       isl::with_exceptions::globalIslCtx(), halideComponents);
   auto globalParameterContext = scop->makeContextFromInputs(inputs);
-  scop = polyhedral::Scop::makeSpecializedScop(
-      *scop, globalParameterContext.intersect(scop->globalParameterContext));
+  scop = polyhedral::Scop::makeSpecializedScop(*scop, globalParameterContext);
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << options;
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << "original schedule:\n"
                                       << *(scop->scheduleRoot());

--- a/tc/core/cuda/cuda_tc_executor.cc
+++ b/tc/core/cuda/cuda_tc_executor.cc
@@ -90,7 +90,7 @@ CudaCompilationResult CudaBackend::compileWithTcMapper(
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << "Mapped schedule:" << std::endl
                                       << *(mappedScop->schedule());
 
-  auto parameters = mappedScop->scop().getParameterValues(pvm);
+  auto parameters = mappedScop->scop().getParameterValues();
   auto specializedName = specializeKernelName(tcName, parameters);
 
   // This updates the launch bounds with the actual result from compilation

--- a/tc/core/cuda/cuda_tc_executor.cc
+++ b/tc/core/cuda/cuda_tc_executor.cc
@@ -77,7 +77,8 @@ CudaCompilationResult CudaBackend::compileWithTcMapper(
   // context to specialize the scop..
   auto scop = polyhedral::Scop::makeScop(
       isl::with_exceptions::globalIslCtx(), halideComponents);
-  auto globalParameterContext = scop->makeContextFromInputs(inputs);
+  auto pvm = computeParamValueMap(halideComponents, inputs);
+  auto globalParameterContext = scop->makeContext(pvm);
   scop = polyhedral::Scop::makeSpecializedScop(*scop, globalParameterContext);
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << options;
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << "original schedule:\n"

--- a/tc/core/cuda/cuda_tc_executor.cc
+++ b/tc/core/cuda/cuda_tc_executor.cc
@@ -78,8 +78,7 @@ CudaCompilationResult CudaBackend::compileWithTcMapper(
   auto scop = polyhedral::Scop::makeScop(
       isl::with_exceptions::globalIslCtx(), halideComponents);
   auto pvm = computeParamValueMap(halideComponents, inputs);
-  auto globalParameterContext = scop->makeContext(pvm);
-  scop = polyhedral::Scop::makeSpecializedScop(*scop, globalParameterContext);
+  scop = polyhedral::Scop::makeSpecializedScop(*scop, pvm);
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << options;
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << "original schedule:\n"
                                       << *(scop->scheduleRoot());

--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -227,17 +227,17 @@ isl::aff makeIslAffFromExpr(isl::space space, const Expr& e) {
   return list[0];
 }
 
-isl::space makeParamSpace(isl::ctx ctx, const SymbolTable& symbolTable) {
+isl::space makeParamSpace(isl::ctx ctx, const ParameterVector& params) {
   auto space = isl::space(ctx, 0);
   // set parameter names
-  for (auto p : symbolTable.params) {
+  for (auto p : params) {
     space = space.add_param(isl::id(ctx, p.name()));
   }
   return space;
 }
 
 isl::set makeParamContext(isl::ctx ctx, const SymbolTable& symbolTable) {
-  auto space = makeParamSpace(ctx, symbolTable);
+  auto space = makeParamSpace(ctx, symbolTable.params);
   auto context = isl::set::universe(space);
   for (auto p : symbolTable.params) {
     isl::aff a(isl::aff::param_on_domain_space(space, isl::id(ctx, p.name())));

--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -236,10 +236,10 @@ isl::space makeParamSpace(isl::ctx ctx, const ParameterVector& params) {
   return space;
 }
 
-isl::set makeParamContext(isl::ctx ctx, const SymbolTable& symbolTable) {
-  auto space = makeParamSpace(ctx, symbolTable.params);
+isl::set makeParamContext(isl::ctx ctx, const ParameterVector& params) {
+  auto space = makeParamSpace(ctx, params);
   auto context = isl::set::universe(space);
-  for (auto p : symbolTable.params) {
+  for (auto p : params) {
     isl::aff a(isl::aff::param_on_domain_space(space, isl::id(ctx, p.name())));
     context = context & (a >= 0);
   }

--- a/tc/core/halide2isl.h
+++ b/tc/core/halide2isl.h
@@ -33,10 +33,11 @@ namespace halide2isl {
 /// Helper functions that participate in translating Halide IR to ISL
 ///
 
+using ParameterVector = std::vector<Halide::Internal::Parameter>;
 /// Find and categorize all variables referenced in a piece of Halide IR
 struct SymbolTable {
   std::vector<std::string> reductionVars, idxVars;
-  std::vector<Halide::Internal::Parameter> params;
+  ParameterVector params;
 };
 SymbolTable makeSymbolTable(const tc2halide::HalideComponents& components);
 

--- a/tc/core/halide2isl.h
+++ b/tc/core/halide2isl.h
@@ -41,8 +41,8 @@ struct SymbolTable {
 };
 SymbolTable makeSymbolTable(const tc2halide::HalideComponents& components);
 
-/// Make the space of all parameter values from the symbol table
-isl::space makeParamSpace(isl::ctx ctx, const SymbolTable& symbolTable);
+/// Make the space of all given parameter values
+isl::space makeParamSpace(isl::ctx ctx, const ParameterVector& params);
 
 /// Make the parameter set marking all parameters from the symbol table
 /// as non-negative.

--- a/tc/core/halide2isl.h
+++ b/tc/core/halide2isl.h
@@ -44,9 +44,9 @@ SymbolTable makeSymbolTable(const tc2halide::HalideComponents& components);
 /// Make the space of all given parameter values
 isl::space makeParamSpace(isl::ctx ctx, const ParameterVector& params);
 
-/// Make the parameter set marking all parameters from the symbol table
+/// Make the parameter set marking all given parameters
 /// as non-negative.
-isl::set makeParamContext(isl::ctx ctx, const SymbolTable& symbolTable);
+isl::set makeParamContext(isl::ctx ctx, const ParameterVector& params);
 
 /// Make a constant-valued affine function over a space.
 isl::aff makeIslAffFromInt(isl::space space, int64_t i);

--- a/tc/core/halide_utils.cc
+++ b/tc/core/halide_utils.cc
@@ -16,6 +16,7 @@
 #include "tc/core/halide_utils.h"
 
 #include <map>
+#include <unordered_map>
 #include <vector>
 
 #include "tc/core/flags.h"
@@ -36,10 +37,10 @@ DLDataType fromHalideType(const Halide::Type& type) {
   return dtype;
 }
 
-std::map<std::string, int> computeParamValueMap(
+std::unordered_map<std::string, int> computeParamValueMap(
     const tc2halide::HalideComponents& halide,
     const std::vector<const DLConstTensor*>& inputsDLT) {
-  std::map<std::string, int> pvm;
+  std::unordered_map<std::string, int> pvm;
   if (halide.inputs.size() != inputsDLT.size()) {
     throw lang::ErrorReport(halide.getDef())
         << "expected " << halide.inputs.size() << " inputs but got "

--- a/tc/core/halide_utils.h
+++ b/tc/core/halide_utils.h
@@ -17,7 +17,6 @@
 
 #include <chrono>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "tc/core/tc2halide.h"

--- a/tc/core/halide_utils.h
+++ b/tc/core/halide_utils.h
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "tc/core/tc2halide.h"
@@ -28,7 +29,7 @@ namespace tc {
 /// (metadata of) input tensors with specific shapes, compute a map between TC
 /// parametric tensor sizes, represented as strings, and their numerical values
 /// with given input sizes.
-std::map<std::string, int> computeParamValueMap(
+std::unordered_map<std::string, int> computeParamValueMap(
     const tc2halide::HalideComponents& components,
     const std::vector<const DLConstTensor*>& inputsDLT);
 

--- a/tc/core/polyhedral/codegen_llvm.cc
+++ b/tc/core/polyhedral/codegen_llvm.cc
@@ -324,8 +324,7 @@ llvm::Value* CodeGen_TC::getValue(isl::ast_expr expr) {
 
 class LLVMCodegen {
   void collectTensor(const Halide::OutputImageParam& t) {
-    auto sizes =
-        getTensorSizesWithoutLeadingDim(t, scop_.globalParameterContext);
+    auto sizes = getTensorSizesWithoutLeadingDim(t, scop_.context());
     if (not sizes.empty()) {
       args_.emplace_back(
           makePtrToArrayType(halide_cg.llvm_type_of(t.type()), sizes));
@@ -509,7 +508,7 @@ class LLVMCodegen {
       CHECK(condLHS);
       CHECK_EQ(condLHS.get_id(), iterator);
 
-      IslAstExprInterpeter i(scop_.globalParameterContext);
+      IslAstExprInterpeter i(scop_.context());
       auto condRHSVal = i.interpret(cond_expr.get_arg(1));
 
       auto cond = [&]() {

--- a/tc/core/polyhedral/cuda/codegen.cc
+++ b/tc/core/polyhedral/cuda/codegen.cc
@@ -747,15 +747,8 @@ string emitCudaKernel(
 
   // Make a map of the specialized scalar parameter values
   map<string, Halide::Expr> paramValues;
-  {
-    auto set = scop.globalParameterContext;
-    for (unsigned i = 0; i < set.n_param(); i++) {
-      auto val = set.plain_get_val_if_fixed(isl::dim_type::param, i);
-      auto name = set.get_space().get_dim_name(isl::dim_type::param, i);
-      if (!val.is_nan()) {
-        paramValues[name] = static_cast<int>(val.get_num_si());
-      }
-    }
+  for (const auto& kvp : scop.parameterValues) {
+    paramValues[kvp.first] = kvp.second;
   }
 
   stringstream ss;

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -855,7 +855,7 @@ std::unique_ptr<MappedScop> makeSpecializedMappedScop(
   // outer schedule dimensions, so the space of a parameter context code is that
   // of a zero-dimensional space.
   auto root = scop->scheduleRoot();
-  updateTopLevelContext(root, scop->globalParameterContext.from_params());
+  updateTopLevelContext(root, scop->context().from_params());
 
   tc::Grid grid = mappedScop.numBlocks;
   tc::Block block = mappedScop.numThreads;
@@ -878,7 +878,7 @@ std::unique_ptr<MappedScop> makeSpecializedMappedScop(
 } // namespace
 
 // Before generating code, make a copy of the scop and insert
-// the globalParameterContext of the original scop as top-level
+// the context of the original scop as top-level
 // context node in schedule tree.
 std::tuple<std::string, tc::Grid, tc::Block> MappedScop::codegen(
     const std::string& specializedName) const {

--- a/tc/core/polyhedral/cuda/tighten_launch_bounds.cc
+++ b/tc/core/polyhedral/cuda/tighten_launch_bounds.cc
@@ -84,7 +84,7 @@ std::pair<tc::Grid, tc::Block> tightenLaunchBounds(
     const tc::Grid& grid,
     const tc::Block& block) {
   auto root = scop.scheduleRoot();
-  auto params = scop.globalParameterContext;
+  auto params = scop.context();
 
   auto max = [root, params](const mapping::MappingId& id) -> size_t {
     size_t sizetMax = std::numeric_limits<size_t>::max();

--- a/tc/core/polyhedral/memory_promotion.cc
+++ b/tc/core/polyhedral/memory_promotion.cc
@@ -421,10 +421,7 @@ isl::set tensorElementsSet(const Scop& scop, isl::id tensorId) {
         (isl::aff_set(aff) < (minAff + extentAff));
   }
 
-  if (scop.globalParameterContext) {
-    tensorElements =
-        tensorElements.intersect_params(scop.globalParameterContext);
-  }
+  tensorElements = tensorElements.intersect_params(scop.context());
   return tensorElements;
 }
 

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -262,17 +262,17 @@ void Scop::promoteEverythingAt(std::vector<size_t> pos) {
   insertSyncsAroundCopies(tree);
 }
 
-std::vector<long> Scop::getParameterValues(
-    const std::unordered_map<std::string, int>& sizes) const {
+std::vector<long> Scop::getParameterValues() const {
   // Scop holds a vector of Variables.
   // Iterate over parameters in order, checking if the
-  // context contains a parameter whose name corresponds to that
+  // map of known parameter values contains a parameter
+  // whose name corresponds to that
   // Variable and push respective parameter values.
   std::vector<long> paramValues;
   for (auto const& param : halide.params) {
     auto name = param.name();
-    CHECK(sizes.count(name) == 1);
-    paramValues.push_back(sizes.at(name));
+    CHECK(parameterValues.count(name) == 1);
+    paramValues.push_back(parameterValues.at(name));
   }
   return paramValues;
 }

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -262,25 +262,17 @@ void Scop::promoteEverythingAt(std::vector<size_t> pos) {
   insertSyncsAroundCopies(tree);
 }
 
-std::vector<long> Scop::getParameterValues(isl::set context) const {
-  auto ctx = context.get_ctx();
-  auto longMax = isl::val(ctx, std::numeric_limits<long>::max());
-  auto space = context.get_space();
-  auto p = context.sample_point();
-  CHECK(context.is_equal(p));
-
+std::vector<long> Scop::getParameterValues(
+    const std::unordered_map<std::string, int>& sizes) const {
   // Scop holds a vector of Variables.
   // Iterate over parameters in order, checking if the
   // context contains a parameter whose name corresponds to that
   // Variable and push respective parameter values.
   std::vector<long> paramValues;
   for (auto const& param : halide.params) {
-    isl::id id(ctx, param.name());
-    CHECK(context.involves_param(id));
-    auto val = isl::aff::param_on_domain_space(space, id).eval(p);
-    CHECK(val.is_int()) << "fractional parameters unsupported";
-    CHECK(val.le(longMax)) << "parameter value overflows long";
-    paramValues.push_back(val.get_num_si());
+    auto name = param.name();
+    CHECK(sizes.count(name) == 1);
+    paramValues.push_back(sizes.at(name));
   }
   return paramValues;
 }

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -47,11 +47,9 @@ ScopUPtr Scop::makeScop(
 
   halide2isl::SymbolTable sym = halide2isl::makeSymbolTable(components);
 
-  auto globalParameterContext = halide2isl::makeParamContext(ctx, sym.params);
-  isl::space paramSpace = globalParameterContext.get_space();
+  isl::space paramSpace = halide2isl::makeParamSpace(ctx, sym.params);
 
   ScopUPtr scop(new Scop());
-  scop->globalParameterContext = globalParameterContext;
   scop->halide.params = sym.params;
   scop->halide.idx = sym.idxVars;
   scop->halide.reductionIdx = sym.reductionVars;

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -78,7 +78,7 @@ ScopUPtr Scop::makeScop(isl::ctx ctx, const lang::TreeRef& treeRef) {
   return makeScop(ctx, tc2halide::translate(ctx, treeRef));
 }
 
-isl::union_set& Scop::domain() {
+isl::union_set& Scop::domainRef() {
   auto dom = scheduleRoot()->elemAs<ScheduleTreeElemDomain>();
   CHECK(dom) << "root is not a domain in: " << *scheduleRoot();
   // TODO: activate this when the invariant has a chance of working (i.e. we
@@ -92,7 +92,7 @@ isl::union_set& Scop::domain() {
 }
 
 const isl::union_set Scop::domain() const {
-  return const_cast<Scop*>(this)->domain();
+  return const_cast<Scop*>(this)->domainRef();
 }
 
 std::ostream& operator<<(std::ostream& os, const Scop& s) {

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -47,7 +47,7 @@ ScopUPtr Scop::makeScop(
 
   halide2isl::SymbolTable sym = halide2isl::makeSymbolTable(components);
 
-  auto globalParameterContext = halide2isl::makeParamContext(ctx, sym);
+  auto globalParameterContext = halide2isl::makeParamContext(ctx, sym.params);
   isl::space paramSpace = globalParameterContext.get_space();
 
   ScopUPtr scop(new Scop());

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -472,7 +472,7 @@ struct Scop {
  public:
   // Halide stuff
   struct {
-    std::vector<Halide::Internal::Parameter> params;
+    halide2isl::ParameterVector params;
     std::vector<std::string> idx, reductionIdx;
     std::vector<Halide::ImageParam> inputs;
     std::vector<Halide::OutputImageParam> outputs;

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -102,12 +102,9 @@ struct Scop {
     // strategy.proto.fix_parameters_before_scheduling to true.
     // If you want to fix the parameters in the support domain,
     // then you need to do it explicitly.
-    // Note that the access relations must be intersect with the context as
-    // well to obtain consistent dependences.
     // TODO: this is still subject to interpretation but intersecting seems
     // final here so probably we're right not doing it.
-    // res->domain() =
-    // res->domain().intersect_params(res->globalParameterContext);
+    // res->specializeToContext();
     return res;
   }
 

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -93,9 +93,6 @@ struct Scop {
   static std::unique_ptr<Scop> makeSpecializedScop(
       const Scop& scop,
       isl::set extraGlobalParameterContext) {
-    CHECK(extraGlobalParameterContext.is_subset(scop.globalParameterContext))
-        << "expected extra context " << extraGlobalParameterContext
-        << " to be more specialized than " << scop.globalParameterContext;
     auto res = makeScop(scop);
     res->intersectContext(extraGlobalParameterContext);
     // **WARNING** if called before scheduling, this could result in a

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -135,13 +135,6 @@ struct Scop {
     return makeSpecializationSet(s, sizes);
   }
 
-  // Compute the values of parameters based on the effective sizes of the
-  // tensors provided as arguments and their parametric expressions stored in
-  // halide ImageParams.  We only know input sizes, output sizes are inferred.
-  // Result is an isl set directly usable as context.
-  isl::set makeContextFromInputs(
-      const std::vector<const DLConstTensor*>& inputs) const;
-
   // Fix the values of the specified parameters in the context
   // to the corresponding specified values.
   template <typename T>

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -110,7 +110,7 @@ struct Scop {
 
   // Specialize the Scop with respect to its globalParameterContext.
   void specializeToContext() {
-    domain() = domain().intersect_params(globalParameterContext);
+    domainRef() = domain().intersect_params(globalParameterContext);
     reads = reads.intersect_params(globalParameterContext);
     writes = writes.intersect_params(globalParameterContext);
   }
@@ -489,7 +489,9 @@ struct Scop {
   // state is kept.
   // By analogy with generalized functions, the domain is the "support" part
   // of the ScheduleTree "function".
-  isl::union_set& domain();
+ private:
+  isl::union_set& domainRef();
+ public:
   const isl::union_set domain() const;
   // The parameter values of a specialized Scop.
   std::unordered_map<std::string, int> parameterValues;

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -95,8 +95,7 @@ struct Scop {
       const Scop& scop,
       const std::unordered_map<std::string, T>& sizes) {
     auto res = makeScop(scop);
-    auto extraGlobalParameterContext = scop.makeContext(sizes);
-    res->intersectContext(extraGlobalParameterContext);
+    res->fixParameters(sizes);
     // **WARNING** if called before scheduling, this could result in a
     // (partially) specialized schedule, i.e. force
     // strategy.proto.fix_parameters_before_scheduling to true.

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -84,22 +84,24 @@ struct Scop {
     globalParameterContext = context;
   }
 
-  // Specialize a Scop with extra globalParameterContext information
+  // Specialize a Scop by fixing the given parameters to the given sizes.
   // If you want to intersect the support domain with the
-  // extraGlobalParameterContext then you need to do it explicitly.
+  // resulting context then you need to do it explicitly.
   // Otherwise ambiguities will ensue.
   // TODO: this is still subject to interpretation but intersecting seems a
   // bit final here so probably we're right not doing it.
+  template <typename T>
   static std::unique_ptr<Scop> makeSpecializedScop(
       const Scop& scop,
-      isl::set extraGlobalParameterContext) {
+      const std::unordered_map<std::string, T>& sizes) {
     auto res = makeScop(scop);
+    auto extraGlobalParameterContext = scop.makeContext(sizes);
     res->intersectContext(extraGlobalParameterContext);
     // **WARNING** if called before scheduling, this could result in a
     // (partially) specialized schedule, i.e. force
     // strategy.proto.fix_parameters_before_scheduling to true.
-    // If you want to intersect the support domain with the
-    // extraGlobalParameterContext then you need to do it explicitly.
+    // If you want to fix the parameters in the support domain,
+    // then you need to do it explicitly.
     // Note that the access relations must be intersect with the context as
     // well to obtain consistent dependences.
     // TODO: this is still subject to interpretation but intersecting seems

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -142,10 +142,12 @@ struct Scop {
     intersectContext(makeContext(sizes));
   }
 
-  // Given the context set, return the list of parameter values in the same
+  // Given a map between TC parametric tensor sizes, represented as strings,
+  // and their numerical values, return the list of parameter values in the same
   // order as codegen places them in the function signature, i.e. following the
   // order of scop.params.
-  std::vector<long> getParameterValues(isl::set context) const;
+  std::vector<long> getParameterValues(
+      const std::unordered_map<std::string, int>& sizes) const;
 
   isl::id nextGroupIdForTensor(isl::id tensorId) {
     auto ctx = domain().get_ctx();

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -358,9 +358,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
 )TC";
 
   auto scop = PrepareAndJoinBands(tc);
-  auto scopPtr = scop.get();
-  auto context = scopPtr->makeContext<int>({{"N", 512}});
-  scop = Scop::makeSpecializedScop(*scop, context);
+  scop = Scop::makeSpecializedScop<int>(*scop, {{"N", 512}});
   auto mscop = TileAndMapBlocksAndThreads(
       std::move(scop), {16ul, 16ul}, {256ul, 256ul}, {16ul, 16ul});
 

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -520,10 +520,9 @@ constexpr auto kExpectedMatmul_64_64_64 =
 TEST_F(PolyhedralMapperTest, MergedContexts) {
   auto scop = PrepareAndJoinBandsMatMul();
 
-  // Unit test claims to use scop->globalParameterContext properly
+  // Unit test claims to use the specialized context properly
   scop->fixParameters<int>({{"M", 64}, {"N", 64}, {"K", 64}});
-  auto globalParameterContext = scop->globalParameterContext;
-  scop->domain() = scop->domain().intersect_params(globalParameterContext);
+  scop->specializeToContext();
 
   auto mscop = TileAndMapThreads(std::move(scop), {16, 16}, {32ul, 8ul});
   auto res = std::get<0>(mscop->codegen(specializedName));

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -359,8 +359,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
 
   auto scop = PrepareAndJoinBands(tc);
   auto scopPtr = scop.get();
-  auto context =
-      scopPtr->makeContext(std::unordered_map<std::string, int>{{"N", 512}});
+  auto context = scopPtr->makeContext<int>({{"N", 512}});
   scop = Scop::makeSpecializedScop(*scop, context);
   auto mscop = TileAndMapBlocksAndThreads(
       std::move(scop), {16ul, 16ul}, {256ul, 256ul}, {16ul, 16ul});

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -521,10 +521,8 @@ TEST_F(PolyhedralMapperTest, MergedContexts) {
   auto scop = PrepareAndJoinBandsMatMul();
 
   // Unit test claims to use scop->globalParameterContext properly
-  auto context = scop->makeContext<int>({{"M", 64}, {"N", 64}, {"K", 64}});
-  auto& globalParameterContext =
-      const_cast<isl::set&>(scop->globalParameterContext);
-  globalParameterContext = globalParameterContext.intersect(context);
+  scop->fixParameters<int>({{"M", 64}, {"N", 64}, {"K", 64}});
+  auto globalParameterContext = scop->globalParameterContext;
   scop->domain() = scop->domain().intersect_params(globalParameterContext);
 
   auto mscop = TileAndMapThreads(std::move(scop), {16, 16}, {32ul, 8ul});

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -525,7 +525,7 @@ TEST_F(PolyhedralMapperTest, MergedContexts) {
   auto& globalParameterContext =
       const_cast<isl::set&>(scop->globalParameterContext);
   globalParameterContext = globalParameterContext.intersect(context);
-  scop->domain() = scop->domain().intersect(globalParameterContext);
+  scop->domain() = scop->domain().intersect_params(globalParameterContext);
 
   auto mscop = TileAndMapThreads(std::move(scop), {16, 16}, {32ul, 8ul});
   auto res = std::get<0>(mscop->codegen(specializedName));

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -361,8 +361,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
   auto scopPtr = scop.get();
   auto context =
       scopPtr->makeContext(std::unordered_map<std::string, int>{{"N", 512}});
-  scop = Scop::makeSpecializedScop(
-      *scop, context.intersect(scop->globalParameterContext));
+  scop = Scop::makeSpecializedScop(*scop, context);
   auto mscop = TileAndMapBlocksAndThreads(
       std::move(scop), {16ul, 16ul}, {256ul, 256ul}, {16ul, 16ul});
 

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -45,7 +45,7 @@ class TestMapper : public ::testing::Test {
       std::unordered_map<std::string, size_t> problemSizes) {
     auto ctx = isl::with_exceptions::globalIslCtx();
     auto scop = Scop::makeScop(ctx, tc);
-    scop = Scop::makeSpecializedScop(*scop, scop->makeContext(problemSizes));
+    scop = Scop::makeSpecializedScop(*scop, problemSizes);
     scop->domain() =
         scop->domain().intersect_params(scop->globalParameterContext);
     return MappedScop::makeWithOuterBlockInnerThreadStrategy(

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -45,10 +45,7 @@ class TestMapper : public ::testing::Test {
       std::unordered_map<std::string, size_t> problemSizes) {
     auto ctx = isl::with_exceptions::globalIslCtx();
     auto scop = Scop::makeScop(ctx, tc);
-    scop = Scop::makeSpecializedScop(
-        *scop,
-        scop->makeContext(problemSizes)
-            .intersect(scop->globalParameterContext));
+    scop = Scop::makeSpecializedScop(*scop, scop->makeContext(problemSizes));
     scop->domain() =
         scop->domain().intersect_params(scop->globalParameterContext);
     return MappedScop::makeWithOuterBlockInnerThreadStrategy(

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -46,8 +46,7 @@ class TestMapper : public ::testing::Test {
     auto ctx = isl::with_exceptions::globalIslCtx();
     auto scop = Scop::makeScop(ctx, tc);
     scop = Scop::makeSpecializedScop(*scop, problemSizes);
-    scop->domain() =
-        scop->domain().intersect_params(scop->globalParameterContext);
+    scop->specializeToContext();
     return MappedScop::makeWithOuterBlockInnerThreadStrategy(
         std::move(scop), mappingOptions);
   }
@@ -251,7 +250,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
         {tile1, tile2});
     auto& scop = const_cast<Scop&>(mscop->scop());
     // Must force domain intersection for overapproximation to work
-    scop.domain() = scop.domain().intersect_params(scop.globalParameterContext);
+    scop.specializeToContext();
     auto ctx = scop.domain().get_ctx();
     auto groups = TensorReferenceGroup::accessedBySubtree(
         scop.scheduleRoot()->child(childPos), scop);
@@ -331,7 +330,7 @@ def fun(float(N, M) A) -> (B, C) {
         {tile1, tile2});
     auto& scop = const_cast<Scop&>(mscop->scop());
     // Must force domain intersection for overapproximation to work
-    scop.domain() = scop.domain().intersect_params(scop.globalParameterContext);
+    scop.specializeToContext();
     auto ctx = scop.domain().get_ctx();
     auto groups = TensorReferenceGroup::accessedBySubtree(
         scop.scheduleRoot()->child(childPos), scop);

--- a/test/test_mapper_llvm.cc
+++ b/test/test_mapper_llvm.cc
@@ -45,8 +45,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext(
-      std::unordered_map<std::string, int>{{"N", N}, {"M", M}});
+  auto context = scop->makeContext<int>({{"N", N}, {"M", M}});
   scop = Scop::makeSpecializedScop(*scop, context);
 
   Jit jit;
@@ -81,8 +80,8 @@ TEST(LLVMCodegen, MultiStmt) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext(std::unordered_map<std::string, int>{
-      {"N", N}, {"M", M}, {"K", K}, {"L", L}});
+  auto context =
+      scop->makeContext<int>({{"N", N}, {"M", M}, {"K", K}, {"L", L}});
   scop = Scop::makeSpecializedScop(*scop, context);
 
   at::Tensor A = at::CPU(at::kFloat).rand({N, M, K, L});
@@ -153,8 +152,8 @@ def batch_matmul(float(B, N, M) X, float(B, M, K) Y) -> (Z) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext(std::unordered_map<std::string, int>{
-      {"N", N}, {"M", M}, {"K", K}, {"B", B}});
+  auto context =
+      scop->makeContext<int>({{"N", N}, {"M", M}, {"K", K}, {"B", B}});
   scop = Scop::makeSpecializedScop(*scop, context);
 
   Jit jit;
@@ -188,14 +187,13 @@ def convolution(float(N,C,H,W) I, float(O,C,KH,KW) W1, float(O) B) -> (tmp, O1)
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context =
-      scop->makeContext(std::unordered_map<std::string, int>{{"N", NN},
-                                                             {"O", O},
-                                                             {"H", H},
-                                                             {"KH", KH},
-                                                             {"W", W},
-                                                             {"KW", KW},
-                                                             {"C", C}});
+  auto context = scop->makeContext<int>({{"N", NN},
+                                         {"O", O},
+                                         {"H", H},
+                                         {"KH", KH},
+                                         {"W", W},
+                                         {"KW", KW},
+                                         {"C", C}});
   scop = Scop::makeSpecializedScop(*scop, context);
 
   Jit jit;
@@ -227,8 +225,7 @@ def concat(float(M, N) A, float(M, N) B) -> (O1) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext(
-      std::unordered_map<std::string, int>{{"N", N}, {"M", M}});
+  auto context = scop->makeContext<int>({{"N", N}, {"M", M}});
   scop = Scop::makeSpecializedScop(*scop, context);
 
   Jit jit;

--- a/test/test_mapper_llvm.cc
+++ b/test/test_mapper_llvm.cc
@@ -45,8 +45,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext<int>({{"N", N}, {"M", M}});
-  scop = Scop::makeSpecializedScop(*scop, context);
+  scop = Scop::makeSpecializedScop<int>(*scop, {{"N", N}, {"M", M}});
 
   Jit jit;
   jit.codegenScop("kernel_anon", *scop);
@@ -80,9 +79,8 @@ TEST(LLVMCodegen, MultiStmt) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context =
-      scop->makeContext<int>({{"N", N}, {"M", M}, {"K", K}, {"L", L}});
-  scop = Scop::makeSpecializedScop(*scop, context);
+  scop = Scop::makeSpecializedScop<int>(
+      *scop, {{"N", N}, {"M", M}, {"K", K}, {"L", L}});
 
   at::Tensor A = at::CPU(at::kFloat).rand({N, M, K, L});
   at::Tensor B = at::CPU(at::kFloat).rand({N, M});
@@ -152,9 +150,8 @@ def batch_matmul(float(B, N, M) X, float(B, M, K) Y) -> (Z) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context =
-      scop->makeContext<int>({{"N", N}, {"M", M}, {"K", K}, {"B", B}});
-  scop = Scop::makeSpecializedScop(*scop, context);
+  scop = Scop::makeSpecializedScop<int>(
+      *scop, {{"N", N}, {"M", M}, {"K", K}, {"B", B}});
 
   Jit jit;
   jit.codegenScop("batch_matmul", *scop);
@@ -187,14 +184,15 @@ def convolution(float(N,C,H,W) I, float(O,C,KH,KW) W1, float(O) B) -> (tmp, O1)
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext<int>({{"N", NN},
-                                         {"O", O},
-                                         {"H", H},
-                                         {"KH", KH},
-                                         {"W", W},
-                                         {"KW", KW},
-                                         {"C", C}});
-  scop = Scop::makeSpecializedScop(*scop, context);
+  scop = Scop::makeSpecializedScop<int>(
+      *scop,
+      {{"N", NN},
+       {"O", O},
+       {"H", H},
+       {"KH", KH},
+       {"W", W},
+       {"KW", KW},
+       {"C", C}});
 
   Jit jit;
   jit.codegenScop("convolution", *scop);
@@ -225,8 +223,7 @@ def concat(float(M, N) A, float(M, N) B) -> (O1) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext<int>({{"N", N}, {"M", M}});
-  scop = Scop::makeSpecializedScop(*scop, context);
+  scop = Scop::makeSpecializedScop<int>(*scop, {{"N", N}, {"M", M}});
 
   Jit jit;
   jit.codegenScop("concat", *scop);

--- a/test/test_mapper_tapir.cc
+++ b/test/test_mapper_tapir.cc
@@ -48,8 +48,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext<int>({{"N", N}, {"M", M}});
-  scop = Scop::makeSpecializedScop(*scop, context);
+  scop = Scop::makeSpecializedScop<int>(*scop, {{"N", N}, {"M", M}});
   SchedulerOptionsProto sop;
   SchedulerOptionsView sov(sop);
   scop = Scop::makeScheduled(*scop, sov);

--- a/test/test_mapper_tapir.cc
+++ b/test/test_mapper_tapir.cc
@@ -48,8 +48,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
 
   auto ctx = isl::with_exceptions::globalIslCtx();
   auto scop = polyhedral::Scop::makeScop(ctx, tc);
-  auto context = scop->makeContext(
-      std::unordered_map<std::string, int>{{"N", N}, {"M", M}});
+  auto context = scop->makeContext<int>({{"N", N}, {"M", M}});
   scop = Scop::makeSpecializedScop(*scop, context);
   SchedulerOptionsProto sop;
   SchedulerOptionsView sov(sop);


### PR DESCRIPTION
There is little point in trying to extract these values from a context
when those very same values were used to create the context.
Simply use the original known values.

Perform some additional clean-ups along the way.