### PR TITLE
Fix undefined variable errors

### DIFF
--- a/tc/core/mapping_options-inl.h
+++ b/tc/core/mapping_options-inl.h
@@ -161,7 +161,7 @@ MappingOptionsView& MappingOptionsView::scheduleFusionStrategy(
 
 MappingOptionsView& MappingOptionsView::scheduleFusionStrategy(
     const std::string& str) {
-  FusionStrategy fs;
+  FusionStrategy fs(FusionStrategy::Max);
   bool couldParse = FusionStrategy_Parse(str, &fs);
   CHECK(couldParse) << "unknown FusionStrategy " << str;
   return scheduleFusionStrategy(fs);
@@ -175,7 +175,7 @@ MappingOptionsView& MappingOptionsView::outerScheduleFusionStrategy(
 
 MappingOptionsView& MappingOptionsView::outerScheduleFusionStrategy(
     const std::string& str) {
-  FusionStrategy fs;
+  FusionStrategy fs(FusionStrategy::Max);
   bool couldParse = FusionStrategy_Parse(str, &fs);
   CHECK(couldParse) << "unknown FusionStrategy " << str;
   return outerScheduleFusionStrategy(fs);
@@ -199,7 +199,7 @@ MappingOptionsView& MappingOptionsView::intraTileScheduleFusionStrategy(
 
 MappingOptionsView& MappingOptionsView::intraTileScheduleFusionStrategy(
     const std::string& str) {
-  FusionStrategy fs;
+  FusionStrategy fs(FusionStrategy::Max);
   bool couldParse = FusionStrategy_Parse(str, &fs);
   CHECK(couldParse) << "unknown FusionStrategy " << str;
   return intraTileScheduleFusionStrategy(fs);

--- a/test/isl_cli_strategy.h
+++ b/test/isl_cli_strategy.h
@@ -80,7 +80,7 @@ namespace tc {
 //    (at a minimum: tile, mapToThreads and mapToBlocks)
 // 3. call makeCliStrategy with the overridden options
 tc::CudaMappingOptions makeBaseCliStrategy() {
-  tc::FusionStrategy fs;
+  tc::FusionStrategy fs(FusionStrategy::Max);
   CHECK(tc::FusionStrategy_Parse(DEFAULT_FUSION_STRATEGY, &fs));
   CudaMappingOptions options =
       CudaMappingOptions::makeNaiveMappingOptions()
@@ -104,7 +104,7 @@ tc::CudaMappingOptions makeBaseCliStrategy() {
 
 tc::CudaMappingOptions makeCliStrategy(tc::CudaMappingOptions options) {
   if (FLAGS_fusion_strategy != std::string(DEFAULT_FUSION_STRATEGY)) {
-    tc::FusionStrategy fs;
+    tc::FusionStrategy fs(FusionStrategy::Max);
     if (tc::FusionStrategy_Parse(FLAGS_fusion_strategy, &fs)) {
       options.scheduleFusionStrategy(fs);
     } else {


### PR DESCRIPTION
For some reason they only triggered for me when trying to rebase tc_check.
This is still relevant as an independent fix.