### PR TITLE
Tunable shared promotion depth

### DIFF
--- a/tc/autotuner/autotuner-inl.h
+++ b/tc/autotuner/autotuner-inl.h
@@ -374,6 +374,8 @@ void setupTuningParameters(
       RangeParameter(powers2(FLAGS_tuner_max_unroll_size), "unroll");
   configuration.privateDepth =
       RangeParameter({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "pdepth");
+  configuration.sharedDepth =
+      RangeParameter({0, 1, 2, 3, 4, 5, 6, 7}, "sdepth");
 }
 } // namespace
 

--- a/tc/autotuner/parameters.cc
+++ b/tc/autotuner/parameters.cc
@@ -240,6 +240,7 @@ void TuningConfiguration::applyToParameters(
   useReadOnlyCache.apply(f);
   matchLibraryCalls.apply(f);
   privateDepth.apply(f);
+  sharedDepth.apply(f);
 }
 
 bool TuningConfiguration::isValid() const {
@@ -275,6 +276,7 @@ std::vector<ParameterView> TuningConfiguration::collectParameters() {
   params.emplace_back(useReadOnlyCache);
   params.emplace_back(matchLibraryCalls);
   params.emplace_back(privateDepth);
+  params.emplace_back(sharedDepth);
 
   return params;
 }
@@ -306,6 +308,7 @@ void TuningConfiguration::fromCudaMappingOptions(
   unrollCopyShared.selectValue(options.proto().unroll_copy_shared());
   useReadOnlyCache.selectValue(options.proto().use_readonly_cache());
   privateDepth.selectFromValue(options.proto().private_depth());
+  sharedDepth.selectFromValue(options.proto().shared_depth());
 }
 
 void TuningConfiguration::fromCpuMappingOptions(
@@ -335,6 +338,7 @@ void TuningConfiguration::applyToCudaMappingOptions(
   options.unrollCopyShared(unrollCopyShared.value());
   options.useReadOnlyCache(useReadOnlyCache.value());
   options.privateDepth(privateDepth.value());
+  options.sharedDepth(sharedDepth.value());
 }
 
 void TuningConfiguration::applyToCpuMappingOptions(

--- a/tc/autotuner/parameters.h
+++ b/tc/autotuner/parameters.h
@@ -191,6 +191,7 @@ class TuningConfiguration {
   BoolParameter useReadOnlyCache;
   BoolParameter matchLibraryCalls;
   RangeParameter privateDepth;
+  RangeParameter sharedDepth;
 
  private:
   std::vector<std::function<bool(const TuningConfiguration&)>> validators_;
@@ -229,6 +230,7 @@ class TuningParameterFixer {
   llvm::Optional<bool> useReadOnlyCache;
   llvm::Optional<bool> matchLibraryCalls;
   llvm::Optional<uint32_t> privateDepth;
+  llvm::Optional<uint32_t> sharedDepth;
 
   friend class TuningConfiguration;
 };

--- a/tc/core/cuda/cuda_mapping_options.cc
+++ b/tc/core/cuda/cuda_mapping_options.cc
@@ -294,6 +294,11 @@ CudaMappingOptions& CudaMappingOptions::privateDepth(uint32_t depth) {
   return *this;
 }
 
+CudaMappingOptions& CudaMappingOptions::sharedDepth(uint32_t depth) {
+  ownedProto_.set_shared_depth(depth);
+  return *this;
+}
+
 CudaMappingOptions& CudaMappingOptions::mapToThreads(
     const std::string& commaSeparatedSizes) {
   auto sizes = parseCommaSeparatedIntegers<uint64_t>(commaSeparatedSizes);

--- a/tc/core/cuda/cuda_mapping_options.h
+++ b/tc/core/cuda/cuda_mapping_options.h
@@ -196,6 +196,7 @@ class CudaMappingOptions {
   CudaMappingOptions& unrollCopyShared(bool b);
   CudaMappingOptions& useReadOnlyCache(bool b);
   CudaMappingOptions& privateDepth(uint32_t depth);
+  CudaMappingOptions& sharedDepth(uint32_t depth);
   ///@}
 
   /// Static constructors for predefined strategies.

--- a/tc/core/cuda/cuda_mapping_options_cpp_printer.cc
+++ b/tc/core/cuda/cuda_mapping_options_cpp_printer.cc
@@ -39,6 +39,7 @@ CudaMappingOptionsCppPrinter& operator<<(
         "maxSharedMemory", cudaOptions.proto().max_shared_memory());
   }
   prn.printValueOption("privateDepth", cudaOptions.proto().private_depth());
+  prn.printValueOption("sharedDepth", cudaOptions.proto().shared_depth());
   prn.endStmt();
   return prn;
 }

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -1079,7 +1079,7 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
               !generic.proto.has_unroll())
           << "requested to unroll copies to shared memory without providing the unroll size";
 
-      promoteGreedilyAtDepth(
+      promoteToSharedAtDepth(
           *mappedScop,
           std::min(band->nOuterCoincident(), mappedScop->numBlocks.view.size()),
           sharedMemorySize,

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -1049,8 +1049,9 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
   LOG_IF(INFO, FLAGS_debug_tc_mapper) << "After mapping to blocks:" << std::endl
                                       << *mappedScop->schedule();
 
-  // 8. Promote to shared memory below the loops mapped to blocks.
-  // This may split the outer band, so find the new outer band after promotion.
+  // 8. Promote to shared memory.
+  // If shared promotion depth is specified in the mapping options, use the
+  // specified value.  Otherwise, promote below the loops mapped to blocks.
   if (cudaOptions.proto().use_shared_memory()) {
     size_t sharedMemorySize = cudaOptions.proto().has_max_shared_memory()
         ? cudaOptions.proto().max_shared_memory()
@@ -1069,19 +1070,21 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
       sharedMemorySize -= reductionMemoryRequirement;
     }
 
-    auto band = outerBand->as<ScheduleTreeBand>();
-    LOG_IF(WARNING, FLAGS_debug_tc_mapper && band->nMember() == 0)
-        << "Aborting memory promotion because outer band has 0 members (NYI)";
-    if (band->nMember() > 0 && sharedMemorySize > 0) {
+    if (sharedMemorySize > 0) {
       LOG_IF(
           WARNING,
           cudaOptions.proto().unroll_copy_shared() &&
               !generic.proto.has_unroll())
           << "requested to unroll copies to shared memory without providing the unroll size";
 
+      auto depth = cudaOptions.proto().has_shared_depth()
+          ? cudaOptions.proto().shared_depth()
+          : std::min(
+                outerBand->as<ScheduleTreeBand>()->nOuterCoincident(),
+                mappedScop->numBlocks.view.size());
       promoteToSharedAtDepth(
           *mappedScop,
-          std::min(band->nOuterCoincident(), mappedScop->numBlocks.view.size()),
+          depth,
           sharedMemorySize,
           cudaOptions.proto().unroll_copy_shared() &&
               generic.proto.has_unroll());

--- a/tc/core/polyhedral/cuda/mapped_scop.cc
+++ b/tc/core/polyhedral/cuda/mapped_scop.cc
@@ -1088,13 +1088,6 @@ std::unique_ptr<MappedScop> MappedScop::makeWithOuterBlockInnerThreadStrategy(
           sharedMemorySize,
           cudaOptions.proto().unroll_copy_shared() &&
               generic.proto.has_unroll());
-
-      auto bands = ScheduleTree::collectDFSPreorder(
-          scop->scheduleRoot(), ScheduleTreeType::Band);
-      if (bands.size() == 0) { // Sanity check.
-        throw NoBandsException("no bands after promotion");
-      }
-      outerBand = bands[0];
     }
   }
 

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -440,9 +440,10 @@ void promoteToSharedBelow(
     size_t& remainingMemory) {
   auto root = scop.scheduleRoot();
   auto partialSched = partialSchedule(root, bandNode);
+  auto mapping = collectMappingsTo<mapping::BlockId>(scop);
 
   auto groupMap = TensorReferenceGroup::accessedWithin(
-      partialSched, scop.reads, scop.writes);
+      partialSched.intersect_domain(mapping), scop.reads, scop.writes);
   // Pure affine schedule without (mapping) filters.
   auto partialSchedMupa = partialScheduleMupa(root, bandNode);
 

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -551,11 +551,7 @@ void promoteToSharedBelow(
  * Only promote if the tensor elements referenced by the group are reused or
  * accessed in a non-coalesced way.
  */
-void promoteToSharedGreedy(
-    Scop& scop,
-    const Block& block,
-    size_t depth,
-    size_t maxMemory) {
+void promoteToSharedGreedy(Scop& scop, size_t depth, size_t maxMemory) {
   using namespace tc::polyhedral::detail;
 
   if (depth == 0) {
@@ -597,8 +593,7 @@ void promoteGreedilyAtDepth(
     size_t sharedMemorySize,
     bool unrollCopies) {
   // 1. Promote using heuristic.
-  promoteToSharedGreedy(
-      mscop.scop(), mscop.numThreads, depth, sharedMemorySize);
+  promoteToSharedGreedy(mscop.scop(), depth, sharedMemorySize);
 
   // 2. Map copies to shared, state by copy
   mapCopiesToThreads(mscop, unrollCopies);

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -264,8 +264,7 @@ const detail::ScheduleTree* findThreadMappingAncestor(
 bool promotionImprovesCoalescing(
     const detail::ScheduleTree* root,
     const detail::ScheduleTree* node,
-    const TensorReferenceGroup& group,
-    isl::union_map schedule) {
+    const TensorReferenceGroup& group) {
   auto originalAccesses = group.originalAccesses();
 
   auto tensorDim = group.approximation.dim();
@@ -279,6 +278,7 @@ bool promotionImprovesCoalescing(
     auto depth = marker->scheduleDepth(root);
     auto activePoints = activeDomainPoints(root, mapping);
     auto localAccesses = originalAccesses.intersect_domain(activePoints);
+    auto schedule = prefixSchedule(root, marker);
     auto scheduledAccesses = localAccesses.apply_domain(schedule);
     for (auto access : isl::UnionAsVector<isl::union_map>(scheduledAccesses)) {
       auto scheduleSpace = access.get_space().domain();
@@ -486,14 +486,11 @@ std::vector<detail::ScheduleTree*> bandsSplitAfterDepth(
 /*
  * Promote to shared memory in "scop" below the node "bandNode".  Use at most
  * "remainingMemory" bytes, and update the variable to reflect the amount of
- * available shared memory remaining after promotion.  "fullSched" is the union
- * of schedules at leaves of the schedule tree, expected to be computed by
- * "fullSchedule".
+ * available shared memory remaining after promotion.
  */
 void promoteToSharedBelow(
     Scop& scop,
     detail::ScheduleTree* bandNode,
-    isl::union_map fullSched,
     size_t& remainingMemory) {
   auto root = scop.scheduleRoot();
   auto partialSched = partialSchedule(root, bandNode);
@@ -560,7 +557,7 @@ void promoteToSharedBelow(
       // Do not promote if the group features no reuse and is accessed in a
       // coalesced way.
       if (!hasReuseWithin(*group, partialSchedMupa) &&
-          !promotionImprovesCoalescing(root, bandNode, *group, fullSched)) {
+          !promotionImprovesCoalescing(root, bandNode, *group)) {
         continue;
       }
 
@@ -607,19 +604,14 @@ void promoteToSharedGreedy(
   auto bands = bandsContainingScheduleDepth(root, depth);
   bands = bandsSplitAfterDepth(bands, root, depth);
 
-  // 2. Compute full schedule without mapping filters.  The filters would make
-  // it impossible to test for coalescing by incrementing a member of a band as
-  // only the values divisible by grid or block size pass through the filter.
-  auto fullSched = fullSchedule(root);
-
-  // 3. For each band that ends at "depth", take decisions about promotion
+  // 2. For each band that ends at "depth", take decisions about promotion
   // immediately below it in the tree.  In particular, promote if the
   // approximated footprint fits into the remaining memory, and the reference
   // group either features reuse or is accessed in a non-coalesced way, or
   // both.
   size_t remainingMemory = maxMemory;
   for (auto bandNode : bands) {
-    promoteToSharedBelow(scop, bandNode, fullSched, remainingMemory);
+    promoteToSharedBelow(scop, bandNode, remainingMemory);
   }
 }
 

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -584,10 +584,6 @@ void promoteToSharedAtDepth(
     bool unrollCopies) {
   using namespace tc::polyhedral::detail;
 
-  if (depth == 0) {
-    throw promotion::PromotionNYI("promotion before any band");
-  }
-
   auto& scop = mscop.scop();
   auto root = scop.scheduleRoot();
 

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -439,6 +439,14 @@ void promoteToSharedBelow(
     detail::ScheduleTree* node,
     size_t& remainingMemory) {
   auto root = scop.scheduleRoot();
+
+  // Children of a sequence/set band must be filters, but promotion would
+  // insert an extension node.
+  if (node->as<detail::ScheduleTreeSequence>() ||
+      node->as<detail::ScheduleTreeSet>()) {
+    throw promotion::IncorrectScope("cannot promote below a sequence/set node");
+  }
+
   auto partialSched = partialSchedule(root, node);
   auto mapping = collectMappingsTo<mapping::BlockId>(scop);
 

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -525,11 +525,10 @@ void promoteToSharedGreedy(
   // both.
   size_t remainingMemory = maxMemory;
   for (auto bandNode : bands) {
-    auto activePoints = activeDomainPoints(root, bandNode);
     auto partialSched = partialSchedule(root, bandNode);
 
-    auto groupMap = TensorReferenceGroup::accessedWithin(
-        partialSched.intersect_domain(activePoints), scop.body);
+    auto groupMap =
+        TensorReferenceGroup::accessedWithin(partialSched, scop.body);
     // Pure affine schedule without (mapping) filters.
     auto partialSchedMupa = partialScheduleMupa(root, bandNode);
 

--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.h
@@ -33,10 +33,7 @@ class ScheduleTree;
 // promote to shared memory at "depth" until "sharedMemorySize" is used.
 // Map copies between global and shared memory to threads and unroll those
 // copies if "unrollCopies" is set, using the options in "mscop".
-// "threadIdxXScheduleDepthState" contains the schedule depth at which the
-// computation was mapped to thread x and is used to check whether the global
-// memory is accessed in a coalesced way.
-void promoteGreedilyAtDepth(
+void promoteToSharedAtDepth(
     MappedScop& scop,
     std::size_t depth,
     std::size_t sharedMemorySize,

--- a/tc/proto/mapping_options.proto
+++ b/tc/proto/mapping_options.proto
@@ -72,6 +72,8 @@ message CudaMappingOptionsProto {
   required bool use_readonly_cache = 8;
   // Depth of promotion to private memory, ignored if use_private_memory is false.
   optional uint32 private_depth = 9;
+  // Depth of promotion to shared memory, ignored if use_shared_memory is false.
+  optional uint32 shared_depth = 10;
 }
 
 message CpuMappingOptionsProto {

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -392,7 +392,7 @@ def fun(float(N, M) A) -> (B, C) {
       size_t maxSharedMemory) {
     auto mscop = prepareScop(
         tc, {{"N", problemSize1}, {"M", problemSize2}}, {tileSize1, tileSize2});
-    promoteGreedilyAtDepth(*mscop, depth, maxSharedMemory, false);
+    promoteToSharedAtDepth(*mscop, depth, maxSharedMemory, false);
     return mscop;
   }
 };

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -437,12 +437,14 @@ TEST_F(MapperMemoryPromotionRAW, fitAtOuterDepths) {
       << "expected one reference group to be promoted";
 }
 
-TEST_F(MapperMemoryPromotionRAW, throwIfCopiesBelowThreads) {
-  EXPECT_THROW(
-      makeWithSharedGreedy(42, 40, 64, 64, 3, 8192), promotion::IncorrectScope);
+TEST_F(MapperMemoryPromotionRAW, noSharedPromotionBelowThreads) {
+  auto mscop1 = makeWithSharedGreedy(42, 40, 64, 64, 3, 8192);
+  EXPECT_EQ(mscop1->scop().promotedDecls().size(), 0u)
+      << "expected no promotion below threads";
 
-  EXPECT_THROW(
-      makeWithSharedGreedy(42, 40, 64, 64, 4, 8192), promotion::IncorrectScope);
+  auto mscop2 = makeWithSharedGreedy(42, 40, 64, 64, 4, 8192);
+  EXPECT_EQ(mscop2->scop().promotedDecls().size(), 0u)
+      << "expected no promotion below threads";
 }
 
 class MatMulBias : public TestMapper {

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -439,12 +439,10 @@ TEST_F(MapperMemoryPromotionRAW, fitAtOuterDepths) {
 
 TEST_F(MapperMemoryPromotionRAW, throwIfCopiesBelowThreads) {
   EXPECT_THROW(
-      makeWithSharedGreedy(42, 40, 64, 64, 3, 8192),
-      promotion::PromotionBelowThreadsException);
+      makeWithSharedGreedy(42, 40, 64, 64, 3, 8192), promotion::IncorrectScope);
 
   EXPECT_THROW(
-      makeWithSharedGreedy(42, 40, 64, 64, 4, 8192),
-      promotion::PromotionBelowThreadsException);
+      makeWithSharedGreedy(42, 40, 64, 64, 4, 8192), promotion::IncorrectScope);
 }
 
 class MatMulBias : public TestMapper {


### PR DESCRIPTION
This PR is similar to #521 but for shared memory.  Most of the infrastructure functions have been already available since #521 and #489.

The `shared_depth` field is marked as optional in protobuf.  If it is not provided, the old behavior (promote below the loops mapped to blocks) is triggered, ensuring backwards-compatibility.  In particular, this PR should not affect performance of benchmarks with pre-tuned options that do not specify `shared_depth`.

A full tuning run is very welcome.

Closes #492 