### PR TITLE
More pybind functions

### DIFF
--- a/tensor_comprehensions/pybinds/tclib.cc
+++ b/tensor_comprehensions/pybinds/tclib.cc
@@ -30,6 +30,7 @@
 #include "tc/aten/aten_autotuner.h"
 #include "tc/autotuner/genetic_search.h"
 #include "tc/autotuner/options_cache.h"
+#include "tc/core/cuda/cuda.h"
 #include "tc/core/cuda/cuda_backend.h"
 #include "tc/core/cuda/cuda_tc_executor.h"
 #include "tc/core/flags.h"
@@ -445,6 +446,11 @@ PYBIND11_MODULE(tclib, m) {
       res.push_back(kvp.first);
     }
     return res;
+  });
+
+  // Get GPU shared memory size
+  m.def("shared_memory_size", []() {
+    return CudaGPUInfo::GPUInfo().SharedMemorySize();
   });
 
   // Low-level stateful API compile returns an executor on which run and


### PR DESCRIPTION
Add two functions to the python binder: 

tclib.shared_memory_size(), TcExecutor.profile_kernel(input, (outputs))
- first one for accessing the size of GPU shared memory (useful for one option setting)
- second one for getting the same execution time as in C++