### PR TITLE
Adding functions in Python binder

### DIFF
--- a/tensor_comprehensions/__init__.py
+++ b/tensor_comprehensions/__init__.py
@@ -35,6 +35,7 @@ from tensor_comprehensions.tclib import MappingOptionsCache
 from tensor_comprehensions.tclib import TcExecutor
 from tensor_comprehensions.tclib import Tuner
 from tensor_comprehensions.tclib import TunerConfig
+from tensor_comprehensions.tclib import shared_memory_size
 
 import tensor_comprehensions.tclib as tclib
 
@@ -608,6 +609,7 @@ __all__ = [
     'compile',
     'autotune',
     'autotune_and_compile',
+    'shared_memory_size',
     # Classes exposed by the tclib
     'CompilationCache',
     'MappingOptions',

--- a/tensor_comprehensions/__init__.py
+++ b/tensor_comprehensions/__init__.py
@@ -35,7 +35,6 @@ from tensor_comprehensions.tclib import MappingOptionsCache
 from tensor_comprehensions.tclib import TcExecutor
 from tensor_comprehensions.tclib import Tuner
 from tensor_comprehensions.tclib import TunerConfig
-from tensor_comprehensions.tclib import shared_memory_size
 
 import tensor_comprehensions.tclib as tclib
 
@@ -609,7 +608,6 @@ __all__ = [
     'compile',
     'autotune',
     'autotune_and_compile',
-    'shared_memory_size',
     # Classes exposed by the tclib
     'CompilationCache',
     'MappingOptions',

--- a/tensor_comprehensions/pybinds/tclib.cc
+++ b/tensor_comprehensions/pybinds/tclib.cc
@@ -273,6 +273,23 @@ struct TcExecutor {
       return tupleOrTensor(convertToPyObjects(atOutputs));
     }
   }
+
+  size_t profile(const py::tuple& inputs, const py::tuple& outputs) {
+    if (outputs.size() > 0) {
+      auto atOutputs = getATenTensors(outputs);
+      auto atInputs = getATenTensors(inputs);
+      tc::ProfilingInfo profinfo =
+          tc::aten::profile(*executor, atInputs, atOutputs);
+      return profinfo.kernelRuntime.toMicroSeconds();
+    } else {
+      auto atInputs = getATenTensors(inputs);
+      auto atOutputs = tc::aten::prepareOutputs(tc, entryPoint, atInputs);
+      tc::ProfilingInfo profinfo =
+          tc::aten::profile(*executor, atInputs, atOutputs);
+      return profinfo.kernelRuntime.toMicroSeconds();
+    }
+  }
+
   std::string tc;
   std::string entryPoint;
   std::unique_ptr<tc::CudaBackend::ExecutorType> executor;
@@ -465,7 +482,13 @@ PYBIND11_MODULE(tclib, m) {
           "unchecked_run",
           &TcExecutor::uncheckedRun,
           py::arg("inputs"),
+          py::arg("outputs") = py::tuple())
+      .def(
+          "profile_kernel",
+          &TcExecutor::profile,
+          py::arg("inputs"),
           py::arg("outputs") = py::tuple());
+
   m.def(
       "compile",
       [](const std::string& tc,

--- a/tensor_comprehensions/pybinds/tclib.cc
+++ b/tensor_comprehensions/pybinds/tclib.cc
@@ -30,6 +30,7 @@
 #include "tc/aten/aten_autotuner.h"
 #include "tc/autotuner/genetic_search.h"
 #include "tc/autotuner/options_cache.h"
+#include "tc/core/cuda/cuda.h"
 #include "tc/core/cuda/cuda_backend.h"
 #include "tc/core/cuda/cuda_tc_executor.h"
 #include "tc/core/flags.h"
@@ -445,6 +446,11 @@ PYBIND11_MODULE(tclib, m) {
       res.push_back(kvp.first);
     }
     return res;
+  });
+
+  // Get GPU shared memory size
+  m.def("shared_memory_size", []() {
+    return CudaGPUInfo::GPUInfo().SharedMemorySize();
   });
 
   // Low-level stateful API compile returns an executor on which run and


### PR DESCRIPTION
Adding two functions:
- tc.shared_memory_size()
- TcExecutor.profile_kernel(input, (output))