### PR TITLE
register promotion: promote below any node in the tree

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -509,7 +509,7 @@ isl::multi_union_pw_aff MappedScop::threadMappingSchedule(
     ids.emplace_back(mapping::ThreadId::makeId(i));
   }
   auto tupleId = isl::id(tree->ctx_, kBlock);
-  return extractDomainToIds(tree, ids, tupleId);
+  return extractDomainToIds(scop_->scheduleRoot(), tree, ids, tupleId);
 }
 
 isl::multi_union_pw_aff MappedScop::blockMappingSchedule(

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -476,28 +476,12 @@ constexpr auto kWarp = "warp";
 isl::multi_union_pw_aff extractDomainToThread(
     const detail::ScheduleTree* tree,
     size_t nThread) {
-  using namespace polyhedral::detail;
-
-  auto space = isl::space(tree->ctx_, 0);
-  auto empty = isl::union_set::empty(space);
-  auto id = isl::id(tree->ctx_, kBlock);
-  space = space.named_set_from_params_id(id, nThread);
-  auto zero = isl::multi_val::zero(space);
-  auto domainToThread = isl::multi_union_pw_aff(empty, zero);
-
-  for (auto mapping : tree->collect(tree, ScheduleTreeType::MappingFilter)) {
-    auto mappingNode = mapping->elemAs<ScheduleTreeElemMappingFilter>();
-    auto list = isl::union_pw_aff_list(tree->ctx_, nThread);
-    for (size_t i = 0; i < nThread; ++i) {
-      auto threadId = mapping::ThreadId::makeId(i);
-      auto threadMap = mappingNode->mapping.at(threadId);
-      list = list.add(threadMap);
-    }
-    auto nodeToThread = isl::multi_union_pw_aff(space, list);
-    domainToThread = domainToThread.union_add(nodeToThread);
+  std::vector<mapping::MappingId> ids;
+  for (size_t i = 0; i < nThread; ++i) {
+    ids.emplace_back(mapping::ThreadId::makeId(i));
   }
-
-  return domainToThread;
+  auto tupleId = isl::id(tree->ctx_, kBlock);
+  return extractDomainToIds(tree, ids, tupleId);
 }
 
 /*

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -1068,7 +1068,7 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
 
   // 9. Promote to registers below the loops mapped to threads.
   if (cudaOptions.proto().use_private_memory()) {
-    promoteToRegistersBelowThreads(mappedScop->scop(), -1ull);
+    promoteToRegistersBelowThreads(*mappedScop, -1ull);
   }
 
   LOG_IF(INFO, FLAGS_debug_tc_mapper)

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -461,6 +461,8 @@ bool hasOuterSequentialMember(
   return false;
 }
 
+// Name of the space of blocks inside the grid
+constexpr auto kGrid = "grid";
 // Name of the space of threads inside a block
 constexpr auto kBlock = "block";
 // Name of the space of warps
@@ -508,6 +510,16 @@ isl::multi_union_pw_aff MappedScop::threadMappingSchedule(
   }
   auto tupleId = isl::id(tree->ctx_, kBlock);
   return extractDomainToIds(tree, ids, tupleId);
+}
+
+isl::multi_union_pw_aff MappedScop::blockMappingSchedule(
+    const detail::ScheduleTree* tree) const {
+  std::vector<mapping::MappingId> ids;
+  for (size_t i = 0; i < numBlocks.view.size(); ++i) {
+    ids.emplace_back(mapping::BlockId::makeId(i));
+  }
+  auto tupleId = isl::id(tree->ctx_, kGrid);
+  return extractDomainToIds(scop_->scheduleRoot(), tree, ids, tupleId);
 }
 
 Scop::SyncLevel MappedScop::findBestSync(

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -193,6 +193,13 @@ class MappedScop {
   isl::multi_union_pw_aff threadMappingSchedule(
       const detail::ScheduleTree* tree) const;
 
+  // Extract a mapping from the domain elements active at "tree"
+  // to the block identifiers, where all branches in "tree"
+  // are assumed to have been mapped to block identifiers.
+  // The result lives in a space of the form grid[x, ...].
+  isl::multi_union_pw_aff blockMappingSchedule(
+      const detail::ScheduleTree* tree) const;
+
  private:
   // Insert the optimal combination of synchronizations in the sequence
   void insertBestSyncInSeq(detail::ScheduleTree* seq);

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -186,6 +186,13 @@ class MappedScop {
       size_t nChildren,
       bool hasOuterSequentialMember);
 
+  // Extract a mapping from the domain elements active at "tree"
+  // to the thread identifiers, where all branches in "tree"
+  // are assumed to have been mapped to thread identifiers.
+  // The result lives in a space of the form block[x, ...].
+  isl::multi_union_pw_aff threadMappingSchedule(
+      const detail::ScheduleTree* tree) const;
+
  private:
   // Insert the optimal combination of synchronizations in the sequence
   void insertBestSyncInSeq(detail::ScheduleTree* seq);

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -190,6 +190,8 @@ class MappedScop {
   // to the thread identifiers, where all branches in "tree"
   // are assumed to have been mapped to thread identifiers.
   // The result lives in a space of the form block[x, ...].
+  //
+  // Note: this function ignores statements introduced by extension nodes.
   isl::multi_union_pw_aff threadMappingSchedule(
       const detail::ScheduleTree* tree) const;
 
@@ -197,6 +199,8 @@ class MappedScop {
   // to the block identifiers, where all branches in "tree"
   // are assumed to have been mapped to block identifiers.
   // The result lives in a space of the form grid[x, ...].
+  //
+  // Note: this function ignores statements introduced by extension nodes.
   isl::multi_union_pw_aff blockMappingSchedule(
       const detail::ScheduleTree* tree) const;
 

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -34,9 +34,17 @@ namespace tc {
 namespace polyhedral {
 namespace {
 
-bool isThreadId(const mapping::MappingId& id) {
-  return id == mapping::ThreadId::x() or id == mapping::ThreadId::y() or
-      id == mapping::ThreadId::z();
+/*
+ * Is "id" a mapping of the type provided as template argument?
+ */
+template <typename MappingType>
+bool isMappingIdType(const mapping::MappingId& id) {
+  for (size_t i = 0; i < MappingType::kMaxDim; ++i) {
+    if (id == MappingType::makeId(i)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /*
@@ -47,7 +55,7 @@ bool isThreadMapping(const detail::ScheduleTree* tree) {
 
   if (auto filterNode = tree->elemAs<ScheduleTreeElemMappingFilter>()) {
     for (auto& kvp : filterNode->mapping) {
-      if (isThreadId(kvp.first)) {
+      if (isMappingIdType<mapping::ThreadId>(kvp.first)) {
         return true;
       }
     }

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -734,8 +734,6 @@ void promoteToRegistersBelow(MappedScop& mscop, detail::ScheduleTree* scope) {
 
 // Promote at the positions of the thread specific markers.
 void promoteToRegistersBelowThreads(MappedScop& mscop, size_t nRegisters) {
-  using namespace tc::polyhedral::detail;
-
   auto& scop = mscop.scop();
   auto root = scop.scheduleRoot();
   auto markers = findThreadSpecificMarkers(root);

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -347,34 +347,117 @@ isl::union_set collectMappingsTo(const Scop& scop) {
 }
 
 /*
+ * Check that only unrolled loops may appear in access subscripts.
+ * Because the scoping point can be above a branching tree, descend into each
+ * leaf of the subtree below the scoping point.  For each leaf, construct an
+ * affine multi-expression containing only those band members between the
+ * scoping point and the leaf that are fully unrolled.
+ *
+ * Within each instance of the scope loops, check that loops that are either
+ * unrolled or mapped to threads access a single tensor element in the group
+ * (other loop indices will then not appear in the subscripts, making register
+ * promotion possible).  In other words, check that the relation between the
+ * flat product of prefix, thread-mapped, and unrolled loop indices and
+ * accessed elements is single-valued.
+ *
+ * If band members are mapped to blocks(threads), they may still correspond to
+ * loops in the code in cases where the number of blocks(threads) is less than
+ * the extent of the band member.  If there is no "unroll" flag on these
+ * members, we require that they not appear in the access subscripts similarly
+ * to regular loops.  This is slightly more conservative than necessary because
+ * the actual generated loop iterators may disappear from the access after
+ * mapping to threads in cases where they are used with a modulo that is less
+ * than the number of blocks(threads).  Precise analysis requires non-trivial
+ * schedule manipulations or explicit tiling by grid(block) sizes before
+ * mapping to blocks(threads).
+ *
+ * TODO: note that if a group is formed from partially overlapping references,
+ * one must consider per-reference access relation for single-valuedness as
+ * different references may have different values, but all of them remain
+ * independent of non-unrolled loop iterators.
+ */
+bool accessSubscriptsAreUnrolledLoops(
+    const TensorReferenceGroup& group,
+    const detail::ScheduleTree* root,
+    const detail::ScheduleTree* scope,
+    isl::multi_union_pw_aff outerSchedule) {
+  using namespace detail;
+
+  auto nodes = ScheduleTree::collect(scope);
+  auto leaves = functional::Filter(
+      [](const ScheduleTree* tree) { return tree->numChildren() == 0; }, nodes);
+
+  auto domainNode = root->elemAs<detail::ScheduleTreeElemDomain>();
+  TC_CHECK(domainNode);
+  auto domain = domainNode->domain_;
+
+  // Descend into every leaf.
+  for (auto leaf : leaves) {
+    auto ancestors = leaf->ancestors(root);
+    ancestors.push_back(leaf);
+    auto subdomain = activeDomainPointsBelow(root, leaf);
+
+    auto unrolledDims = isl::union_pw_aff_list(leaf->ctx_, 1);
+    for (auto node : ancestors) {
+      auto band = node->elemAs<detail::ScheduleTreeElemBand>();
+      if (!band) {
+        continue;
+      }
+
+      isl::multi_union_pw_aff schedule = band->mupa_;
+      schedule = schedule.intersect_domain(subdomain);
+      for (size_t i = 0, e = band->nMember(); i < e; ++i) {
+        if (!band->unroll_[i]) {
+          continue;
+        }
+        unrolledDims = unrolledDims.add(schedule.get_union_pw_aff(i));
+      }
+    }
+
+    auto space = isl::space(leaf->ctx_, 0, unrolledDims.n())
+                     .align_params(subdomain.get_space());
+    auto unrolledDimsMupa = isl::multi_union_pw_aff(space, unrolledDims);
+
+    // It is possible that no loops are unrolled, in which case
+    // unrolledDimsMupa is zero-dimensional and needs an explicit domain
+    // to be convertible to a union_map.
+    unrolledDimsMupa =
+        unrolledDimsMupa.intersect_domain(group.originalAccesses().domain());
+
+    auto accesses = group.originalAccesses();
+    auto schedule = outerSchedule.flat_range_product(unrolledDimsMupa);
+    accesses = accesses.apply_domain(isl::union_map::from(schedule));
+
+    if (!accesses.is_single_valued()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*
  * Check if the given "group" can be promoted to registers for the given
  * mapping to thread identifiers and within the given outer schedule.
  *
- * In particular, the group's footprint must contain only one element and the
+ * In particular, all tensor subscripts that may appear in the promoted access
+ * must be either unrolled loops or thread identifiers and the
  * same tensor element should never be accessed by two different threads
  * within the same iteration of the outer schedule.
  * The second test is performed by checking that there is only a single
  * thread associated to a given pair of tensor element and outer schedule
  * iteration.
- * Note that the test for a single thread is performed by looking
- * at the range of "thread".  This range may be larger than the number
- * of threads, such that multiple instances may get mapped to the same thread.
- * Requiring different such instances is therefore slightly more conservative
- * than strictly needed.
  */
-bool isPromotableToRegisterBelowThreads(
+bool isPromotableToRegistersBelow(
     const TensorReferenceGroup& group,
+    const detail::ScheduleTree* root,
+    const detail::ScheduleTree* scope,
     isl::multi_union_pw_aff outer,
     isl::multi_union_pw_aff thread) {
   auto originalAccesses = group.originalAccesses();
 
-  // Return early if more than one element needs to be stored in registers.
-  // TODO: support arrays in registers if they are only accessed with constant
-  // subscripts, e.g. if the inner loops are fully unrolled.
-  auto sizes = group.approximationSizes();
-  auto nElements =
-      std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<size_t>());
-  if (nElements != 1) {
+  if (!accessSubscriptsAreUnrolledLoops(
+          group, root, scope, outer.flat_range_product(thread))) {
     return false;
   }
 
@@ -567,10 +650,12 @@ void promoteGreedilyAtDepth(
 }
 
 // Promote at the positions of the thread specific markers.
-void promoteToRegistersBelowThreads(Scop& scop, size_t nRegisters) {
+void promoteToRegistersBelowThreads(MappedScop& mscop, size_t nRegisters) {
   using namespace tc::polyhedral::detail;
 
+  auto& scop = mscop.scop();
   auto root = scop.scheduleRoot();
+  auto threadMapping = mscop.threadMappingSchedule(root);
 
   {
     auto markers = findThreadSpecificMarkers(root);
@@ -578,10 +663,7 @@ void promoteToRegistersBelowThreads(Scop& scop, size_t nRegisters) {
     for (auto marker : markers) {
       auto partialSched = prefixSchedule(root, marker);
       // Pure affine schedule without (mapping) filters.
-      auto mapping = findThreadMappingAncestor(root, marker);
-      auto prefixSchedMupa = prefixScheduleMupa(root, mapping);
-      auto mapSchedMupa = infixScheduleMupa(root, mapping, marker);
-      auto partialSchedMupa = prefixSchedMupa.flat_range_product(mapSchedMupa);
+      auto partialSchedMupa = partialScheduleMupa(root, marker);
 
       // Because this function is called below the thread mapping marker,
       // partialSched has been intersected with both the block and the thread
@@ -600,8 +682,8 @@ void promoteToRegistersBelowThreads(Scop& scop, size_t nRegisters) {
           if (sizes.size() == 0) {
             continue;
           }
-          if (!isPromotableToRegisterBelowThreads(
-                  *group, prefixSchedMupa, mapSchedMupa)) {
+          if (!isPromotableToRegistersBelow(
+                  *group, root, marker, partialSchedMupa, threadMapping)) {
             continue;
           }
           if (!hasReuseWithin(*group, partialSchedMupa)) {

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -25,6 +25,10 @@ namespace polyhedral {
 class MappedScop;
 class Scop;
 
+namespace detail {
+class ScheduleTree;
+}
+
 // In the given mapped scop "mscop",
 // promote to shared memory at "depth" until "sharedMemorySize" is used.
 // Map copies between global and shared memory to threads and unroll those
@@ -37,6 +41,8 @@ void promoteGreedilyAtDepth(
     std::size_t depth,
     std::size_t sharedMemorySize,
     bool unrollCopies);
+
+void promoteToRegistersBelow(MappedScop& mscop, detail::ScheduleTree* scope);
 
 void promoteToRegistersBelowThreads(MappedScop& scop, std::size_t nRegisters);
 } // namespace polyhedral

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -38,6 +38,6 @@ void promoteGreedilyAtDepth(
     std::size_t sharedMemorySize,
     bool unrollCopies);
 
-void promoteToRegistersBelowThreads(Scop& scop, std::size_t nRegisters);
+void promoteToRegistersBelowThreads(MappedScop& scop, std::size_t nRegisters);
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/exceptions.h
+++ b/tc/core/polyhedral/exceptions.h
@@ -62,6 +62,10 @@ struct PromotionNYI : public std::logic_error {
 struct GroupingError : public std::logic_error {
   explicit GroupingError(const std::string& s) : std::logic_error(s) {}
 };
+
+struct IncorrectScope : public std::logic_error {
+  explicit IncorrectScope(const std::string& s) : std::logic_error(s) {}
+};
 } // namespace promotion
 
 namespace codegen {

--- a/tc/core/polyhedral/memory_promotion.cc
+++ b/tc/core/polyhedral/memory_promotion.cc
@@ -459,6 +459,11 @@ isl::multi_aff dropDummyTensorDimensions(
   space = add_range(space, list.n());
   return isl::multi_aff(space, list);
 }
+
+inline void unrollAllMembers(detail::ScheduleTreeElemBand* band) {
+  band->unroll_ = std::vector<bool>(band->nMember(), true);
+}
+
 } // namespace
 
 ScheduleTree* insertCopiesUnder(
@@ -466,7 +471,8 @@ ScheduleTree* insertCopiesUnder(
     ScheduleTree* tree,
     const TensorReferenceGroup& group,
     isl::id tensorId,
-    isl::id groupId) {
+    isl::id groupId,
+    bool unrollAllCopies) {
   const ScheduleTree* root = scop.scheduleRoot();
   auto ctx = root->ctx_;
   isl::id readId = isl::id(ctx, std::string(kReadIdName));
@@ -493,6 +499,11 @@ ScheduleTree* insertCopiesUnder(
 
   auto readBandNode = ScheduleTree::makeBand(readSchedule);
   auto writeBandNode = ScheduleTree::makeBand(writeSchedule);
+
+  if (unrollAllCopies) {
+    unrollAllMembers(readBandNode->elemAs<detail::ScheduleTreeElemBand>());
+    unrollAllMembers(writeBandNode->elemAs<detail::ScheduleTreeElemBand>());
+  }
 
   auto extension =
       promotion.wrap().identity().domain_factor_domain().domain_factor_domain();

--- a/tc/core/polyhedral/memory_promotion.cc
+++ b/tc/core/polyhedral/memory_promotion.cc
@@ -475,9 +475,6 @@ ScheduleTree* insertCopiesUnder(
   // Take the set of all tensor elements.
   auto tensorElements = tensorElementsSet(scop, tensorId);
 
-  if (groupId.is_null()) {
-    throw promotion::GroupingError("expected group id");
-  }
   auto promotion =
       isl::map(group.promotion()).set_tuple_id(isl::dim_type::out, groupId);
   auto promotionSpace = promotion.get_space();

--- a/tc/core/polyhedral/memory_promotion.h
+++ b/tc/core/polyhedral/memory_promotion.h
@@ -214,6 +214,6 @@ detail::ScheduleTree* insertCopiesUnder(
     detail::ScheduleTree* tree,
     const TensorReferenceGroup& group,
     isl::id tensorId,
-    isl::id groupId = isl::id());
+    isl::id groupId);
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/memory_promotion.h
+++ b/tc/core/polyhedral/memory_promotion.h
@@ -214,6 +214,7 @@ detail::ScheduleTree* insertCopiesUnder(
     detail::ScheduleTree* tree,
     const TensorReferenceGroup& group,
     isl::id tensorId,
-    isl::id groupId);
+    isl::id groupId,
+    bool unrollAllCopies);
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/memory_promotion.h
+++ b/tc/core/polyhedral/memory_promotion.h
@@ -111,9 +111,10 @@ class TensorReferenceGroup {
   TensorReferenceGroup() {}
 
  public:
-  static TensorGroups accessedBySubtree(
-      const detail::ScheduleTree* tree,
-      const Scop& scop);
+  static TensorGroups accessedWithin(
+      isl::union_map outerSchedule,
+      isl::union_map reads,
+      isl::union_map writes);
 
   bool isReadOnly() const;
 

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -486,9 +486,9 @@ isl::multi_union_pw_aff prefixScheduleMupa(
 isl::multi_union_pw_aff partialScheduleMupa(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* tree) {
+  auto prefix = prefixScheduleMupa(root, tree);
   auto band = tree->elemAs<ScheduleTreeElemBand>();
-  TC_CHECK(band);
-  return prefixScheduleMupa(root, tree).flat_range_product(band->mupa_);
+  return band ? prefix.flat_range_product(band->mupa_) : prefix;
 }
 
 void updateTopLevelContext(detail::ScheduleTree* root, isl::set context) {

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -145,6 +145,18 @@ isl::union_set activeDomainPointsBelow(
   return activeDomainPointsHelper(root, ancestors);
 }
 
+isl::union_set activeDomainPointsNoMappingNoExtension(
+    const detail::ScheduleTree* root,
+    const detail::ScheduleTree* tree) {
+  auto domain = root->elemAs<detail::ScheduleTreeElemDomain>()->domain_;
+  for (auto t : tree->ancestors(root)) {
+    if (auto f = t->elemAs<detail::ScheduleTreeElemFilter>()) {
+      domain = domain.intersect(f->filter_);
+    }
+  }
+  return domain;
+}
+
 vector<ScheduleTree*> collectScheduleTreesPath(
     std::function<ScheduleTree*(ScheduleTree*)> next,
     ScheduleTree* start) {
@@ -804,6 +816,10 @@ void orderAfter(ScheduleTree* root, ScheduleTree* tree, isl::union_set filter) {
  * to identifiers "ids", where all branches in "tree"
  * are assumed to have been mapped to these identifiers.
  * The result lives in a space of the form "tupleId"["ids"...].
+ *
+ * Note: this function only takes into account points that are present in the
+ * root domain node.  Those introduced by extension nodes are ignored.  This
+ * behavior can change in the future.
  */
 isl::multi_union_pw_aff extractDomainToIds(
     const detail::ScheduleTree* root,
@@ -833,12 +849,17 @@ isl::multi_union_pw_aff extractDomainToIds(
       continue;
     }
     auto nodeToIds = isl::multi_union_pw_aff(space, list);
+    auto active = activeDomainPointsNoMappingNoExtension(root, mapping);
+    TC_CHECK(active.intersect(domainToIds.domain()).is_empty())
+        << "conflicting mappings; are the filters in the tree disjoint?";
+    nodeToIds = nodeToIds.intersect_domain(active);
     domainToIds = domainToIds.union_add(nodeToIds);
   }
 
-  TC_CHECK(activeDomainPoints(root, tree).is_subset(domainToIds.domain()))
-      << "not all domain points of" << activeDomainPoints(root, tree)
-      << "were mapped to the required ids";
+  auto active = activeDomainPointsNoMappingNoExtension(root, tree);
+  TC_CHECK(active.is_subset(domainToIds.domain()))
+      << "not all domain points of\n"
+      << active << "\nwere mapped to the required ids";
 
   return domainToIds;
 }

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -31,6 +31,7 @@
 #include "tc/core/check.h"
 #include "tc/core/constants.h"
 #include "tc/core/polyhedral/functional.h"
+#include "tc/core/polyhedral/mapping_types.h"
 #include "tc/core/polyhedral/schedule_tree_elem.h"
 #include "tc/core/polyhedral/schedule_tree_matcher.h"
 #include "tc/core/scope_guard.h"
@@ -796,6 +797,39 @@ void orderAfter(ScheduleTree* root, ScheduleTree* tree, isl::union_set filter) {
   auto childPos = tree->positionInParent(parent);
   seq->insertChild(0, gistedFilter(other, parent->detachChild(childPos)));
   parent->insertChild(childPos, std::move(seq));
+}
+
+/*
+ * Extract a mapping from the domain elements active at "tree"
+ * to identifiers "ids", where all branches in "tree"
+ * are assumed to have been mapped to these identifiers.
+ * The result lives in a space of the form "tupleId"["ids"...].
+ */
+isl::multi_union_pw_aff extractDomainToIds(
+    const detail::ScheduleTree* tree,
+    const std::vector<mapping::MappingId>& ids,
+    isl::id tupleId) {
+  using namespace polyhedral::detail;
+
+  auto space = isl::space(tree->ctx_, 0);
+  auto empty = isl::union_set::empty(space);
+  space = space.named_set_from_params_id(tupleId, ids.size());
+  auto zero = isl::multi_val::zero(space);
+  auto domainToIds = isl::multi_union_pw_aff(empty, zero);
+
+  for (auto mapping : tree->collect(tree, ScheduleTreeType::MappingFilter)) {
+    auto mappingNode = mapping->elemAs<ScheduleTreeElemMappingFilter>();
+    auto list = isl::union_pw_aff_list(tree->ctx_, ids.size());
+    for (auto id : ids) {
+      CHECK_GT(mappingNode->mapping.count(id), 0) << "no mapping to id " << id;
+      auto idMap = mappingNode->mapping.at(id);
+      list = list.add(idMap);
+    }
+    auto nodeToIds = isl::multi_union_pw_aff(space, list);
+    domainToIds = domainToIds.union_add(nodeToIds);
+  }
+
+  return domainToIds;
 }
 
 } // namespace polyhedral

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -326,6 +326,15 @@ isl::union_set activeDomainPointsBelow(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node);
 
+// Get the set of domain points active below the given node without including
+// the points introduced by extension nodes and without treating mapping nodes
+// as filters.  A point is considered active at a schedule node "tree" if it is
+// present in the "root" domain node and was not filtered away on the path from
+// "root" to "tree".  The root must be a domain element.
+isl::union_set activeDomainPointsNoMappingNoExtension(
+    const detail::ScheduleTree* root,
+    const detail::ScheduleTree* tree);
+
 // Extract a mapping from the domain elements active at "tree" (in a tree
 // rooted at "root") to identifiers "ids", where all branches in "tree" are
 // assumed to have been mapped to these identifiers.  The result lives in a

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "tc/core/polyhedral/functional.h"
+#include "tc/core/polyhedral/mapping_types.h"
 #include "tc/core/polyhedral/options.h"
 #include "tc/core/polyhedral/schedule_tree.h"
 #include "tc/external/isl.h"
@@ -324,6 +325,15 @@ isl::union_set activeDomainPoints(
 isl::union_set activeDomainPointsBelow(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node);
+
+// Extract a mapping from the domain elements active at "tree"
+// to identifiers "ids", where all branches in "tree"
+// are assumed to have been mapped to these identifiers.
+// The result lives in a space of the form "tupleId"["ids"...].
+isl::multi_union_pw_aff extractDomainToIds(
+    const detail::ScheduleTree* tree,
+    const std::vector<mapping::MappingId>& ids,
+    isl::id tupleId);
 
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -326,11 +326,12 @@ isl::union_set activeDomainPointsBelow(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node);
 
-// Extract a mapping from the domain elements active at "tree"
-// to identifiers "ids", where all branches in "tree"
-// are assumed to have been mapped to these identifiers.
-// The result lives in a space of the form "tupleId"["ids"...].
+// Extract a mapping from the domain elements active at "tree" (in a tree
+// rooted at "root") to identifiers "ids", where all branches in "tree" are
+// assumed to have been mapped to these identifiers.  The result lives in a
+// space of the form "tupleId"["ids"...].
 isl::multi_union_pw_aff extractDomainToIds(
+    const detail::ScheduleTree* root,
     const detail::ScheduleTree* tree,
     const std::vector<mapping::MappingId>& ids,
     isl::id tupleId);

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -249,7 +249,7 @@ void Scop::promoteEverythingAt(std::vector<size_t> pos) {
   checkFiltersDisjointStatements(scheduleRoot());
   auto schedule = partialSchedule(root, tree);
 
-  auto groupMap = TensorReferenceGroup::accessedBySubtree(tree, *this);
+  auto groupMap = TensorReferenceGroup::accessedWithin(schedule, reads, writes);
   for (auto& p : groupMap) {
     for (auto& gr : p.second) {
       promoteGroup(

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -192,7 +192,13 @@ void Scop::promoteGroup(
     sizes.back() += 1;
   }
   promotedDecls_[groupId] = PromotedDecl{tensorId, sizes, kind};
-  insertCopiesUnder(*this, tree, *gr, tensorId, groupId);
+  insertCopiesUnder(
+      *this,
+      tree,
+      *gr,
+      tensorId,
+      groupId,
+      kind == PromotedDecl::Kind::Register);
 
   // FIXME: we can now store a unique pointer...
   auto group = std::shared_ptr<TensorReferenceGroup>(std::move(gr));

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -451,8 +451,8 @@ TEST_F(MapperMemoryPromotionRAW, throwIfCopiesBelowThreads) {
 }
 
 class MatMulBias : public TestMapper {
- public:
-  std::string emitCode(
+ protected:
+  std::unique_ptr<MappedScop> prepare(
       const std::unordered_map<std::string, size_t>& parameters,
       const CudaMappingOptions& mappingOptions) {
     std::string tc = R"TC(
@@ -462,8 +462,44 @@ def fun(float(N,K) A, float(K,M) B, float(N,M) C) -> (O) {
 }
 )TC";
 
-    auto mscop = makeMappedScop(tc, mappingOptions, parameters);
+    return makeMappedScop(tc, mappingOptions, parameters);
+  }
+
+  std::string emitCode(const std::unique_ptr<MappedScop>& mscop) {
     return std::get<0>(mscop->codegen("fun"));
+  }
+
+  std::string emitCode(
+      const std::unordered_map<std::string, size_t>& parameters,
+      const CudaMappingOptions& mappingOptions) {
+    return emitCode(prepare(parameters, mappingOptions));
+  }
+
+  void expectNoABCPromotion(const std::string& code) {
+    auto aDeclPos = code.find("  float32 _A_0");
+    auto bDeclPos = code.find("  float32 _B_0");
+    auto cDeclPos = code.find("  float32 _C_0");
+    EXPECT_TRUE(aDeclPos == std::string::npos)
+        << "tensor A promoted to register but has elements accessed "
+        << "by multiple threads";
+    EXPECT_TRUE(bDeclPos == std::string::npos)
+        << "tensor B promoted to register but has elements accessed "
+        << "by multiple threads";
+    EXPECT_TRUE(cDeclPos == std::string::npos)
+        << "tensor C promoted to register but has no reuse";
+  }
+
+  void expectNoSymbolicSubscript(const std::string& code) {
+    // We don't know the exact name of the iterator, but it starts with c.
+    auto oWithIteratorPos = code.find("_O_0[c");
+    auto oWithThreadPos = code.find("_O_0[t1");
+
+    EXPECT_TRUE(oWithIteratorPos == std::string::npos)
+        << "accessing local arrays with iterators in subscripts makes "
+        << "these arrays placed in local memory instead of registers";
+    EXPECT_TRUE(oWithThreadPos == std::string::npos)
+        << "expected per-thread groups to be computed, i.e. thread "
+        << "identifiers should not appear in the subscripts";
   }
 };
 
@@ -482,8 +518,6 @@ TEST_F(MatMulBias, RegisterPromotion) {
 
   auto originalAccPos =
       code.find("O[32 * b0 + c3][t0 + 32 * b1]", copyToPos + 1);
-  auto cDeclPos = code.find("float32 _C_0");
-  auto aDeclPos = code.find("float32 _A_0");
 
   EXPECT_TRUE(declPos != std::string::npos) << "no declaration of the register";
   EXPECT_TRUE(copyToPos != std::string::npos) << "expected copy to register";
@@ -492,10 +526,8 @@ TEST_F(MatMulBias, RegisterPromotion) {
 
   EXPECT_NE(originalAccPos, copyFromPos)
       << "global array reference is used in main computation";
-  EXPECT_TRUE(cDeclPos == std::string::npos)
-      << "tensor C promoted to register but has no reuse";
-  EXPECT_TRUE(aDeclPos == std::string::npos)
-      << "tensor A promoted to register but has elements accessed by multiple threads";
+
+  expectNoABCPromotion(code);
 }
 
 TEST_F(MatMulBias, RegisterPromotionSharedPreference) {
@@ -506,16 +538,93 @@ TEST_F(MatMulBias, RegisterPromotionSharedPreference) {
                             .usePrivateMemory(true);
 
   auto code = emitCode({{"N", 42}, {"M", 56}, {"K", 37}}, mappingOptions);
-  auto declPos = code.find("float32 _O_0[1][1]");
-  auto cDeclPos = code.find("float32 _C_0[1][1]");
-  auto aDeclPos = code.find("float32 _A_0[1][1]");
 
+  auto declPos = code.find("float32 _O_0[1][1]");
   EXPECT_TRUE(declPos == std::string::npos)
       << "not expected promotion to register because promoted to shared";
-  EXPECT_TRUE(cDeclPos == std::string::npos)
-      << "tensor C promoted to register but has no reuse";
-  EXPECT_TRUE(aDeclPos == std::string::npos)
-      << "tensor A promoted to register but has elements accessed by multiple threads";
+
+  expectNoABCPromotion(code);
+}
+
+TEST_F(MatMulBias, RegistersAtRoot) {
+  // Disable automatic promotion to registers because we are going to call it
+  // manually.  Require sufficient unrolling to actually hit registers.
+  auto mappingOptions = CudaMappingOptions::makeNaiveMappingOptions()
+                            .unroll(512)
+                            .useSharedMemory(false)
+                            .usePrivateMemory(false);
+
+  auto mscop = prepare({{"N", 42}, {"M", 56}, {"K", 37}}, mappingOptions);
+  promoteToRegistersBelow(*mscop, mscop->scop().scheduleRoot());
+  auto code = emitCode(mscop);
+
+  // Expecting 4 elements because we map the loop i in O[i][j] to 8 threads
+  // after tiling by 32.
+  auto oDeclPos = code.find("float32 _O_0[4][1];");
+  EXPECT_TRUE(oDeclPos != std::string::npos)
+      << "expected O to be promoted to registers";
+
+  expectNoABCPromotion(code);
+  expectNoSymbolicSubscript(code);
+
+  auto o00Pos = code.find("_O_0[0][0]");
+  auto o10Pos = code.find("_O_0[1][0]");
+  auto o20Pos = code.find("_O_0[2][0]");
+  auto o30Pos = code.find("_O_0[3][0]");
+
+  EXPECT_TRUE(o00Pos != std::string::npos)
+      << "expected constant subscripts in _O_0";
+  EXPECT_TRUE(o10Pos != std::string::npos)
+      << "expected constant subscripts in _O_0";
+  EXPECT_TRUE(o20Pos != std::string::npos)
+      << "expected constant subscripts in _O_0";
+  EXPECT_TRUE(o30Pos != std::string::npos)
+      << "expected constant subscripts in _O_0";
+}
+
+TEST_F(MatMulBias, RegistersAtRootNotEnoughUnroll) {
+  // Disable automatic promotion to registers because we are going to call it
+  // manually.  Require no unrolling so as to make promotion to registers
+  // invalid.
+  auto mappingOptions = CudaMappingOptions::makeNaiveMappingOptions()
+                            .unroll(1)
+                            .useSharedMemory(false)
+                            .usePrivateMemory(false);
+
+  auto mscop = prepare({{"N", 42}, {"M", 56}, {"K", 37}}, mappingOptions);
+  promoteToRegistersBelow(*mscop, mscop->scop().scheduleRoot());
+  auto code = emitCode(mscop);
+  auto oDeclPos = code.find("float32 _O_0;");
+
+  EXPECT_TRUE(oDeclPos == std::string::npos)
+      << "not expected O to be promoted to registers";
+
+  expectNoABCPromotion(code);
+  expectNoSymbolicSubscript(code);
+}
+
+TEST_F(MatMulBias, RegistersBelowFirstBand) {
+  using namespace polyhedral::detail;
+
+  // Disable automatic promotion to registers because we are going to call it
+  // manually.
+  auto mappingOptions = CudaMappingOptions::makeNaiveMappingOptions()
+                            .useSharedMemory(false)
+                            .usePrivateMemory(false);
+  auto mscop = prepare({{"N", 42}, {"M", 56}, {"K", 37}}, mappingOptions);
+
+  auto nodes = ScheduleTree::collectDFSPostorder(
+      mscop->scop().scheduleRoot(), ScheduleTreeType::Band);
+  ASSERT_GT(nodes.size(), 0u);
+  auto node = nodes[0];
+  promoteToRegistersBelow(*mscop, node);
+  auto code = emitCode(mscop);
+
+  auto oDeclPos = code.find("float32 _O_0[1][1];");
+  EXPECT_TRUE(oDeclPos != std::string::npos)
+      << "expected O to be promoted to registers";
+  expectNoABCPromotion(code);
+  expectNoSymbolicSubscript(code);
 }
 
 class Strided : public TestMapper {

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -51,6 +51,21 @@ class TestMapper : public ::testing::Test {
     return MappedScop::makeWithOuterBlockInnerThreadStrategy(
         std::move(scop), mappingOptions);
   }
+
+  // This mimics behavior of the old TensorReferenceGroup::accessedBySubtree.
+  // In particular, it takes the partial schedule until "tree" inclusive,
+  // intersecting its domain with all (mapping) filter ancestors and computes
+  // accessed tensor reference groups within that schedule.
+  // If the schedule happens to contain the block/thread mapping filter, the
+  // groups are per-block/thread.  Otherwise, they include all blocks/threads,
+  // which is questionable, but corresponds to what the test currently checks.
+  TensorGroups accessedBySubtree(
+      const polyhedral::detail::ScheduleTree* tree,
+      const Scop& scop) {
+    auto schedule = partialSchedule(scop.scheduleRoot(), tree);
+    return TensorReferenceGroup::accessedWithin(
+        schedule, scop.reads, scop.writes);
+  }
 };
 
 class MapperMemoryPromotion2DHelper : public TestMapper {
@@ -253,8 +268,7 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
     // Must force domain intersection for overapproximation to work
     scop.specializeToContext();
     auto ctx = scop.domain().get_ctx();
-    auto groups = TensorReferenceGroup::accessedBySubtree(
-        scop.scheduleRoot()->child(childPos), scop);
+    auto groups = accessedBySubtree(scop.scheduleRoot()->child(childPos), scop);
     LOG(INFO) << "Groups:\n" << groups;
 
     EXPECT_EQ(groups.size(), 3u);
@@ -333,8 +347,7 @@ def fun(float(N, M) A) -> (B, C) {
     // Must force domain intersection for overapproximation to work
     scop.specializeToContext();
     auto ctx = scop.domain().get_ctx();
-    auto groups = TensorReferenceGroup::accessedBySubtree(
-        scop.scheduleRoot()->child(childPos), scop);
+    auto groups = accessedBySubtree(scop.scheduleRoot()->child(childPos), scop);
     LOG(INFO) << "Groups:\n" << groups;
 
     ASSERT_EQ(groups.size(), 3u);
@@ -521,8 +534,8 @@ class Strided : public TestMapper {
     auto& scop = mscop->scop();
     auto ctx = scop.domain().get_ctx();
 
-    auto groups = TensorReferenceGroup::accessedBySubtree(
-        scop.scheduleRoot()->child({0, 0, 0}), scop);
+    auto groups =
+        accessedBySubtree(scop.scheduleRoot()->child({0, 0, 0}), scop);
     EXPECT_EQ(groups.size(), 2u) << "expected groups for both tensors";
 
     for (const auto& g : groups) {


### PR DESCRIPTION
Introduce promoteToRegistersBelow that takes a schedule tree node as a
scoping point and attempts register promotion below that node.  Rewrite
promoteToRegistersBelowThreads to keep the existing behavior.

Independently of the promotion scope, tensor reference groups must be
computed per-thread (and per-block).  Include the thread (and block)
mapping in the domain of the outer schedule when computing the groups.

Since registers are private to a thread, different threads should not 
access the same value within the given scope.  Inside the promotion
scope, there may be multiple subtrees with different thread mappings.
Furthermore, these mappings are not included in the prefix (scope)
schedule.  Always include thread schedule when checking if accesses are 
performed from one thread only.  This schedule takes into account
potentially different mappings.

Relax the restriction for a promoted group to contain only one element.
Instead, check that all only the dimensions that either correspond to
unrolled loops or are mapped to blocks or threads appear in the access
subscripts.  During code generation, the corresponding loop iterators
are either replaced by constants due to unrolling or become implicit in
block/thread-specific groups (i.e., each thread in each block accesses
different elements so it can use the same "address" for them).

Compute reuse within threads by appending thread schedule to the prefix
schedule before checking for reuse.

Closes #505
Closes #490 