### PR TITLE
[DO-NOT-MERGE] extractDomainToThread: differentiate between different branches

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -494,6 +494,11 @@ isl::multi_union_pw_aff extractDomainToThread(
       list = list.add(threadMap);
     }
     auto nodeToThread = isl::multi_union_pw_aff(space, list);
+    for (auto ancestor : mapping->ancestors(tree)) {
+      if (auto filterNode = ancestor->elemAs<ScheduleTreeElemFilter>()) {
+        nodeToThread = nodeToThread.intersect_domain(filterNode->filter_);
+      }
+    }
     domainToThread = domainToThread.union_add(nodeToThread);
   }
 


### PR DESCRIPTION
Within a given schedule tree (different) elements of the same statements
may get mapped to threads in different branch (and therefore possibly
also using a different mapping).  This happens in particular
in case of full/partial tile separation for reduction detection.
The domains of these separate mappings need to be made disjoint
to prevent them from interacting (in particular, getting summed
together).

Closes #505

Note that this conflicts with #489, which extracts out an
`extractMappingToIds` from `extractDomainToThread`
for some reason.