### PR TITLE
Tunable register promotion depth

### DIFF
--- a/tc/autotuner/autotuner-inl.h
+++ b/tc/autotuner/autotuner-inl.h
@@ -372,6 +372,8 @@ void setupTuningParameters(
   configuration.gridParams.setRange(range, "g");
   configuration.unrollFactor =
       RangeParameter(powers2(FLAGS_tuner_max_unroll_size), "unroll");
+  configuration.privateDepth =
+      RangeParameter({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "pdepth");
 }
 } // namespace
 

--- a/tc/autotuner/parameters.cc
+++ b/tc/autotuner/parameters.cc
@@ -239,6 +239,7 @@ void TuningConfiguration::applyToParameters(
   unrollCopyShared.apply(f);
   useReadOnlyCache.apply(f);
   matchLibraryCalls.apply(f);
+  privateDepth.apply(f);
 }
 
 bool TuningConfiguration::isValid() const {
@@ -273,6 +274,7 @@ std::vector<ParameterView> TuningConfiguration::collectParameters() {
   params.emplace_back(unrollCopyShared);
   params.emplace_back(useReadOnlyCache);
   params.emplace_back(matchLibraryCalls);
+  params.emplace_back(privateDepth);
 
   return params;
 }
@@ -303,6 +305,7 @@ void TuningConfiguration::fromCudaMappingOptions(
   usePrivateMemory.selectValue(options.proto().use_private_memory());
   unrollCopyShared.selectValue(options.proto().unroll_copy_shared());
   useReadOnlyCache.selectValue(options.proto().use_readonly_cache());
+  privateDepth.selectFromValue(options.proto().private_depth());
 }
 
 void TuningConfiguration::fromCpuMappingOptions(
@@ -331,6 +334,7 @@ void TuningConfiguration::applyToCudaMappingOptions(
   options.usePrivateMemory(usePrivateMemory.value());
   options.unrollCopyShared(unrollCopyShared.value());
   options.useReadOnlyCache(useReadOnlyCache.value());
+  options.privateDepth(privateDepth.value());
 }
 
 void TuningConfiguration::applyToCpuMappingOptions(

--- a/tc/autotuner/parameters.h
+++ b/tc/autotuner/parameters.h
@@ -190,6 +190,7 @@ class TuningConfiguration {
   BoolParameter unrollCopyShared;
   BoolParameter useReadOnlyCache;
   BoolParameter matchLibraryCalls;
+  RangeParameter privateDepth;
 
  private:
   std::vector<std::function<bool(const TuningConfiguration&)>> validators_;
@@ -227,6 +228,7 @@ class TuningParameterFixer {
   llvm::Optional<bool> unrollCopyShared;
   llvm::Optional<bool> useReadOnlyCache;
   llvm::Optional<bool> matchLibraryCalls;
+  llvm::Optional<uint32_t> privateDepth;
 
   friend class TuningConfiguration;
 };

--- a/tc/core/cuda/cuda_mapping_options.cc
+++ b/tc/core/cuda/cuda_mapping_options.cc
@@ -289,6 +289,11 @@ CudaMappingOptions& CudaMappingOptions::useReadOnlyCache(bool b) {
   return *this;
 }
 
+CudaMappingOptions& CudaMappingOptions::privateDepth(uint32_t depth) {
+  ownedProto_.set_private_depth(depth);
+  return *this;
+}
+
 CudaMappingOptions& CudaMappingOptions::mapToThreads(
     const std::string& commaSeparatedSizes) {
   auto sizes = parseCommaSeparatedIntegers<uint64_t>(commaSeparatedSizes);

--- a/tc/core/cuda/cuda_mapping_options.h
+++ b/tc/core/cuda/cuda_mapping_options.h
@@ -195,6 +195,7 @@ class CudaMappingOptions {
   CudaMappingOptions& maxSharedMemory(uint64_t size);
   CudaMappingOptions& unrollCopyShared(bool b);
   CudaMappingOptions& useReadOnlyCache(bool b);
+  CudaMappingOptions& privateDepth(uint32_t depth);
   ///@}
 
   /// Static constructors for predefined strategies.

--- a/tc/core/cuda/cuda_mapping_options_cpp_printer.cc
+++ b/tc/core/cuda/cuda_mapping_options_cpp_printer.cc
@@ -38,6 +38,7 @@ CudaMappingOptionsCppPrinter& operator<<(
     prn.printValueOption(
         "maxSharedMemory", cudaOptions.proto().max_shared_memory());
   }
+  prn.printValueOption("privateDepth", cudaOptions.proto().private_depth());
   prn.endStmt();
   return prn;
 }

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -1068,7 +1068,7 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
 
   // 9. Promote to registers below the loops mapped to threads.
   if (cudaOptions.proto().use_private_memory()) {
-    promoteToRegistersBelowThreads(*mappedScop, -1ull);
+    promoteToRegistersAtDepth(*mappedScop, cudaOptions.proto().private_depth());
   }
 
   LOG_IF(INFO, FLAGS_debug_tc_mapper)

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -437,13 +437,19 @@ bool isPromotableToRegistersBelow(
 }
 
 /*
- * Starting from the root, find bands where depth is reached.  Using
+ * Starting from the root, find bands where depth is reached.  If zero depth is
+ * requested, insert a zero-dimensional band node below the root (or the
+ * context node if present) and return it.  Otherwise, use
  * DFSPreorder to make sure order is specified and consistent for tests.
  */
 std::vector<detail::ScheduleTree*> bandsContainingScheduleDepth(
     detail::ScheduleTree* root,
     size_t depth) {
   using namespace tc::polyhedral::detail;
+
+  if (depth == 0) {
+    return {insertTopLevelEmptyBand(root)};
+  }
 
   auto bands =
       ScheduleTree::collectDFSPreorder(root, detail::ScheduleTreeType::Band);

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -779,16 +779,5 @@ void promoteToRegistersAtDepth(MappedScop& mscop, size_t depth) {
   }
 }
 
-// Promote at the positions of the thread specific markers.
-void promoteToRegistersBelowThreads(MappedScop& mscop, size_t nRegisters) {
-  auto& scop = mscop.scop();
-  auto root = scop.scheduleRoot();
-  auto markers = findThreadSpecificMarkers(root);
-
-  for (auto marker : markers) {
-    promoteToRegistersBelow(mscop, marker);
-  }
-}
-
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -44,7 +44,6 @@ void promoteGreedilyAtDepth(
 
 void promoteToRegistersBelow(MappedScop& mscop, detail::ScheduleTree* scope);
 
-void promoteToRegistersBelowThreads(MappedScop& scop, std::size_t nRegisters);
 void promoteToRegistersAtDepth(MappedScop& scop, std::size_t depth);
 
 } // namespace polyhedral

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -45,5 +45,7 @@ void promoteGreedilyAtDepth(
 void promoteToRegistersBelow(MappedScop& mscop, detail::ScheduleTree* scope);
 
 void promoteToRegistersBelowThreads(MappedScop& scop, std::size_t nRegisters);
+void promoteToRegistersAtDepth(MappedScop& scop, std::size_t depth);
+
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/schedule_transforms.cc
+++ b/tc/core/polyhedral/schedule_transforms.cc
@@ -275,6 +275,15 @@ ScheduleTree* bandScale(ScheduleTree* tree, const vector<size_t>& scales) {
   return tree;
 }
 
+ScheduleTree* insertTopLevelEmptyBand(ScheduleTree* root) {
+  auto node = root;
+  if (node->numChildren() > 0 &&
+      node->child({0})->elemAs<detail::ScheduleTreeElemContext>()) {
+    node = node->child({0});
+  }
+  return insertNodeBelow(node, ScheduleTree::makeEmptyBand(root));
+}
+
 void updateTopLevelContext(detail::ScheduleTree* root, isl::set context) {
   if (!matchOne(tc::polyhedral::domain(tc::polyhedral::context(any())), root)) {
     root->appendChild(ScheduleTree::makeContext(

--- a/tc/core/polyhedral/schedule_transforms.h
+++ b/tc/core/polyhedral/schedule_transforms.h
@@ -102,6 +102,10 @@ detail::ScheduleTree* bandScale(
     detail::ScheduleTree* tree,
     const std::vector<size_t>& scales);
 
+// Insert an empty band node below "root" or below the only child of "root" if
+// the child is a context node.
+detail::ScheduleTree* insertTopLevelEmptyBand(detail::ScheduleTree* root);
+
 // Update the top-level context node by intersecting it with "context".  The
 // top-level context node must be located directly under the root of the tree.
 // If there is no such node, insert one with universe context first.

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -243,6 +243,13 @@ void Scop::insertSyncsAroundCopies(ScheduleTree* tree) {
       ++i;
     }
   }
+  insertSyncsAroundSeqChildren(seqNode);
+}
+
+void Scop::insertSyncsAroundSeqChildren(detail::ScheduleTree* seqNode) {
+  TC_CHECK(seqNode->elemAs<detail::ScheduleTreeElemSequence>())
+      << "expected sequence node, got\n"
+      << *seqNode;
   insertSync(seqNode, 0);
   insertSync(seqNode, seqNode->numChildren());
 }

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -461,6 +461,10 @@ struct Scop {
   //
   void insertSyncsAroundCopies(detail::ScheduleTree* tree);
 
+  // Given a sequence node, insert synchronizations before its first child node
+  // and after its last child node.
+  void insertSyncsAroundSeqChildren(detail::ScheduleTree* tree);
+
  private:
   // Compute a schedule satisfying the given schedule constraints and
   // taking into account the scheduler options.

--- a/tc/proto/mapping_options.proto
+++ b/tc/proto/mapping_options.proto
@@ -70,6 +70,8 @@ message CudaMappingOptionsProto {
   optional uint64 max_shared_memory = 7;
   // Use the readonly cache (i.e. emit __ldg loads)
   required bool use_readonly_cache = 8;
+  // Depth of promotion to private memory, ignored if use_private_memory is false.
+  optional uint32 private_depth = 9;
 }
 
 message CpuMappingOptionsProto {

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -531,8 +531,12 @@ def fun(float(N,K) A, float(K,M) B, float(N,M) C) -> (O) {
 };
 
 TEST_F(MatMulBias, RegisterPromotion) {
+  // Scheduled code has three loops, tile all, the top band gets mapped to 2
+  // blocks, the bottom band gets mapped to 2 threads, test promotion before
+  // thread-mapped loops, that is at depth 3 + 2 = 5.
   auto mappingOptions = CudaMappingOptions::makeNaiveMappingOptions()
                             .tile(32, 32, 32)
+                            .privateDepth(5)
                             .useSharedMemory(false)
                             .usePrivateMemory(true);
 


### PR DESCRIPTION
Introduce a tunable parameter for the privateDepth option introduced by
the previous commit.  Choose initial depth within the range [0, 6] since
we rarely have deeper loops.

Closes #491 
Closes #468 