### PR TITLE
Update to support upcoming Caffe2 API

### DIFF
--- a/python/examples/min_distance.py
+++ b/python/examples/min_distance.py
@@ -103,9 +103,9 @@ luts_t = torch.from_numpy(luts).cuda()
 
 T = tc.define(lang, tc.make_naive_options_factory())
 S = T.reduce_codes(luts_t, codes_t)
-V = T.min_2d(S.view((D, N / D)))
+V = T.min_2d(S.view((D, N // D)))
 v = T.min_1d(V)
-MinIdx = T.argmin_2d(S.view((D, N / D)), v)
+MinIdx = T.argmin_2d(S.view((D, N // D)), v)
 min_idx = T.argmin_1d(S, MinIdx)
 print("minval: {} minidx: {}".format(v, min_idx))
 
@@ -159,8 +159,8 @@ def argmin_1d(float(K, N) S, int32(K, D) MinIdx2) -> (MinIdx) {
 
 T = tc.define(lang, tc.make_naive_options_factory())
 S = T.reduce_codes(luts_t, codes_t)
-V2 = T.min_2d(S.view((K, D, N / D)))
+V2 = T.min_2d(S.view((K, D, N // D)))
 V = T.min_1d(V2)
-MinIdx2 = T.argmin_2d(S.view((K, D, N / D)), V)
+MinIdx2 = T.argmin_2d(S.view((K, D, N // D)), V)
 MinIdx = T.argmin_1d(S, MinIdx2)
 print("minval: {} minidx: {}".format(V, MinIdx))

--- a/test/caffe2/test_harness-inl.h
+++ b/test/caffe2/test_harness-inl.h
@@ -69,8 +69,11 @@ caffe2::Tensor<typename Caffe2Backend::Context> GetNamedTensor(
     caffe2::Workspace& ws,
     const std::string& name) {
   // Resolved dynamically
-  return caffe2::Tensor<typename Caffe2Backend::Context>(
-      ws.GetBlob(name)->Get<typename Caffe2Backend::Tensor>());
+  auto& t = ws.GetBlob(name)->Get<typename Caffe2Backend::Tensor>();
+  caffe2::Tensor<typename Caffe2Backend::Context> res;
+  res.ResizeLike(t);
+  res.ShareData(t);
+  return res;
 }
 
 // helper functions to construct an ATen tensor from a caffe2 tensor


### PR DESCRIPTION
This PR introduces a few modifications to sync OSS to fbcode.
1. Caffe2 API killed the copy constructor and now requires an explicit cast.
2. improper division operator was used in `min_distance.py`
3. updating the caffe2 test and benchmark to the new API

Tested internally with the latest API.