### PR TITLE
let tc_core depend on generate_isl when building isl bindings

### DIFF
--- a/tc/core/CMakeLists.txt
+++ b/tc/core/CMakeLists.txt
@@ -48,6 +48,9 @@ target_link_libraries(
   tc_version
   tc_proto
 )
+if (WITH_BINDINGS)
+  add_dependencies(tc_core generate_isl)
+endif()
 install(
   TARGETS
   tc_core

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,9 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_executable(test_basic test_basic.cc)
 add_test(test_basic test_basic)
 target_link_libraries(test_basic ${GOOGLE_LIBRARIES} ${ISL_LIBRARIES} ${ATEN_LIBRARIES} pthread)
+if (WITH_BINDINGS)
+  add_dependencies(test_basic generate_isl)
+endif()
 
 ################################################################################
 # Core library only tests


### PR DESCRIPTION
This ensures that the bindings are built before tc_core
(which needs those bindings) is compiled.