### PR TITLE
test_cpu.sh: run test_cuda_mapper_memory_promotion

### DIFF
--- a/test_cpu.sh
+++ b/test_cpu.sh
@@ -18,7 +18,7 @@ function run_test {
 }
 
 TEST_PATH="./build/test"
-TEST_REGEX="test_basic test_core test_inference test_isl_scheduler test_lang test_mapper* test_tc2halide test_cuda_mapper"
+TEST_REGEX="test_basic test_core test_inference test_isl_scheduler test_lang test_mapper* test_tc2halide test_cuda_mapper test_cuda_mapper_memory_promotion"
 run_test
 
 echo SUCCESS


### PR DESCRIPTION
Despite the name, this test does not require CUDA to be present in the
system to run.  It only includes syntactic tests on CUDA code generator
and can be run by CPU only.  Run it in test_cpu.sh, including on
CircleCI by default.