### PR TITLE
Suppress warnings

### DIFF
--- a/tc/autotuner/autotuner-inl.h
+++ b/tc/autotuner/autotuner-inl.h
@@ -394,6 +394,9 @@ Autotuner<Backend, SearchStrategy>::tune(
   TC_CHECK_EQ(tcEntryPointMap.count(tcEntryPoint), 1u)
       << "Error looking up " << tcEntryPoint;
 
+  // Do not emit lang warnings during the tuning run
+  auto enableWarnings = lang::EnableWarnings(false);
+
   // Initialize a model configuration
   TuningConfiguration modelConfiguration;
   TC_CHECK_GE(inputs.size(), 1u);

--- a/tc/autotuner/utils.cc
+++ b/tc/autotuner/utils.cc
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <sstream>
 
+#include <glog/logging.h>
 #include <glog/stl_logging.h>
 
 #include "tc/core/flags.h"

--- a/tc/core/CMakeLists.txt
+++ b/tc/core/CMakeLists.txt
@@ -39,7 +39,6 @@ target_include_directories(tc_core PUBLIC ${LLVM_INCLUDE_DIRS})
 target_link_libraries(
   tc_core
 
-  gflags
   glog
 
   ${HALIDE_LIBRARIES}
@@ -50,6 +49,7 @@ target_link_libraries(
   tc_version
   tc_proto
 )
+set_target_properties(tc_lang PROPERTIES LINK_INTERFACE_LIBRARIES gflags)
 if (WITH_BINDINGS)
   add_dependencies(tc_core generate_isl_cpp_h)
 endif()

--- a/tc/core/flags.h
+++ b/tc/core/flags.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 
 namespace tc {
 

--- a/tc/lang/CMakeLists.txt
+++ b/tc/lang/CMakeLists.txt
@@ -4,10 +4,13 @@ add_library(
 
   SHARED
 
+  error_report.cc
   parser.cc
   lexer.cc
   tc_format.cc
 )
+
+set_target_properties(tc_lang PROPERTIES LINK_INTERFACE_LIBRARIES gflags)
 
 install(
   TARGETS

--- a/tc/lang/error_report.cc
+++ b/tc/lang/error_report.cc
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2018, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/lang/error_report.h"
+
+namespace lang {
+
+DEFINE_bool(warn, true, "Emit compilation warnings");
+
+} // namespace lang

--- a/tc/lang/error_report.h
+++ b/tc/lang/error_report.h
@@ -17,7 +17,11 @@
 
 #include "tc/lang/tree.h"
 
+#include <gflags/gflags.h>
+
 namespace lang {
+
+DECLARE_bool(warn);
 
 struct ErrorReport : public std::exception {
   ErrorReport(const ErrorReport& e)
@@ -43,6 +47,9 @@ struct ErrorReport : public std::exception {
 };
 
 inline void warn(const ErrorReport& err) {
+  if (!FLAGS_warn) {
+    return;
+  }
   std::cerr << "WARNING: " << err.what();
 }
 

--- a/tc/lang/error_report.h
+++ b/tc/lang/error_report.h
@@ -64,4 +64,20 @@ const ErrorReport& operator<<(const ErrorReport& e, const T& t) {
     throw ::lang::ErrorReport(ctx)                                         \
         << __FILE__ << ":" << __LINE__ << ": assertion failed: " << #cond; \
   }
+
+// Simple RAII to change the value of FLAGS_warn locally to a scope.
+class EnableWarnings {
+ public:
+  explicit EnableWarnings(bool warn) {
+    previous_ = FLAGS_warn;
+    FLAGS_warn = warn;
+  }
+
+  ~EnableWarnings() {
+    FLAGS_warn = previous_;
+  }
+
+ private:
+  bool previous_;
+};
 } // namespace lang


### PR DESCRIPTION
Currently, warnings are always emitted during TC parsing (including
bounds inference) and semantic analysis.  This leads to megabytes of
identical warning spew in the autotuning, among other problems.
Introduce a boolean flag, "--warn", to control whether warnings should
be printed.  Set it to true by default.

This required to introduce the gflags support into the tc_lang library:
previously, flags were concentrated in the tc_core library, but tc_core
links to tc_lang making it impossible to put lang-specific flags in
core.  As a consequence, tc_lang now links gflags statically and
tc_core does not.  This is not a problem since tc_core links tc_lang
anyway.

Introducing even more gflags is not the best solution, since they are essentially global variables, but it is a pragmatic one.  We want to consider introducing some `CompilerOptions` structure that would include `MappingOptions` and other configurations (for example, kernel timeout), but I expect the discussion to take long.

Closes #456 