### PR TITLE
properly override isl CMakeLists.txt ISL_INT setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ message(STATUS "Found ATen.so file: ${ATEN_LIBRARIES}")
 ################################################################################
 # isl
 ################################################################################
-set(ISL_INT gmp)
+set(ISL_INT "gmp" CACHE STRING "Which package to use to represent multi-precision integers (gmp|imath)")
 include_directories(AFTER ${PROJECT_SOURCE_DIR}/third-party/islpp/include)
 include_directories(AFTER ${CMAKE_CURRENT_BINARY_DIR}/third-party/islpp/include)
 add_subdirectory(third-party/islpp)


### PR DESCRIPTION
Prior to b72b7f11f (Redo the build system, Tue May 22 09:32:11 2018 -0600),
the ISL_INT GMP value would be set on the command line, which apparently
overrides the cache setting, in isl's CMakeLists.txt.
However, since that commit, the _first_ time isl's CMakeLists.txt
is run, it would initialize ISL_INT to imath (ignoring the value set
in TC's CMakeLists.txt), while on any further run, the value set
in TC's CMakeLists.txt would override the cache value and
isl's CMakeLists.txt would keep the gmp value.

Now, it is not clear why a fork of isl that is specific to TC
would set the value to imath in the first place if TC wants
this value to be gmp, but given this situation, let TC's CMakeLists.txt
create the cache entry such that it gets initialized to the proper value
and in particular doesn't change over different runs.