### PR TITLE
makeIslAffFromExpr: only accept parametric expressions

### DIFF
--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -251,31 +251,25 @@ isl::set makeParamContext(isl::ctx ctx, const ParameterVector& params) {
 namespace {
 
 isl::map extractAccess(
-    isl::set domain,
+    const IterationDomain& domain,
     const IRNode* op,
     const std::string& tensor,
     const std::vector<Expr>& args,
     AccessMap* accesses) {
   // Make an isl::map representing this access. It maps from the iteration space
   // to the tensor's storage space, using the coordinates accessed.
+  // First construct a set describing the accessed element
+  // in terms of the parameters (including those corresponding
+  // to the outer loop iterators) and then convert this set
+  // into a map in terms of the iteration domain.
 
-  isl::space domainSpace = domain.get_space();
-  isl::space paramSpace = domainSpace.params();
+  isl::space paramSpace = domain.paramSpace;
   isl::id tensorID(paramSpace.get_ctx(), tensor);
-  auto rangeSpace = paramSpace.named_set_from_params_id(tensorID, args.size());
+  auto tensorSpace = paramSpace.named_set_from_params_id(tensorID, args.size());
 
-  // Add a tag to the domain space so that we can maintain a mapping
-  // between each access in the IR and the reads/writes maps.
-  std::string tag = "__tc_ref_" + std::to_string(accesses->size());
-  isl::id tagID(domain.get_ctx(), tag);
-  accesses->emplace(op, tagID);
-  isl::space tagSpace = paramSpace.named_set_from_params_id(tagID, 0);
-  domainSpace = domainSpace.product(tagSpace);
-
-  // Start with a totally unconstrained relation - every point in
-  // the iteration domain could write to every point in the allocation.
-  isl::map map =
-      isl::map::universe(domainSpace.map_from_domain_and_range(rangeSpace));
+  // Start with a totally unconstrained set - every point in
+  // the allocation could be accessed.
+  isl::set access = isl::set::universe(tensorSpace);
 
   for (size_t i = 0; i < args.size(); i++) {
     // Then add one equality constraint per dimension to encode the
@@ -285,19 +279,34 @@ isl::map extractAccess(
 
     // The coordinate written to in the range ...
     auto rangePoint =
-        isl::pw_aff(isl::local_space(rangeSpace), isl::dim_type::set, i);
-    // ... equals the coordinate accessed as a function of the domain.
-    auto domainPoint = halide2isl::makeIslAffFromExpr(domainSpace, args[i]);
+        isl::pw_aff(isl::local_space(tensorSpace), isl::dim_type::set, i);
+    // ... equals the coordinate accessed as a function of the parameters.
+    auto domainPoint = halide2isl::makeIslAffFromExpr(tensorSpace, args[i]);
     if (!domainPoint.is_null()) {
-      map = map.intersect(isl::pw_aff(domainPoint).eq_map(rangePoint));
+      access = access.intersect(isl::pw_aff(domainPoint).eq_set(rangePoint));
     }
   }
+
+  // Now convert the set into a relation with respect to the iteration domain.
+  auto map = access.unbind_params_insert_domain(domain.tuple);
+
+  // Add a tag to the domain space so that we can maintain a mapping
+  // between each access in the IR and the reads/writes maps.
+  std::string tag = "__tc_ref_" + std::to_string(accesses->size());
+  isl::id tagID(domain.paramSpace.get_ctx(), tag);
+  accesses->emplace(op, tagID);
+  isl::space domainSpace = map.get_space().domain();
+  isl::space tagSpace = domainSpace.params().named_set_from_params_id(tagID, 0);
+  domainSpace = domainSpace.product(tagSpace).unwrap();
+  map = map.preimage_domain(isl::multi_aff::domain_map(domainSpace));
 
   return map;
 }
 
-std::pair<isl::union_map, isl::union_map>
-extractAccesses(isl::set domain, const Stmt& s, AccessMap* accesses) {
+std::pair<isl::union_map, isl::union_map> extractAccesses(
+    const IterationDomain& domain,
+    const Stmt& s,
+    AccessMap* accesses) {
   class FindAccesses : public IRGraphVisitor {
     using IRGraphVisitor::visit;
 
@@ -315,17 +324,17 @@ extractAccesses(isl::set domain, const Stmt& s, AccessMap* accesses) {
           writes.unite(extractAccess(domain, op, op->name, op->args, accesses));
     }
 
-    const isl::set& domain;
+    const IterationDomain& domain;
     AccessMap* accesses;
 
    public:
     isl::union_map reads, writes;
 
-    FindAccesses(const isl::set& domain, AccessMap* accesses)
+    FindAccesses(const IterationDomain& domain, AccessMap* accesses)
         : domain(domain),
           accesses(accesses),
-          reads(isl::union_map::empty(domain.get_space())),
-          writes(isl::union_map::empty(domain.get_space())) {}
+          reads(isl::union_map::empty(domain.tuple.get_space())),
+          writes(isl::union_map::empty(domain.tuple.get_space())) {}
   } finder(domain, accesses);
   s.accept(&finder);
   return {finder.reads, finder.writes};
@@ -440,7 +449,8 @@ isl::schedule makeScheduleTreeHelper(
     schedule = isl::schedule::from_domain(domain);
 
     isl::union_map newReads, newWrites;
-    std::tie(newReads, newWrites) = extractAccesses(domain, op, accesses);
+    std::tie(newReads, newWrites) =
+        extractAccesses(iterationDomain, op, accesses);
 
     *reads = reads->unite(newReads);
     *writes = writes->unite(newWrites);

--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -174,16 +174,9 @@ std::vector<isl::aff> makeIslAffBoundsFromExpr(
   const Max* maxOp = e.as<Max>();
 
   if (const Variable* op = e.as<Variable>()) {
-    isl::local_space ls = isl::local_space(space);
-    int pos = space.find_dim_by_name(isl::dim_type::param, op->name);
-    if (pos >= 0) {
-      return {isl::aff(ls, isl::dim_type::param, pos)};
-    } else {
-      // FIXME: thou shalt not rely upon set dimension names
-      pos = space.find_dim_by_name(isl::dim_type::set, op->name);
-      if (pos >= 0) {
-        return {isl::aff(ls, isl::dim_type::set, pos)};
-      }
+    isl::id id(space.get_ctx(), op->name);
+    if (space.has_param(id)) {
+      return {isl::aff::param_on_domain_space(space, id)};
     }
     LOG(FATAL) << "Variable not found in isl::space: " << space << ": " << op
                << ": " << op->name << '\n';

--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -338,7 +338,7 @@ extractAccesses(isl::set domain, const Stmt& s, AccessMap* accesses) {
  * recursively descending over the Stmt.
  * "s" is the current position in the recursive descent.
  * "set" describes the bounds on the outer loop iterators.
- * "outer" contains the names of the outer loop iterators
+ * "outer" contains the identifiers of the outer loop iterators
  * from outermost to innermost.
  * Return the schedule corresponding to the subtree at "s".
  *
@@ -353,7 +353,7 @@ extractAccesses(isl::set domain, const Stmt& s, AccessMap* accesses) {
 isl::schedule makeScheduleTreeHelper(
     const Stmt& s,
     isl::set set,
-    std::vector<std::string>& outer,
+    isl::id_list outer,
     isl::union_map* reads,
     isl::union_map* writes,
     AccessMap* accesses,
@@ -394,8 +394,7 @@ isl::schedule makeScheduleTreeHelper(
     }
 
     // Recursively descend.
-    auto outerNext = outer;
-    outerNext.push_back(op->name);
+    auto outerNext = outer.add(isl::id(set.get_ctx(), op->name));
     auto body = makeScheduleTreeHelper(
         op->body, set, outerNext, reads, writes, accesses, statements, domains);
 
@@ -438,8 +437,10 @@ isl::schedule makeScheduleTreeHelper(
     size_t stmtIndex = statements->size();
     isl::id id(set.get_ctx(), kStatementLabel + std::to_string(stmtIndex));
     statements->emplace(id, op);
+    auto tupleSpace = isl::space(set.get_ctx(), 0);
+    tupleSpace = tupleSpace.named_set_from_params_id(id, outer.n());
     IterationDomain iterationDomain;
-    iterationDomain.iterators = outer;
+    iterationDomain.tuple = isl::multi_id(tupleSpace, outer);
     domains->emplace(id, iterationDomain);
     isl::set domain = set.set_tuple_id(id);
     schedule = isl::schedule::from_domain(domain);
@@ -462,7 +463,7 @@ ScheduleTreeAndAccesses makeScheduleTree(isl::space paramSpace, const Stmt& s) {
   result.writes = result.reads = isl::union_map::empty(paramSpace);
 
   // Walk the IR building a schedule tree
-  std::vector<std::string> outer;
+  isl::id_list outer(paramSpace.get_ctx(), 0);
   auto schedule = makeScheduleTreeHelper(
       s,
       isl::set::universe(paramSpace),

--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -361,23 +361,17 @@ isl::schedule makeScheduleTreeHelper(
     IterationDomainMap* domains) {
   isl::schedule schedule;
   if (auto op = s.as<For>()) {
-    // Add one additional dimension to our set of loop variables
-    int thisLoopIdx = set.dim(isl::dim_type::set);
-    set = set.add_dims(isl::dim_type::set, 1);
-
-    // Make an id for this loop var. For set dimensions this is
-    // really just for pretty-printing.
+    // Make an id for this loop var.  It starts out as a parameter.
     isl::id id(set.get_ctx(), op->name);
-    set = set.set_dim_id(isl::dim_type::set, thisLoopIdx, id);
+    auto space = set.get_space().add_param(id);
 
-    // Construct a variable (affine function) that indexes the new dimension of
-    // this space.
-    isl::aff loopVar(
-        isl::local_space(set.get_space()), isl::dim_type::set, thisLoopIdx);
+    // Construct a variable (affine function) that references
+    // the new parameter.
+    auto loopVar = isl::aff::param_on_domain_space(space, id);
 
     // Then we add our new loop bound constraints.
-    auto lbs = halide2isl::makeIslAffBoundsFromExpr(
-        set.get_space(), op->min, false, true);
+    auto lbs =
+        halide2isl::makeIslAffBoundsFromExpr(space, op->min, false, true);
     TC_CHECK_GT(lbs.size(), 0u)
         << "could not obtain polyhedral lower bounds from " << op->min;
     for (auto lb : lbs) {
@@ -385,8 +379,7 @@ isl::schedule makeScheduleTreeHelper(
     }
 
     Expr max = simplify(op->min + op->extent - 1);
-    auto ubs =
-        halide2isl::makeIslAffBoundsFromExpr(set.get_space(), max, true, false);
+    auto ubs = halide2isl::makeIslAffBoundsFromExpr(space, max, true, false);
     TC_CHECK_GT(ubs.size(), 0u)
         << "could not obtain polyhedral upper bounds from " << max;
     for (auto ub : ubs) {
@@ -407,7 +400,7 @@ isl::schedule makeScheduleTreeHelper(
     isl::multi_union_pw_aff mupa;
     body.get_domain().foreach_set([&](isl::set s) {
       isl::aff newLoopVar(
-          isl::local_space(s.get_space()), isl::dim_type::set, thisLoopIdx);
+          isl::local_space(s.get_space()), isl::dim_type::set, outer.n());
       if (mupa) {
         mupa = mupa.union_add(isl::union_pw_aff(isl::pw_aff(newLoopVar)));
       } else {
@@ -442,7 +435,7 @@ isl::schedule makeScheduleTreeHelper(
     IterationDomain iterationDomain;
     iterationDomain.tuple = isl::multi_id(tupleSpace, outer);
     domains->emplace(id, iterationDomain);
-    isl::set domain = set.set_tuple_id(id);
+    auto domain = set.unbind_params(iterationDomain.tuple);
     schedule = isl::schedule::from_domain(domain);
 
     isl::union_map newReads, newWrites;

--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -248,6 +248,8 @@ isl::set makeParamContext(isl::ctx ctx, const ParameterVector& params) {
   return context;
 }
 
+namespace {
+
 isl::map extractAccess(
     isl::set domain,
     const IRNode* op,
@@ -328,6 +330,8 @@ extractAccesses(isl::set domain, const Stmt& s, AccessMap* accesses) {
   s.accept(&finder);
   return {finder.reads, finder.writes};
 }
+
+} // namespace
 
 /*
  * Helper function for extracting a schedule from a Halide Stmt,
@@ -446,8 +450,7 @@ isl::schedule makeScheduleTreeHelper(
     schedule = isl::schedule::from_domain(domain);
 
     isl::union_map newReads, newWrites;
-    std::tie(newReads, newWrites) =
-        halide2isl::extractAccesses(domain, op, accesses);
+    std::tie(newReads, newWrites) = extractAccesses(domain, op, accesses);
 
     *reads = reads->unite(newReads);
     *writes = writes->unite(newWrites);

--- a/tc/core/halide2isl.cc
+++ b/tc/core/halide2isl.cc
@@ -433,6 +433,7 @@ isl::schedule makeScheduleTreeHelper(
     auto tupleSpace = isl::space(set.get_ctx(), 0);
     tupleSpace = tupleSpace.named_set_from_params_id(id, outer.n());
     IterationDomain iterationDomain;
+    iterationDomain.paramSpace = set.get_space();
     iterationDomain.tuple = isl::multi_id(tupleSpace, outer);
     domains->emplace(id, iterationDomain);
     auto domain = set.unbind_params(iterationDomain.tuple);

--- a/tc/core/halide2isl.h
+++ b/tc/core/halide2isl.h
@@ -58,8 +58,10 @@ isl::aff makeIslAffFromExpr(isl::space space, const Halide::Expr& e);
 
 // Iteration domain information associated to a statement identifier.
 struct IterationDomain {
-  // The outer loop iterators, from outermost to innermost.
-  std::vector<std::string> iterators;
+  // The identifier tuple corresponding to the iteration domain.
+  // The identifiers in the tuple are the outer loop iterators,
+  // from outermost to innermost.
+  isl::multi_id tuple;
 };
 
 typedef std::unordered_map<isl::id, IterationDomain, isl::IslIdIslHash>

--- a/tc/core/halide2isl.h
+++ b/tc/core/halide2isl.h
@@ -53,7 +53,10 @@ isl::aff makeIslAffFromInt(isl::space space, int64_t i);
 
 // Make an affine function over a space from a Halide Expr. Returns a
 // null isl::aff if the expression is not affine. Fails if Variable
-// does not correspond to a parameter or set dimension of the space.
+// does not correspond to a parameter of the space.
+// Note that the input space can be either a parameter space or
+// a set space, but the expression can only reference
+// the parameters in the space.
 isl::aff makeIslAffFromExpr(isl::space space, const Halide::Expr& e);
 
 // Iteration domain information associated to a statement identifier.

--- a/tc/core/halide2isl.h
+++ b/tc/core/halide2isl.h
@@ -58,6 +58,9 @@ isl::aff makeIslAffFromExpr(isl::space space, const Halide::Expr& e);
 
 // Iteration domain information associated to a statement identifier.
 struct IterationDomain {
+  // All parameters active at the point where the iteration domain
+  // was created, including those corresponding to outer loop iterators.
+  isl::space paramSpace;
   // The identifier tuple corresponding to the iteration domain.
   // The identifiers in the tuple are the outer loop iterators,
   // from outermost to innermost.

--- a/tc/core/halide2isl.h
+++ b/tc/core/halide2isl.h
@@ -56,8 +56,14 @@ isl::aff makeIslAffFromInt(isl::space space, int64_t i);
 // does not correspond to a parameter or set dimension of the space.
 isl::aff makeIslAffFromExpr(isl::space space, const Halide::Expr& e);
 
-typedef std::unordered_map<isl::id, std::vector<std::string>, isl::IslIdIslHash>
-    IteratorMap;
+// Iteration domain information associated to a statement identifier.
+struct IterationDomain {
+  // The outer loop iterators, from outermost to innermost.
+  std::vector<std::string> iterators;
+};
+
+typedef std::unordered_map<isl::id, IterationDomain, isl::IslIdIslHash>
+    IterationDomainMap;
 typedef std::unordered_map<isl::id, Halide::Internal::Stmt, isl::IslIdIslHash>
     StatementMap;
 typedef std::unordered_map<const Halide::Internal::IRNode*, isl::id> AccessMap;
@@ -81,9 +87,9 @@ struct ScheduleTreeAndAccesses {
   /// refered to above.
   StatementMap statements;
 
-  /// The correspondence between statement ids and the outer loop iterators
+  /// The correspondence between statement ids and the iteration domain
   /// of the corresponding leaf Stmt.
-  IteratorMap iterators;
+  IterationDomainMap domains;
 };
 
 /// Make a schedule tree from a Halide Stmt, along with auxiliary data

--- a/tc/core/polyhedral/codegen_llvm.cc
+++ b/tc/core/polyhedral/codegen_llvm.cc
@@ -637,7 +637,7 @@ isl::ast_node collectIteratorMaps(
   auto stmtId = expr.get_arg(0).as<isl::ast_expr_id>().get_id();
   TC_CHECK_EQ(0u, iteratorMaps.count(stmtId)) << "entry exists: " << stmtId;
   auto iteratorMap = isl::pw_multi_aff(scheduleMap.reverse());
-  auto iterators = scop.halide.iterators.at(stmtId);
+  auto iterators = scop.halide.domains.at(stmtId).iterators;
   auto& stmtIteratorMap = iteratorMaps[stmtId];
   for (size_t i = 0; i < iterators.size(); ++i) {
     auto expr = build.expr_from(iteratorMap.get_pw_aff(i));

--- a/tc/core/polyhedral/codegen_llvm.cc
+++ b/tc/core/polyhedral/codegen_llvm.cc
@@ -637,11 +637,11 @@ isl::ast_node collectIteratorMaps(
   auto stmtId = expr.get_arg(0).as<isl::ast_expr_id>().get_id();
   TC_CHECK_EQ(0u, iteratorMaps.count(stmtId)) << "entry exists: " << stmtId;
   auto iteratorMap = isl::pw_multi_aff(scheduleMap.reverse());
-  auto iterators = scop.halide.domains.at(stmtId).iterators;
+  auto tuple = scop.halide.domains.at(stmtId).tuple;
   auto& stmtIteratorMap = iteratorMaps[stmtId];
-  for (size_t i = 0; i < iterators.size(); ++i) {
+  for (int i = 0; i < tuple.size(); ++i) {
     auto expr = build.expr_from(iteratorMap.get_pw_aff(i));
-    stmtIteratorMap.emplace(iterators[i], expr);
+    stmtIteratorMap.emplace(tuple.get_id(i).get_name(), expr);
   }
   auto& subscripts = stmtSubscripts[stmtId];
   auto provide =

--- a/tc/core/polyhedral/codegen_llvm.cc
+++ b/tc/core/polyhedral/codegen_llvm.cc
@@ -648,8 +648,7 @@ isl::ast_node collectIteratorMaps(
       scop.halide.statements.at(stmtId).as<Halide::Internal::Provide>();
   for (auto e : provide->args) {
     const auto& map = iteratorMap;
-    auto space = map.get_space().params();
-    auto aff = scop.makeIslAffFromStmtExpr(stmtId, space, e);
+    auto aff = scop.makeIslAffFromStmtExpr(stmtId, e);
     auto pulled = isl::pw_aff(aff).pullback(map);
     TC_CHECK_EQ(pulled.n_piece(), 1);
     subscripts.push_back(build.expr_from(pulled));

--- a/tc/core/polyhedral/cuda/codegen.h
+++ b/tc/core/polyhedral/cuda/codegen.h
@@ -136,8 +136,7 @@ struct CodegenStatementContext : CodegenContext {
   // of the variables does not correspond to a parameter or
   // an instance identifier of the statement.
   isl::aff makeIslAffFromExpr(const Halide::Expr& e) const {
-    auto space = iteratorMap().get_space().params();
-    return scop().makeIslAffFromStmtExpr(statementId(), space, e);
+    return scop().makeIslAffFromStmtExpr(statementId(), e);
   }
 
   isl::id astNodeId;

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -507,14 +507,12 @@ isl::aff Scop::makeIslAffFromStmtExpr(
     isl::id stmtId,
     isl::space paramSpace,
     const Halide::Expr& e) const {
-  auto ctx = stmtId.get_ctx();
-  auto iterators = halide.domains.at(stmtId).iterators;
-  auto space = paramSpace.named_set_from_params_id(stmtId, iterators.size());
+  auto tuple = halide.domains.at(stmtId).tuple;
+  auto space = paramSpace.named_set_from_params_id(stmtId, tuple.size());
   // Set the names of the set dimensions of "space" for use
   // by halide2isl::makeIslAffFromExpr.
-  for (size_t i = 0; i < iterators.size(); ++i) {
-    isl::id id(ctx, iterators[i]);
-    space = space.set_dim_id(isl::dim_type::set, i, id);
+  for (int i = 0; i < tuple.size(); ++i) {
+    space = space.set_dim_id(isl::dim_type::set, i, tuple.get_id(i));
   }
   return halide2isl::makeIslAffFromExpr(space, e);
 }

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -503,18 +503,12 @@ const Halide::OutputImageParam& Scop::findArgument(isl::id id) const {
   return *halide.inputs.begin();
 }
 
-isl::aff Scop::makeIslAffFromStmtExpr(
-    isl::id stmtId,
-    isl::space paramSpace,
-    const Halide::Expr& e) const {
-  auto tuple = halide.domains.at(stmtId).tuple;
-  auto space = paramSpace.named_set_from_params_id(stmtId, tuple.size());
-  // Set the names of the set dimensions of "space" for use
-  // by halide2isl::makeIslAffFromExpr.
-  for (int i = 0; i < tuple.size(); ++i) {
-    space = space.set_dim_id(isl::dim_type::set, i, tuple.get_id(i));
-  }
-  return halide2isl::makeIslAffFromExpr(space, e);
+isl::aff Scop::makeIslAffFromStmtExpr(isl::id stmtId, const Halide::Expr& e)
+    const {
+  auto domain = halide.domains.at(stmtId);
+  auto aff = halide2isl::makeIslAffFromExpr(domain.paramSpace, e);
+  aff = aff.unbind_params_insert_domain(domain.tuple);
+  return aff;
 }
 
 } // namespace polyhedral

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -64,7 +64,7 @@ ScopUPtr Scop::makeScop(
   scop->halide.statements = std::move(tree.statements);
   scop->halide.accesses = std::move(tree.accesses);
   scop->halide.reductions = halide2isl::findReductions(components.stmt);
-  scop->halide.iterators = std::move(tree.iterators);
+  scop->halide.domains = std::move(tree.domains);
 
   return scop;
 }
@@ -508,7 +508,7 @@ isl::aff Scop::makeIslAffFromStmtExpr(
     isl::space paramSpace,
     const Halide::Expr& e) const {
   auto ctx = stmtId.get_ctx();
-  auto iterators = halide.iterators.at(stmtId);
+  auto iterators = halide.domains.at(stmtId).iterators;
   auto space = paramSpace.named_set_from_params_id(stmtId, iterators.size());
   // Set the names of the set dimensions of "space" for use
   // by halide2isl::makeIslAffFromExpr.

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -411,15 +411,11 @@ struct Scop {
   const Halide::OutputImageParam& findArgument(isl::id id) const;
 
   // Make an affine function from a Halide Expr that is defined
-  // over the instance set of the statement with identifier "stmtId" and
-  // with parameters specified by "paramSpace".  Return a
-  // null isl::aff if the expression is not affine.  Fail if any
+  // over the instance set of the statement with identifier "stmtId".
+  // Return a null isl::aff if the expression is not affine.  Fail if any
   // of the variables does not correspond to a parameter or
   // an instance identifier of the statement.
-  isl::aff makeIslAffFromStmtExpr(
-      isl::id stmtId,
-      isl::space paramSpace,
-      const Halide::Expr& e) const;
+  isl::aff makeIslAffFromStmtExpr(isl::id stmtId, const Halide::Expr& e) const;
 
   // Promote a tensor reference group to a storage of a given "kind",
   // inserting the copy

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -490,7 +490,7 @@ struct Scop {
     std::unordered_map<isl::id, Halide::Internal::Stmt, isl::IslIdIslHash>
         statements;
     std::unordered_map<const Halide::Internal::IRNode*, isl::id> accesses;
-    halide2isl::IteratorMap iterators;
+    halide2isl::IterationDomainMap domains;
   } halide;
 
   // Polyhedral IR


### PR DESCRIPTION
The function makeIslAffBoundsFromExpr currently relies on the names
of the set dimensions in a space.  Even though the dependence
is very localized and it is unlikely that those names would
get dropped, it is better to not rely on them at all.

First change the users of makeIslAffFromExpr to only create expressions
in terms of parameters and then change makeIslAffFromExpr
to only construct those.

Start by collecting the constraints on the outer loop iterators
in terms of parameters and only convert them into set dimensions
at the point where the iteration domain is constructed.

Treating the outer loop iterators as parameters at first
makes sense because they have a fixed value at the point
where the statement is executed.
It is only at the point where the iteration domain is constructed
that the loop iterators should no longer be considered as parameters.

