### PR TITLE
no longer consider ScheduleTreeElemMappingFilter to be a subclass of filter

### DIFF
--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -65,7 +65,7 @@ void validate(const detail::ScheduleTree* root) {
       filter(
           [](isl::union_set uset) { return !uset || uset.is_empty(); }, any()),
       root);
-  throwIfHasPattern<EmptyMappingFilterException>(
+  throwIfHasPattern<EmptyMappingException>(
       mapping_filter(
           [](isl::union_set uset) { return !uset || uset.is_empty(); }, any()),
       root);
@@ -130,7 +130,7 @@ detail::ScheduleTree* MappedScop::map(
     idList.emplace_back(id);
   }
 
-  auto mapping = detail::ScheduleTree::makeMappingFilter(idList, affList);
+  auto mapping = detail::ScheduleTree::makeMapping(idList, affList);
   tree = insertNodeAbove(root, tree, std::move(mapping))->child({0});
 
   return tree;

--- a/tc/core/polyhedral/cuda/mapped_scop.h
+++ b/tc/core/polyhedral/cuda/mapped_scop.h
@@ -190,8 +190,6 @@ class MappedScop {
   // to the thread identifiers, where all branches in "tree"
   // are assumed to have been mapped to thread identifiers.
   // The result lives in a space of the form block[x, ...].
-  //
-  // Note: this function ignores statements introduced by extension nodes.
   isl::multi_union_pw_aff threadMappingSchedule(
       const detail::ScheduleTree* tree) const;
 
@@ -199,8 +197,6 @@ class MappedScop {
   // to the block identifiers, where all branches in "tree"
   // are assumed to have been mapped to block identifiers.
   // The result lives in a space of the form grid[x, ...].
-  //
-  // Note: this function ignores statements introduced by extension nodes.
   isl::multi_union_pw_aff blockMappingSchedule(
       const detail::ScheduleTree* tree) const;
 

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -296,9 +296,6 @@ bool promotionImprovesCoalescing(
 
 /*
  * Returns the union of all mapping filters to "MappingType" in "scop".
- *
- * Note: similarly to MappedScop::[thread|block]MappingSchedule, this function
- * does not take into account elements introduced by extension nodes.
  */
 template <typename MappingType>
 isl::union_set collectMappingsTo(const Scop& scop) {
@@ -310,8 +307,7 @@ isl::union_set collectMappingsTo(const Scop& scop) {
   auto mapping = isl::union_set::empty(domain.get_space());
   for (auto mf : mappingFilters) {
     auto filterNode = mf->elemAs<detail::ScheduleTreeElemMappingFilter>();
-    auto filter = filterNode->filter_.intersect(
-        activeDomainPointsNoMappingNoExtension(root, mf));
+    auto filter = filterNode->filter_.intersect(activeDomainPoints(root, mf));
     mapping = mapping.unite(filterNode->filter_);
   }
   return mapping;

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -34,24 +34,6 @@ namespace tc {
 namespace polyhedral {
 namespace {
 
-/*
- * Is "tree" a mapping filter that maps identifiers of the type provided as
- * template argument?
- */
-template <typename MappingType>
-bool isMappingTo(const detail::ScheduleTree* tree) {
-  using namespace detail;
-
-  if (auto filterNode = tree->elemAs<ScheduleTreeElemMappingFilter>()) {
-    for (auto& kvp : filterNode->mapping) {
-      if (kvp.first.is<MappingType>()) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 // Map global<->shared copy bands to threads, starting from the innermost
 // loop as it iterates over the last subscript and will result in coalescing.
 void mapCopiesToThreads(MappedScop& mscop, bool unroll) {
@@ -245,6 +227,8 @@ isl::map makeNextElementMap(isl::space setSpace, unsigned dim) {
 const detail::ScheduleTree* findThreadMappingAncestor(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node) {
+  using namespace tc::polyhedral::detail;
+
   auto ancestors = node->ancestors(root);
   ancestors = functional::Filter(isMappingTo<mapping::ThreadId>, ancestors);
   if (ancestors.size() < 1) {

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -232,7 +232,7 @@ const detail::ScheduleTree* findThreadMappingAncestor(
   auto ancestors = node->ancestors(root);
   ancestors = functional::Filter(isMappingTo<mapping::ThreadId>, ancestors);
   if (ancestors.size() < 1) {
-    throw promotion::PromotionLogicError("missing MappingFilter");
+    throw promotion::PromotionLogicError("missing Mapping");
   }
   return ancestors[0];
 }
@@ -301,12 +301,12 @@ template <typename MappingType>
 isl::union_set collectMappingsTo(const Scop& scop) {
   auto root = scop.scheduleRoot();
   auto domain = scop.domain();
-  auto mappingFilters = detail::ScheduleTree::collect(
-      root, detail::ScheduleTreeType::MappingFilter);
+  auto mappingFilters =
+      detail::ScheduleTree::collect(root, detail::ScheduleTreeType::Mapping);
   mappingFilters = functional::Filter(isMappingTo<MappingType>, mappingFilters);
   auto mapping = isl::union_set::empty(domain.get_space());
   for (auto mf : mappingFilters) {
-    auto filterNode = mf->elemAs<detail::ScheduleTreeElemMappingFilter>();
+    auto filterNode = mf->elemAs<detail::ScheduleTreeElemMapping>();
     auto filter = filterNode->filter_.intersect(activeDomainPoints(root, mf));
     mapping = mapping.unite(filterNode->filter_);
   }

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -35,19 +35,6 @@ namespace polyhedral {
 namespace {
 
 /*
- * Is "id" a mapping of the type provided as template argument?
- */
-template <typename MappingType>
-bool isMappingIdType(const mapping::MappingId& id) {
-  for (size_t i = 0; i < MappingType::kMaxDim; ++i) {
-    if (id == MappingType::makeId(i)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/*
  * Is "tree" a mapping filter that maps identifiers of the type provided as
  * template argument?
  */
@@ -57,7 +44,7 @@ bool isMappingTo(const detail::ScheduleTree* tree) {
 
   if (auto filterNode = tree->elemAs<ScheduleTreeElemMappingFilter>()) {
     for (auto& kvp : filterNode->mapping) {
-      if (isMappingIdType<MappingType>(kvp.first)) {
+      if (kvp.first.is<MappingType>()) {
         return true;
       }
     }

--- a/tc/core/polyhedral/cuda/tighten_launch_bounds.cc
+++ b/tc/core/polyhedral/cuda/tighten_launch_bounds.cc
@@ -87,7 +87,7 @@ std::pair<tc::Grid, tc::Block> tightenLaunchBounds(
   auto root = scop.scheduleRoot();
   auto params = scop.context();
 
-  auto max = [root, params](const mapping::MappingId& id) -> size_t {
+  auto maxValue = [root, params](const mapping::MappingId& id) -> size_t {
     size_t sizetMax = std::numeric_limits<size_t>::max();
     size_t max = 0;
     size_t min = sizetMax;
@@ -128,12 +128,12 @@ std::pair<tc::Grid, tc::Block> tightenLaunchBounds(
   // Corner case: take the min with the current size to avoid degenerate
   // range in the unbounded case.
   return std::make_pair(
-      tc::Grid({std::min(max(BX), BX.mappingSize(grid)),
-                std::min(max(BY), BY.mappingSize(grid)),
-                std::min(max(BZ), BZ.mappingSize(grid))}),
-      tc::Block({std::min(max(TX), TX.mappingSize(block)),
-                 std::min(max(TY), TY.mappingSize(block)),
-                 std::min(max(TZ), TZ.mappingSize(block))}));
+      tc::Grid({std::min(maxValue(BX), BX.mappingSize(grid)),
+                std::min(maxValue(BY), BY.mappingSize(grid)),
+                std::min(maxValue(BZ), BZ.mappingSize(grid))}),
+      tc::Block({std::min(maxValue(TX), TX.mappingSize(block)),
+                 std::min(maxValue(TY), TY.mappingSize(block)),
+                 std::min(maxValue(TZ), TZ.mappingSize(block))}));
 }
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/cuda/tighten_launch_bounds.cc
+++ b/tc/core/polyhedral/cuda/tighten_launch_bounds.cc
@@ -74,10 +74,10 @@ size_t maxValue(const Scop& scop, const MappingIdType& id) {
   size_t sizetMax = std::numeric_limits<size_t>::max();
   size_t max = 0;
   size_t min = sizetMax;
-  auto filters = root->collect(root, ScheduleTreeType::MappingFilter);
+  auto filters = root->collect(root, ScheduleTreeType::Mapping);
   filters = functional::Filter(isMappingTo<MappingIdType>, filters);
   for (auto p : filters) {
-    auto mappingNode = p->elemAs<ScheduleTreeElemMappingFilter>();
+    auto mappingNode = p->elemAs<ScheduleTreeElemMapping>();
     auto active = activeDomainPoints(root, p).intersect_params(params);
     active = active.intersect(mappingNode->filter_);
     auto range = rangeOfMappingParameter(active.params(), id);

--- a/tc/core/polyhedral/exceptions.h
+++ b/tc/core/polyhedral/exceptions.h
@@ -25,8 +25,8 @@ struct EmptyFilterException : public std::runtime_error {
   explicit EmptyFilterException(const std::string& s) : std::runtime_error(s) {}
 };
 
-struct EmptyMappingFilterException : public std::runtime_error {
-  explicit EmptyMappingFilterException(const std::string& s)
+struct EmptyMappingException : public std::runtime_error {
+  explicit EmptyMappingException(const std::string& s)
       : std::runtime_error(s) {}
 };
 

--- a/tc/core/polyhedral/mapping_types.h
+++ b/tc/core/polyhedral/mapping_types.h
@@ -28,6 +28,17 @@ struct MappingId : public isl::id {
  public:
   MappingId(const MappingId& id) : isl::id(id), dim(id.dim) {}
 
+  // Is "id" a mapping of the type provided as template argument?
+  template <typename MappingType>
+  bool is() const {
+    for (size_t i = 0; i < MappingType::kMaxDim; ++i) {
+      if (*this == MappingType::makeId(i)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // For indexing into positional arrays
   // TODO: this should go away but this probably requires tinkering with
   // mapping_options.h::Grid/Block.

--- a/tc/core/polyhedral/memory_promotion.cc
+++ b/tc/core/polyhedral/memory_promotion.cc
@@ -115,7 +115,7 @@ std::unique_ptr<TensorReferenceGroup> TensorReferenceGroup::makeSingleton(
   return group;
 }
 
-isl::set TensorReferenceGroup::approximateFootprint() const {
+isl::map TensorReferenceGroup::approximateFootprint() const {
   auto scopedDomain = scopedAccesses().domain();
   auto space = approximation.box.get_space();
   auto accessed = isl::map::universe(space).intersect_domain(scopedDomain);
@@ -134,7 +134,7 @@ isl::set TensorReferenceGroup::approximateFootprint() const {
 
     accessed = accessed & partial;
   }
-  return accessed.range();
+  return accessed;
 }
 
 isl::multi_aff ScopedFootprint::lowerBounds() const {
@@ -517,9 +517,8 @@ ScheduleTree* insertCopiesUnder(
       isl::set::universe(promotionSpace.domain().unwrap().domain());
   auto arrayId =
       promotionSpace.domain().unwrap().get_tuple_id(isl::dim_type::out);
-  auto approximatedRead = scheduleUniverse.product(
-      group.approximateFootprint().set_tuple_id(arrayId).intersect(
-          tensorElements));
+  auto approximatedRead =
+      group.approximateFootprint().intersect_range(tensorElements).wrap();
   approximatedRead = approximatedRead.product(promotedFootprint);
   auto readExtension = extension.intersect_range(approximatedRead)
                            .set_tuple_id(isl::dim_type::out, readId);

--- a/tc/core/polyhedral/memory_promotion.h
+++ b/tc/core/polyhedral/memory_promotion.h
@@ -142,8 +142,8 @@ class TensorReferenceGroup {
   }
 
   // Rectangular overapproximation of the set of tensor elements accessed below
-  // the scoping point.
-  isl::set approximateFootprint() const;
+  // and relative to the scoping point.
+  isl::map approximateFootprint() const;
 
   isl::multi_aff promotion() const;
   isl::set promotedFootprint() const;

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -180,7 +180,7 @@ isl::schedule_node insert(isl::schedule_node node, const ScheduleTree* st) {
     node = node.insert_context(context->context_);
   } else if (auto filter = st->elemAs<ScheduleTreeElemFilter>()) {
     node = node.insert_filter(filter->filter_);
-  } else if (auto filter = st->elemAs<ScheduleTreeElemMappingFilter>()) {
+  } else if (auto filter = st->elemAs<ScheduleTreeElemMapping>()) {
     node = node.insert_filter(filter->filter_);
   } else if (
       st->elemAs<ScheduleTreeElemSet>() ||

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -196,7 +196,9 @@ isl::schedule_node insert(isl::schedule_node node, const ScheduleTree* st) {
     node = bandNode;
   } else if (auto context = st->elemAs<ScheduleTreeElemContext>()) {
     node = node.insert_context(context->context_);
-  } else if (auto filter = st->elemAsBase<ScheduleTreeElemFilter>()) {
+  } else if (auto filter = st->elemAs<ScheduleTreeElemFilter>()) {
+    node = node.insert_filter(filter->filter_);
+  } else if (auto filter = st->elemAs<ScheduleTreeElemMappingFilter>()) {
     node = node.insert_filter(filter->filter_);
   } else if (
       st->elemAs<ScheduleTreeElemSet>() ||

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -121,7 +121,7 @@ std::vector<size_t> findCorePositions(
 isl::schedule_node graftFromFilterSubtree(
     const ScheduleTree* st,
     isl::union_map extension) {
-  auto filter = st->elemAsBase<ScheduleTreeElemFilter>();
+  auto filter = st->elemAs<ScheduleTreeElemFilter>();
   TC_CHECK(filter);
   auto filterExtension = extension.intersect_range(filter->filter_);
   auto extensionNode = isl::schedule_node::from_extension(filterExtension);

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -32,24 +32,6 @@ namespace tc {
 namespace polyhedral {
 namespace detail {
 
-// static constexpr std::initializer_list need both definition and declaration
-constexpr std::initializer_list<detail::ScheduleTreeType>
-    ScheduleTreeElemExtension::NodeDerivedTypes;
-constexpr std::initializer_list<detail::ScheduleTreeType>
-    ScheduleTreeElemSequence::NodeDerivedTypes;
-constexpr std::initializer_list<detail::ScheduleTreeType>
-    ScheduleTreeElemSet::NodeDerivedTypes;
-constexpr std::initializer_list<detail::ScheduleTreeType>
-    ScheduleTreeElemDomain::NodeDerivedTypes;
-constexpr std::initializer_list<detail::ScheduleTreeType>
-    ScheduleTreeElemFilter::NodeDerivedTypes;
-constexpr std::initializer_list<detail::ScheduleTreeType>
-    ScheduleTreeElemMappingFilter::NodeDerivedTypes;
-constexpr std::initializer_list<detail::ScheduleTreeType>
-    ScheduleTreeElemBand::NodeDerivedTypes;
-constexpr std::initializer_list<detail::ScheduleTreeType>
-    ScheduleTreeElemContext::NodeDerivedTypes;
-
 namespace {
 
 isl::schedule_node insertChild(isl::schedule_node node, const ScheduleTree* st);

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -103,7 +103,7 @@ std::vector<size_t> findCorePositions(
   std::vector<size_t> positions;
   TC_CHECK(st->elemAs<ScheduleTreeElemSequence>());
   for (size_t i = 0; i < st->numChildren(); ++i) {
-    auto filter = st->child({i})->elemAsBase<ScheduleTreeElemFilter>();
+    auto filter = st->child({i})->elemAs<ScheduleTreeElemFilter>();
     TC_CHECK(filter);
     if (!filter->filter_.intersect(domain).is_empty()) {
       positions.emplace_back(i);

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -66,7 +66,7 @@ isl::schedule_node insertBranch(
     const std::vector<size_t>& pos) {
   auto filters = isl::union_set_list(node.get_ctx(), st->numChildren());
   for (size_t i = 0; i < pos.size(); ++i) {
-    auto filter = st->child({pos[i]})->elemAsBase<ScheduleTreeElemFilter>();
+    auto filter = st->child({pos[i]})->elemAs<ScheduleTreeElemFilter>();
     TC_CHECK(filter);
     filters = filters.add(filter->filter_);
   }

--- a/tc/core/polyhedral/schedule_print.cc
+++ b/tc/core/polyhedral/schedule_print.cc
@@ -122,7 +122,7 @@ std::ostream& operator<<(std::ostream& os, detail::ScheduleTreeType nt) {
     os << "extension";
   } else if (nt == detail::ScheduleTreeType::Filter) {
     os << "filter";
-  } else if (nt == detail::ScheduleTreeType::MappingFilter) {
+  } else if (nt == detail::ScheduleTreeType::Mapping) {
     os << "mapping_filter";
   } else if (nt == detail::ScheduleTreeType::Sequence) {
     os << "sequence";
@@ -200,7 +200,7 @@ std::ostream& ScheduleTreeElemFilter::write(std::ostream& os) const {
   return os;
 }
 
-std::ostream& ScheduleTreeElemMappingFilter::write(std::ostream& os) const {
+std::ostream& ScheduleTreeElemMapping::write(std::ostream& os) const {
   WS w;
   os << w.tab() << "mapping_filter(ids(";
   for (auto& kvp : mapping) {

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -55,7 +55,7 @@ isl::union_map extendSchedule(
       schedule =
           schedule.flat_range_product(isl::union_map::from(bandElem->mupa_));
     }
-  } else if (auto filterElem = node->elemAsBase<ScheduleTreeElemFilter>()) {
+  } else if (auto filterElem = node->elemAs<ScheduleTreeElemFilter>()) {
     schedule = schedule.intersect_domain(filterElem->filter_);
   } else if (auto extensionElem = node->elemAs<ScheduleTreeElemExtension>()) {
     // FIXME: we may need to restrict the range of reversed extension map to

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -102,7 +102,7 @@ isl::union_map partialSchedule(
 }
 
 namespace {
-// Get a set of domain elements that are active below
+// Get the set of domain elements that are active below
 // the given branch of nodes.
 //
 // Domain elements are introduced by the root domain node.  Filter nodes

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -105,8 +105,8 @@ namespace {
 /*
  * If "node" is any filter, then intersect "domain" with that filter.
  */
-isl::union_set applyAnyFilter(isl::union_set domain, const ScheduleTree* node) {
-  if (auto filterElem = node->elemAsBase<ScheduleTreeElemFilter>()) {
+isl::union_set applyFilter(isl::union_set domain, const ScheduleTree* node) {
+  if (auto filterElem = node->elemAs<ScheduleTreeElemFilter>()) {
     return domain.intersect(filterElem->filter_);
   }
   return domain;
@@ -155,7 +155,7 @@ isl::union_set collectDomain(
 isl::union_set activeDomainPointsHelper(
     const ScheduleTree* root,
     const vector<const ScheduleTree*>& nodes) {
-  return collectDomain(root, nodes, &applyAnyFilter);
+  return collectDomain(root, nodes, &applyFilter);
 }
 
 } // namespace

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -113,10 +113,10 @@ isl::union_set applyFilter(isl::union_set domain, const ScheduleTree* node) {
 }
 
 /*
- * If "node" is a mapping filter, then intersect "domain" with that filter.
+ * If "node" is a mapping, then intersect "domain" with its filter.
  */
 isl::union_set applyMapping(isl::union_set domain, const ScheduleTree* node) {
-  if (auto filterElem = node->elemAs<ScheduleTreeElemMappingFilter>()) {
+  if (auto filterElem = node->elemAs<ScheduleTreeElemMapping>()) {
     return domain.intersect(filterElem->filter_);
   }
   return domain;
@@ -736,7 +736,7 @@ namespace {
 void gist(ScheduleTree* tree, isl::union_set context) {
   if (auto bandElem = tree->elemAs<ScheduleTreeElemBand>()) {
     bandElem->mupa_ = bandElem->mupa_.gist(context);
-  } else if (auto filterElem = tree->elemAs<ScheduleTreeElemMappingFilter>()) {
+  } else if (auto filterElem = tree->elemAs<ScheduleTreeElemMapping>()) {
     filterElem->filter_ = filterElem->filter_.gist(context);
   } else if (auto filterElem = tree->elemAs<ScheduleTreeElemFilter>()) {
     filterElem->filter_ = filterElem->filter_.gist(context);
@@ -855,8 +855,8 @@ isl::multi_union_pw_aff extractDomainToIds(
   auto zero = isl::multi_val::zero(space);
   auto domainToIds = isl::multi_union_pw_aff(empty, zero);
 
-  for (auto mapping : tree->collect(tree, ScheduleTreeType::MappingFilter)) {
-    auto mappingNode = mapping->elemAs<ScheduleTreeElemMappingFilter>();
+  for (auto mapping : tree->collect(tree, ScheduleTreeType::Mapping)) {
+    auto mappingNode = mapping->elemAs<ScheduleTreeElemMapping>();
     auto list = isl::union_pw_aff_list(tree->ctx_, ids.size());
     for (auto id : ids) {
       if (mappingNode->mapping.count(id) == 0) {

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -112,6 +112,16 @@ isl::union_set applyAnyFilter(isl::union_set domain, const ScheduleTree* node) {
   return domain;
 }
 
+/*
+ * If "node" is a mapping filter, then intersect "domain" with that filter.
+ */
+isl::union_set applyMapping(isl::union_set domain, const ScheduleTree* node) {
+  if (auto filterElem = node->elemAs<ScheduleTreeElemMappingFilter>()) {
+    return domain.intersect(filterElem->filter_);
+  }
+  return domain;
+}
+
 // Get the set of domain elements that are active below
 // the given branch of nodes, filtered using "filter".
 //
@@ -149,6 +159,12 @@ isl::union_set activeDomainPointsHelper(
 }
 
 } // namespace
+
+isl::union_set prefixMappingFilter(
+    const ScheduleTree* root,
+    const ScheduleTree* node) {
+  return collectDomain(root, node->ancestors(root), &applyMapping);
+}
 
 isl::union_set activeDomainPoints(
     const ScheduleTree* root,

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -736,7 +736,9 @@ namespace {
 void gist(ScheduleTree* tree, isl::union_set context) {
   if (auto bandElem = tree->elemAs<ScheduleTreeElemBand>()) {
     bandElem->mupa_ = bandElem->mupa_.gist(context);
-  } else if (auto filterElem = tree->elemAsBase<ScheduleTreeElemFilter>()) {
+  } else if (auto filterElem = tree->elemAs<ScheduleTreeElemMappingFilter>()) {
+    filterElem->filter_ = filterElem->filter_.gist(context);
+  } else if (auto filterElem = tree->elemAs<ScheduleTreeElemFilter>()) {
     filterElem->filter_ = filterElem->filter_.gist(context);
     if (filterElem->filter_.is_empty()) {
       tree->detachChildren();
@@ -748,7 +750,7 @@ void gist(ScheduleTree* tree, isl::union_set context) {
   if (tree->elemAs<ScheduleTreeElemSequence>()) {
     for (auto i = tree->numChildren(); i > 0; --i) {
       auto child = tree->child({i - 1});
-      if (auto filterElem = child->elemAsBase<ScheduleTreeElemFilter>()) {
+      if (auto filterElem = child->elemAs<ScheduleTreeElemFilter>()) {
         if (filterElem->filter_.is_empty()) {
           tree->detachChild(i - 1);
         }

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -335,6 +335,12 @@ isl::union_set activeDomainPointsNoMappingNoExtension(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* tree);
 
+// Collect the outer block/thread identifier mappings
+// into a filter on the active domain elements.
+isl::union_set prefixMappingFilter(
+    const detail::ScheduleTree* root,
+    const detail::ScheduleTree* node);
+
 // Extract a mapping from the domain elements active at "tree" (in a tree
 // rooted at "root") to identifiers "ids", where all branches in "tree" are
 // assumed to have been mapped to these identifiers.  The result lives in a

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -326,15 +326,6 @@ isl::union_set activeDomainPointsBelow(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node);
 
-// Get the set of domain points active below the given node without including
-// the points introduced by extension nodes and without treating mapping nodes
-// as filters.  A point is considered active at a schedule node "tree" if it is
-// present in the "root" domain node and was not filtered away on the path from
-// "root" to "tree".  The root must be a domain element.
-isl::union_set activeDomainPointsNoMappingNoExtension(
-    const detail::ScheduleTree* root,
-    const detail::ScheduleTree* tree);
-
 // Collect the outer block/thread identifier mappings
 // into a filter on the active domain elements.
 isl::union_set prefixMappingFilter(

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -348,7 +348,7 @@ template <typename MappingType>
 bool isMappingTo(const detail::ScheduleTree* tree) {
   using namespace detail;
 
-  if (auto filterNode = tree->elemAs<ScheduleTreeElemMappingFilter>()) {
+  if (auto filterNode = tree->elemAs<ScheduleTreeElemMapping>()) {
     for (auto& kvp : filterNode->mapping) {
       if (kvp.first.is<MappingType>()) {
         return true;

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -345,6 +345,22 @@ isl::multi_union_pw_aff extractDomainToIds(
     const std::vector<mapping::MappingId>& ids,
     isl::id tupleId);
 
+// Is "tree" a mapping filter that maps identifiers of the type provided as
+// template argument?
+template <typename MappingType>
+bool isMappingTo(const detail::ScheduleTree* tree) {
+  using namespace detail;
+
+  if (auto filterNode = tree->elemAs<ScheduleTreeElemMappingFilter>()) {
+    for (auto& kvp : filterNode->mapping) {
+      if (kvp.first.is<MappingType>()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 } // namespace polyhedral
 } // namespace tc
 

--- a/tc/core/polyhedral/schedule_tree-inl.h
+++ b/tc/core/polyhedral/schedule_tree-inl.h
@@ -21,13 +21,13 @@ namespace tc {
 namespace polyhedral {
 namespace detail {
 template <typename MappingIdType>
-inline ScheduleTreeUPtr ScheduleTree::makeMappingFilter(
+inline ScheduleTreeUPtr ScheduleTree::makeMapping(
     const std::vector<MappingIdType>& mappedIds,
     isl::union_pw_aff_list mappedAffs,
     std::vector<ScheduleTreeUPtr>&& children) {
   TC_CHECK_EQ(mappedIds.size(), static_cast<size_t>(mappedAffs.n()))
       << "expected as many mapped ids as affs";
-  ScheduleTreeElemMappingFilter::Mapping mapping;
+  ScheduleTreeElemMapping::Mapping mapping;
   for (size_t i = 0, n = mappedAffs.n(); i < n; ++i) {
     mapping.emplace(mappedIds.at(i), mappedAffs.get(i));
   }
@@ -36,9 +36,9 @@ inline ScheduleTreeUPtr ScheduleTree::makeMappingFilter(
       << "some id is used more than once in the mapping";
   auto ctx = mappedIds[0].get_ctx();
   ScheduleTreeUPtr res(new ScheduleTree(ctx));
-  res->elem_ = std::unique_ptr<ScheduleTreeElemMappingFilter>(
-      new ScheduleTreeElemMappingFilter(mapping));
-  res->type_ = ScheduleTreeType::MappingFilter;
+  res->elem_ = std::unique_ptr<ScheduleTreeElemMapping>(
+      new ScheduleTreeElemMapping(mapping));
+  res->type_ = ScheduleTreeType::Mapping;
   res->appendChildren(std::move(children));
   return res;
 }

--- a/tc/core/polyhedral/schedule_tree.h
+++ b/tc/core/polyhedral/schedule_tree.h
@@ -449,34 +449,6 @@ struct ScheduleTree {
         const_cast<const ScheduleTreeElemBase*>(elem_.get()));
   }
 
-  // View elem_ as the specified type.
-  // Returns nullptr if neither this type, **nor any of the derived types**,
-  // are T.
-  // Inline impl for now, does not justify an extra -inl.h file
-  template <typename T>
-  T* elemAsBase() {
-    const ScheduleTree* t = this;
-    return const_cast<T*>(t->elemAsBase<const T>());
-  }
-  template <typename T>
-  const T* elemAsBase() const {
-    static_assert(
-        std::is_base_of<ScheduleTreeElemBase, T>::value,
-        "Must call with a class derived from ScheduleTreeElemBase");
-    // These T::NodeDerivedTypes are ugly, let's see if we can improve in the
-    // future but if we want dynamic typing and to avoid enumerations at each
-    // call site, which I claim we absolutely do, then we are not left with
-    // many options.
-    if (type_ != T::NodeType &&
-        std::find(
-            T::NodeDerivedTypes.begin(), T::NodeDerivedTypes.end(), type_) ==
-            T::NodeDerivedTypes.end()) {
-      return nullptr;
-    }
-    return static_cast<const T*>(
-        const_cast<const ScheduleTreeElemBase*>(elem_.get()));
-  }
-
   //
   // Data members
   //

--- a/tc/core/polyhedral/schedule_tree.h
+++ b/tc/core/polyhedral/schedule_tree.h
@@ -272,7 +272,7 @@ struct ScheduleTree {
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   template <typename MappingIdType>
-  static inline ScheduleTreeUPtr makeMappingFilter(
+  static inline ScheduleTreeUPtr makeMapping(
       const std::vector<MappingIdType>& mappedIds,
       isl::union_pw_aff_list mappedAffs,
       std::vector<ScheduleTreeUPtr>&& children = {});
@@ -312,12 +312,12 @@ struct ScheduleTree {
   }
 
   template <typename MappingIdType, typename... Args>
-  static inline ScheduleTreeUPtr makeMappingFilter(
+  static inline ScheduleTreeUPtr makeMapping(
       isl::union_set filter,
       const std::unordered_set<MappingIdType, typename MappingIdType::Hash>&
           mappingIds,
       Args&&... args) {
-    return makeMappingFilter(
+    return makeMapping(
         filter,
         mappingIds,
         vectorFromArgs<ScheduleTreeUPtr>(std::forward<Args>(args)...));

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -111,7 +111,7 @@ std::unique_ptr<ScheduleTreeElemBase> ScheduleTreeElemBase::make(
   ELEM_MAKE_CASE(ScheduleTreeElemDomain)
   ELEM_MAKE_CASE(ScheduleTreeElemExtension)
   ELEM_MAKE_CASE(ScheduleTreeElemFilter)
-  ELEM_MAKE_CASE(ScheduleTreeElemMappingFilter)
+  ELEM_MAKE_CASE(ScheduleTreeElemMapping)
   ELEM_MAKE_CASE(ScheduleTreeElemSequence)
   ELEM_MAKE_CASE(ScheduleTreeElemSet)
   ELEM_MAKE_CASE(ScheduleTreeElemThreadSpecificMarker)
@@ -256,8 +256,8 @@ bool ScheduleTreeElemFilter::operator==(
   return res;
 }
 
-bool ScheduleTreeElemMappingFilter::operator==(
-    const ScheduleTreeElemMappingFilter& other) const {
+bool ScheduleTreeElemMapping::operator==(
+    const ScheduleTreeElemMapping& other) const {
   auto res = filter_.is_equal(other.filter_);
   return res;
 }
@@ -288,7 +288,7 @@ bool elemEquals(
   ELEM_EQUALS_CASE(ScheduleTreeElemDomain)
   ELEM_EQUALS_CASE(ScheduleTreeElemExtension)
   ELEM_EQUALS_CASE(ScheduleTreeElemFilter)
-  ELEM_EQUALS_CASE(ScheduleTreeElemMappingFilter)
+  ELEM_EQUALS_CASE(ScheduleTreeElemMapping)
   ELEM_EQUALS_CASE(ScheduleTreeElemSequence)
   ELEM_EQUALS_CASE(ScheduleTreeElemSet)
   else {

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -139,7 +139,7 @@ struct ScheduleTreeElemFilter : public ScheduleTreeElemBase {
   }
 };
 
-struct ScheduleTreeElemMappingFilter : public ScheduleTreeElemFilter {
+struct ScheduleTreeElemMappingFilter : public ScheduleTreeElemBase {
   using Mapping = std::unordered_map<
       mapping::MappingId,
       isl::union_pw_aff,
@@ -150,9 +150,9 @@ struct ScheduleTreeElemMappingFilter : public ScheduleTreeElemFilter {
       detail::ScheduleTreeType::MappingFilter;
   ScheduleTreeElemMappingFilter() = delete;
   ScheduleTreeElemMappingFilter(const ScheduleTreeElemMappingFilter& eb)
-      : ScheduleTreeElemFilter(eb.filter_), mapping(eb.mapping) {}
+      : mapping(eb.mapping), filter_(eb.filter_) {}
   ScheduleTreeElemMappingFilter(const Mapping& mapping)
-      : ScheduleTreeElemFilter(isl::union_set()), mapping(mapping) {
+      : mapping(mapping), filter_(isl::union_set()) {
     TC_CHECK_GT(mapping.size(), 0u) << "empty mapping filter";
 
     auto domain = mapping.cbegin()->second.domain();
@@ -181,6 +181,8 @@ struct ScheduleTreeElemMappingFilter : public ScheduleTreeElemFilter {
 
   // Mapping from identifiers to affine functions on domain elements.
   const Mapping mapping;
+  // Assignment of the affine functions to the identifiers as parameters.
+  isl::union_set filter_;
 };
 
 struct ScheduleTreeElemSequence : public ScheduleTreeElemBase {

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -38,7 +38,7 @@ enum class ScheduleTreeType {
   Filter,
   Sequence,
   Set,
-  MappingFilter,
+  Mapping,
   ThreadSpecificMarker,
   Any,
 };
@@ -131,17 +131,17 @@ struct ScheduleTreeElemFilter : public ScheduleTreeElemBase {
   }
 };
 
-struct ScheduleTreeElemMappingFilter : public ScheduleTreeElemBase {
+struct ScheduleTreeElemMapping : public ScheduleTreeElemBase {
   using Mapping = std::unordered_map<
       mapping::MappingId,
       isl::union_pw_aff,
       typename mapping::MappingId::Hash>;
   static constexpr detail::ScheduleTreeType NodeType =
-      detail::ScheduleTreeType::MappingFilter;
-  ScheduleTreeElemMappingFilter() = delete;
-  ScheduleTreeElemMappingFilter(const ScheduleTreeElemMappingFilter& eb)
+      detail::ScheduleTreeType::Mapping;
+  ScheduleTreeElemMapping() = delete;
+  ScheduleTreeElemMapping(const ScheduleTreeElemMapping& eb)
       : mapping(eb.mapping), filter_(eb.filter_) {}
-  ScheduleTreeElemMappingFilter(const Mapping& mapping)
+  ScheduleTreeElemMapping(const Mapping& mapping)
       : mapping(mapping), filter_(isl::union_set()) {
     TC_CHECK_GT(mapping.size(), 0u) << "empty mapping filter";
 
@@ -159,9 +159,9 @@ struct ScheduleTreeElemMappingFilter : public ScheduleTreeElemBase {
       filter_ = filter_.intersect(upa.zero_union_set());
     }
   }
-  virtual ~ScheduleTreeElemMappingFilter() override {}
-  bool operator==(const ScheduleTreeElemMappingFilter& other) const;
-  bool operator!=(const ScheduleTreeElemMappingFilter& other) const {
+  virtual ~ScheduleTreeElemMapping() override {}
+  bool operator==(const ScheduleTreeElemMapping& other) const;
+  bool operator!=(const ScheduleTreeElemMapping& other) const {
     return !(*this == other);
   }
   virtual std::ostream& write(std::ostream& os) const override;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -56,8 +56,6 @@ struct ScheduleTreeElemBase {
 };
 
 struct ScheduleTreeElemContext : public ScheduleTreeElemBase {
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::None};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Context;
   isl::set context_;
@@ -77,8 +75,6 @@ struct ScheduleTreeElemContext : public ScheduleTreeElemBase {
 };
 
 struct ScheduleTreeElemDomain : public ScheduleTreeElemBase {
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::None};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Domain;
   isl::union_set domain_;
@@ -98,8 +94,6 @@ struct ScheduleTreeElemDomain : public ScheduleTreeElemBase {
 };
 
 struct ScheduleTreeElemExtension : public ScheduleTreeElemBase {
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::None};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Extension;
   isl::union_map extension_;
@@ -119,8 +113,6 @@ struct ScheduleTreeElemExtension : public ScheduleTreeElemBase {
 };
 
 struct ScheduleTreeElemFilter : public ScheduleTreeElemBase {
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::MappingFilter};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Filter;
   isl::union_set filter_;
@@ -144,8 +136,6 @@ struct ScheduleTreeElemMappingFilter : public ScheduleTreeElemBase {
       mapping::MappingId,
       isl::union_pw_aff,
       typename mapping::MappingId::Hash>;
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::None};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::MappingFilter;
   ScheduleTreeElemMappingFilter() = delete;
@@ -186,8 +176,6 @@ struct ScheduleTreeElemMappingFilter : public ScheduleTreeElemBase {
 };
 
 struct ScheduleTreeElemSequence : public ScheduleTreeElemBase {
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::None};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Sequence;
   explicit ScheduleTreeElemSequence() {}
@@ -204,8 +192,6 @@ struct ScheduleTreeElemSequence : public ScheduleTreeElemBase {
 };
 
 struct ScheduleTreeElemSet : public ScheduleTreeElemBase {
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::None};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Set;
   explicit ScheduleTreeElemSet() {}
@@ -226,8 +212,6 @@ struct ScheduleTreeElemBand : public ScheduleTreeElemBase {
   ScheduleTreeElemBand() = default;
 
  public:
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::None};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Band;
 
@@ -280,8 +264,6 @@ struct ScheduleTreeElemBand : public ScheduleTreeElemBase {
  * underneath the innermost band member mapped to threads.
  */
 struct ScheduleTreeElemThreadSpecificMarker : public ScheduleTreeElemBase {
-  static constexpr std::initializer_list<detail::ScheduleTreeType>
-      NodeDerivedTypes{detail::ScheduleTreeType::None};
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::ThreadSpecificMarker;
   explicit ScheduleTreeElemThreadSpecificMarker() {}

--- a/tc/core/polyhedral/schedule_tree_matcher-inl.h
+++ b/tc/core/polyhedral/schedule_tree_matcher-inl.h
@@ -111,10 +111,10 @@ template <typename... Args>
 inline ScheduleTreeMatcher mapping_filter(
     std::function<bool(isl::union_set)> propertyMatcher,
     Args... children) {
-  ScheduleTreeMatcher m(detail::ScheduleTreeType::MappingFilter, children...);
+  ScheduleTreeMatcher m(detail::ScheduleTreeType::Mapping, children...);
   m.propertyMatcher_ = [propertyMatcher](const detail::ScheduleTree* tree) {
     return propertyMatcher(
-        tree->elemAs<detail::ScheduleTreeElemMappingFilter>()->filter_);
+        tree->elemAs<detail::ScheduleTreeElemMapping>()->filter_);
   };
   return m;
 }
@@ -123,7 +123,7 @@ template <typename... Args>
 inline ScheduleTreeMatcher mapping_filter(
     std::function<bool(const detail::ScheduleTree* tree)> propertyMatcher,
     Args... children) {
-  ScheduleTreeMatcher m(detail::ScheduleTreeType::MappingFilter, children...);
+  ScheduleTreeMatcher m(detail::ScheduleTreeType::Mapping, children...);
   m.propertyMatcher_ = propertyMatcher;
   return m;
 }
@@ -138,11 +138,11 @@ template <
         std::is_same<First, ScheduleTreeMatcher>::value>::type>
 inline ScheduleTreeMatcher mapping_filter(First first, Args... children) {
   return ScheduleTreeMatcher(
-      detail::ScheduleTreeType::MappingFilter, first, children...);
+      detail::ScheduleTreeType::Mapping, first, children...);
 }
 
 inline ScheduleTreeMatcher mapping_filter() {
-  return ScheduleTreeMatcher(detail::ScheduleTreeType::MappingFilter);
+  return ScheduleTreeMatcher(detail::ScheduleTreeType::Mapping);
 }
 
 template <typename... Args>

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -142,7 +142,7 @@ void checkFiltersDisjointStatements(const ScheduleTree* root) {
     isl::union_set alreadyVisitedStmts;
     for (auto child : node->children()) {
       auto filterNode = child->elemAsBase<ScheduleTreeElemFilter>();
-      TC_CHECK(filterNode) << "expected children of seqence to be filters";
+      TC_CHECK(filterNode) << "expected children of sequence to be filters";
       auto filter = filterNode->filter_.universe();
       if (!alreadyVisitedStmts.get()) {
         alreadyVisitedStmts = filter;

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -141,7 +141,7 @@ void checkFiltersDisjointStatements(const ScheduleTree* root) {
        ScheduleTree::collect(root, detail::ScheduleTreeType::Sequence)) {
     isl::union_set alreadyVisitedStmts;
     for (auto child : node->children()) {
-      auto filterNode = child->elemAsBase<ScheduleTreeElemFilter>();
+      auto filterNode = child->elemAs<ScheduleTreeElemFilter>();
       TC_CHECK(filterNode) << "expected children of sequence to be filters";
       auto filter = filterNode->filter_.universe();
       if (!alreadyVisitedStmts.get()) {

--- a/tc/core/polyhedral/unroll.cc
+++ b/tc/core/polyhedral/unroll.cc
@@ -181,6 +181,7 @@ void markUnroll(
 
   auto unrollVal = isl::val(st->ctx_, unroll);
   auto prefix = prefixSchedule(root, st);
+  prefix = prefix.intersect_domain(prefixMappingFilter(root, st));
   boundInstancesAndMarkUnroll(st, prefix, unrollVal);
 }
 } // namespace polyhedral

--- a/test/cuda/test_tc_mapper_bugs.cc
+++ b/test/cuda/test_tc_mapper_bugs.cc
@@ -632,7 +632,7 @@ TEST_F(TMM_128_1024_1024, TooStrictPrecisionAfterTuner) {
   Check(options);
 }
 
-// This exercises a former MappingFilter leaf with a union_set of > 1 spaces
+// This exercises a former Mapping leaf with a union_set of > 1 spaces
 TEST_F(TMM_128_1024_1024, Tightening) {
   Init();
   auto options = tc::CudaMappingOptions::makeNaiveMappingOptions()

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -1099,7 +1099,7 @@ def fun(float(N) I) -> (O) {
  * Check that isolating the update statements does not introduce
  * an empty mapping filter.
  */
-TEST_F(PolyhedralMapperTest, EmptyMappingFilter) {
+TEST_F(PolyhedralMapperTest, EmptyMapping) {
   constexpr static auto tc = R"TC(
   def var_2D_1D(float(N, K) I, float(N) mean) -> (var)
   {


### PR DESCRIPTION
This type was introduced as filter because it is used as a filter
during AST generation.  However, AST generation is performed on
an isl schedule tree and a ScheduleTreeElemMappingFilter can easily
be converted to an isl filter independently of whether
ScheduleTreeElemMappingFilter itself is a filter.
Having ScheduleTreeElemMappingFilter as a subclass is causing
more problems than it is worth because every time a reference
is made to a filter, a careful consideration has to be made
whether or not to include the mapping filters.
Simply stop considering ScheduleTreeElemMappingFilter objects as filters
and deal with them specifically when needed.

This PR also contains some collateral clean-ups.