### PR TITLE
Improve autotuner UX (both C++ and python land)

### DIFF
--- a/tc/autotuner/parameters.cc
+++ b/tc/autotuner/parameters.cc
@@ -459,9 +459,11 @@ void CudaDimParameters::setRange(
 namespace {
 template <typename Params, typename View>
 void fromMappingOptions(Params& params, const View& options) {
-  CHECK_LE(options.size(), params.dims.size());
-  params.numberDims.selectFromValue(options.size());
-  for (size_t i = 0; i < options.size(); ++i) {
+  // It is possible mapping options are higher dimensional than problem sizes
+  // in which case options could be larger
+  auto min = std::min(options.size(), params.dims.size());
+  params.numberDims.selectFromValue(min);
+  for (size_t i = 0; i < min; ++i) {
     params.dims[i].selectFromValue(options[i]);
   }
 }

--- a/tc/core/cpu/cpu_mapping_options.cc
+++ b/tc/core/cpu/cpu_mapping_options.cc
@@ -78,4 +78,12 @@ CpuMappingOptions CpuMappingOptions::makeNaiveMappingOptions() {
   return makeUnmappedMappingOptions().tile(32, 32, 32).unroll(1);
 }
 
+std::ostream& operator<<(
+    std::ostream& os,
+    const CpuMappingOptions& cpuOptions) {
+  OstreamBoolalphaScope scope(os);
+  tc::CpuMappingOptionsAsCpp cpp(cpuOptions);
+  os << cpp;
+  return os;
+}
 } // namespace tc

--- a/tc/core/cpu/cpu_mapping_options.h
+++ b/tc/core/cpu/cpu_mapping_options.h
@@ -79,4 +79,7 @@ class CpuMappingOptions {
  public:
   MappingOptionsView generic;
 };
+
+std::ostream& operator<<(std::ostream& os, const CpuMappingOptions& view);
+
 } // namespace tc

--- a/tc/core/cuda/cuda_mapping_options.cc
+++ b/tc/core/cuda/cuda_mapping_options.cc
@@ -47,35 +47,6 @@ std::string CudaDimView::toCommaSeparatedString() const {
   return ss.str();
 }
 
-std::ostream& operator<<(std::ostream& os, const CudaDimView& view) {
-  os << "CudaDim(" << view.toCommaSeparatedString() << ") @" << &view.proto;
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os, const CudaDim& dim) {
-  os << dim.view;
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os, const Grid& dim) {
-  os << dim.view;
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os, const Block& dim) {
-  os << dim.view;
-  return os;
-}
-
-std::ostream& operator<<(
-    std::ostream& os,
-    const CudaMappingOptions& cudaOptions) {
-  OstreamBoolalphaScope scope(os);
-  tc::CudaMappingOptionsAsCpp cpp(cudaOptions);
-  os << cpp;
-  return os;
-}
-
 // CudaDimView & CudaDim
 //
 CudaDim::CudaDim(std::vector<uint64_t> il) : ownedProto_(), view(ownedProto_) {
@@ -400,4 +371,32 @@ CudaMappingOptions CudaMappingOptions::makeGroupConvolutionMappingOptions() {
       .unroll(1);
 }
 
+std::ostream& operator<<(std::ostream& os, const CudaDimView& view) {
+  os << "CudaDim(" << view.toCommaSeparatedString() << ") @" << &view.proto;
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CudaDim& dim) {
+  os << dim.view;
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Grid& dim) {
+  os << dim.view;
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Block& dim) {
+  os << dim.view;
+  return os;
+}
+
+std::ostream& operator<<(
+    std::ostream& os,
+    const CudaMappingOptions& cudaOptions) {
+  OstreamBoolalphaScope scope(os);
+  tc::CudaMappingOptionsAsCpp cpp(cudaOptions);
+  os << cpp;
+  return os;
+}
 } // namespace tc


### PR DESCRIPTION
This PR serves the purpose of running the autotuner more smoothly on a script sent by a user:

```
wget -P /tmphttps://gist.githubusercontent.com/nicolasvasilache/d069e701229cb07f4b03a4c7980ab737/raw/1eef01140cae9a1bac1e3d771bb9008827e752be/batch_renormalization.py
python setup.py install --prefix=/tmp
python /tmp/batch_renormalization.py
```

I have been hitting Ctrl + C when perf looked "reasonable", user experience feels pretty good to me and we seem able to recover from existing protos.

```
Copying tensor_comprehensions.egg-info to /tmp/lib/python3.6/site-packages/tensor_comprehensions-0.1.1-py3.6.egg-info
running install_scripts
[INFO]: Autotuning cache will be saved to: /tmp/calc_mean_std_2_256_32_32_6.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 44/661/1335
[INFO]: Tuned kernel options found, using those options
[INFO]: Autotuning cache will be saved to: /tmp/calc_r_d_256_256_256_256_6.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 8/9/34
[INFO]: Tuned kernel options found, using those options
[INFO]: Autotuning cache will be saved to: /tmp/calc_O_2_256_32_32_256_256_256_256_256_256.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 20/83/3784
[INFO]: Tuned kernel options found, using those options
[INFO]: Autotuning cache will be saved to: /tmp/calc_running_mean_std_256_256_256_256_6.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 8/9/37
[INFO]: Tuned kernel options found, using those options
[INFO]: Autotuning cache will be saved to: /tmp/calc_xHat_grad_256_2_256_32_32.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 11/31/65
[INFO]: Tuned kernel options found, using those options
[INFO]: Autotuning cache will be saved to: /tmp/calc_mean_std_grad_2_256_32_32_256_256_256_2_256_32_32.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 69/281/1745
Iteration 1     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 65/183/316
[INFO]: Tuned kernel options found, using those options
[INFO]: Autotuning cache will be saved to: /tmp/calc_xHat_2_256_32_32_256_256_256_256.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 12/57/70
[INFO]: Tuned kernel options found, using those options
[INFO]: Autotuning cache will be saved to: /tmp/calc_weight_bias_grad_2_256_32_32_2_256_32_32.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 70/220/2303
[INFO]: Tuned kernel options found, using those options
[INFO]: Autotuning cache will be saved to: /tmp/calc_I_grad_2_256_32_32_256_256_256_2_256_32_32_256_256.options
Iteration 0     Jobs(Compiled, Evaluated)/total  (100, 100)/100   (best/median/worst)us: 16/60/276
[INFO]: Tuned kernel options found, using those options
```

In the process, I had to debug a parameters issue in the second kernel. 
To print things properly it was also necessary to add operator<< to CpuMappingOptions.