### PR TITLE
add a test for mismatching tensor dimension

### DIFF
--- a/test/cuda/test_corner_cases.cc
+++ b/test/cuda/test_corner_cases.cc
@@ -320,6 +320,17 @@ i))
       at::Scalar(d[0]).toFloat());
 }
 
+// Passing a tensor of mismatching dimension should fail.
+TEST(TestCornerCases, E25) {
+  auto a = F(1);
+  auto b = F(1, 1); // 2D-tensor
+  Fail(
+      "expected 1 dimensions but found tensor with 2 dimensions",
+      "def f(float(1) a) -> (b) { b(i) = a(i) }",
+      {a},
+      {b});
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::gflags::ParseCommandLineFlags(&argc, &argv, true);


### PR DESCRIPTION
674ed01e865744973f3d0c34749b40f9a96e0302 hardened the checks for
mismatching tensor dimensions, making TC throw if the input/output
tensor dimensions match those in the TC function signature, but the test
was missing.  Add this test.

Closes #397 