### PR TITLE
ScheduleTree*: hide constructors

### DIFF
--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -237,7 +237,7 @@ namespace {
 
 std::unique_ptr<ScheduleTreeBand> fromIslScheduleNodeBand(
     isl::schedule_node_band b) {
-  auto res = ScheduleTreeBand::fromMultiUnionPwAff(b.get_partial_schedule());
+  auto res = ScheduleTreeBand::make(b.get_partial_schedule());
   res->permutable_ = b.get_permutable();
   for (size_t i = 0; i < b.n_member(); ++i) {
     res->coincident_[i] = b.member_get_coincident(i);

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -276,7 +276,7 @@ std::unique_ptr<ScheduleTree> elemFromIslScheduleNode(isl::schedule_node node) {
   } else if (node.isa<isl::schedule_node_sequence>()) {
     return ScheduleTreeSequence::make(ctx);
   } else if (node.isa<isl::schedule_node_set>()) {
-    return std::unique_ptr<ScheduleTreeSet>(new ScheduleTreeSet(ctx));
+    return ScheduleTreeSet::make(ctx);
   }
   LOG(FATAL) << "NYI: ScheduleTree from type: "
              << isl_schedule_node_get_type(node.get());

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -263,7 +263,7 @@ std::unique_ptr<ScheduleTree> elemFromIslScheduleNode(isl::schedule_node node) {
     return ScheduleTreeExtension::make(e);
   } else if (auto filter = node.as<isl::schedule_node_filter>()) {
     auto f = filter.get_filter();
-    return std::unique_ptr<ScheduleTreeFilter>(new ScheduleTreeFilter(f));
+    return ScheduleTreeFilter::make(f);
   } else if (auto guard = node.as<isl::schedule_node_guard>()) {
     LOG(FATAL) << "guard nodes not supported";
     return nullptr;

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -251,7 +251,7 @@ std::unique_ptr<ScheduleTree> elemFromIslScheduleNode(isl::schedule_node node) {
     return fromIslScheduleNodeBand(band);
   } else if (auto context = node.as<isl::schedule_node_context>()) {
     auto c = context.get_context();
-    return std::unique_ptr<ScheduleTreeContext>(new ScheduleTreeContext(c));
+    return ScheduleTreeContext::make(c);
   } else if (auto domain = node.as<isl::schedule_node_domain>()) {
     auto c = domain.get_domain();
     return std::unique_ptr<ScheduleTreeDomain>(new ScheduleTreeDomain(c));

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -274,7 +274,7 @@ std::unique_ptr<ScheduleTree> elemFromIslScheduleNode(isl::schedule_node node) {
     LOG(FATAL) << "ScheduleTree::make called on explicit leaf";
     return nullptr;
   } else if (node.isa<isl::schedule_node_sequence>()) {
-    return std::unique_ptr<ScheduleTreeSequence>(new ScheduleTreeSequence(ctx));
+    return ScheduleTreeSequence::make(ctx);
   } else if (node.isa<isl::schedule_node_set>()) {
     return std::unique_ptr<ScheduleTreeSet>(new ScheduleTreeSet(ctx));
   }

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -237,12 +237,14 @@ namespace {
 
 std::unique_ptr<ScheduleTreeBand> fromIslScheduleNodeBand(
     isl::schedule_node_band b) {
-  auto res = ScheduleTreeBand::make(b.get_partial_schedule());
-  res->permutable_ = b.get_permutable();
-  for (size_t i = 0; i < b.n_member(); ++i) {
-    res->coincident_[i] = b.member_get_coincident(i);
+  auto n = b.n_member();
+  std::vector<bool> coincident(n, false);
+  std::vector<bool> unroll(n, false);
+  for (size_t i = 0; i < n; ++i) {
+    coincident[i] = b.member_get_coincident(i);
   }
-  return res;
+  return ScheduleTreeBand::make(
+      b.get_partial_schedule(), b.get_permutable(), coincident, unroll);
 }
 
 std::unique_ptr<ScheduleTree> elemFromIslScheduleNode(isl::schedule_node node) {

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -260,7 +260,7 @@ std::unique_ptr<ScheduleTree> elemFromIslScheduleNode(isl::schedule_node node) {
     return nullptr;
   } else if (auto extension = node.as<isl::schedule_node_extension>()) {
     auto e = extension.get_extension();
-    return std::unique_ptr<ScheduleTreeExtension>(new ScheduleTreeExtension(e));
+    return ScheduleTreeExtension::make(e);
   } else if (auto filter = node.as<isl::schedule_node_filter>()) {
     auto f = filter.get_filter();
     return std::unique_ptr<ScheduleTreeFilter>(new ScheduleTreeFilter(f));

--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -254,7 +254,7 @@ std::unique_ptr<ScheduleTree> elemFromIslScheduleNode(isl::schedule_node node) {
     return ScheduleTreeContext::make(c);
   } else if (auto domain = node.as<isl::schedule_node_domain>()) {
     auto c = domain.get_domain();
-    return std::unique_ptr<ScheduleTreeDomain>(new ScheduleTreeDomain(c));
+    return ScheduleTreeDomain::make(c);
   } else if (auto expansion = node.as<isl::schedule_node_expansion>()) {
     LOG(FATAL) << "expansion nodes not supported";
     return nullptr;

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -140,7 +140,7 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   ELEM_MAKE_CASE(ScheduleTreeBand)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeContext)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeDomain)
-  ELEM_MAKE_CASE(ScheduleTreeExtension)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeExtension)
   ELEM_MAKE_CASE(ScheduleTreeFilter)
   ELEM_MAKE_CASE(ScheduleTreeMapping)
   ELEM_MAKE_CASE(ScheduleTreeSequence)

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -129,11 +129,16 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
     return std::unique_ptr<CLASS>(new CLASS(static_cast<const CLASS&>(st))); \
   }
 
+#define ELEM_MAKE_CASE_CSTR(CLASS)                      \
+  else if (st.type_ == CLASS::NodeType) {               \
+    return CLASS::make(static_cast<const CLASS*>(&st)); \
+  }
+
   if (st.type_ == detail::ScheduleTreeType::None) {
     LOG(FATAL) << "Hit Error node!";
   }
   ELEM_MAKE_CASE(ScheduleTreeBand)
-  ELEM_MAKE_CASE(ScheduleTreeContext)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeContext)
   ELEM_MAKE_CASE(ScheduleTreeDomain)
   ELEM_MAKE_CASE(ScheduleTreeExtension)
   ELEM_MAKE_CASE(ScheduleTreeFilter)
@@ -142,6 +147,7 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   ELEM_MAKE_CASE(ScheduleTreeSet)
   ELEM_MAKE_CASE(ScheduleTreeThreadSpecificMarker)
 
+#undef ELEM_MAKE_CASE_CSTR
 #undef ELEM_MAKE_CASE
 
   LOG(FATAL) << "NYI: ScheduleTree from type: " << static_cast<int>(st.type_);

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -142,7 +142,7 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   ELEM_MAKE_CASE_CSTR(ScheduleTreeDomain)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeExtension)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeFilter)
-  ELEM_MAKE_CASE(ScheduleTreeMapping)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeMapping)
   ELEM_MAKE_CASE(ScheduleTreeSequence)
   ELEM_MAKE_CASE(ScheduleTreeSet)
   ELEM_MAKE_CASE(ScheduleTreeThreadSpecificMarker)

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -272,10 +272,7 @@ std::unique_ptr<ScheduleTree> ScheduleTree::makeMappingUnsafe(
   TC_CHECK_EQ(mappedIds.size(), mapping.size())
       << "some id is used more than once in the mapping";
   auto ctx = mappedIds[0].get_ctx();
-  auto res =
-      std::unique_ptr<ScheduleTree>(new ScheduleTreeMapping(ctx, mapping));
-  res->appendChildren(std::move(children));
-  return res;
+  return ScheduleTreeMapping::make(ctx, mapping, std::move(children));
 }
 
 std::unique_ptr<ScheduleTree> ScheduleTree::makeExtension(

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -226,7 +226,7 @@ size_t ScheduleTree::scheduleDepth(const ScheduleTree* relativeRoot) const {
 std::unique_ptr<ScheduleTree> ScheduleTree::makeBand(
     isl::multi_union_pw_aff mupa,
     std::vector<ScheduleTreeUPtr>&& children) {
-  auto res = ScheduleTreeBand::fromMultiUnionPwAff(mupa);
+  auto res = ScheduleTreeBand::make(mupa);
   res->appendChildren(std::move(children));
   return res;
 }

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -122,31 +122,6 @@ vector<ScheduleTree*> ancestorsInSubTree(
   }
   return res;
 }
-
-static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
-#define ELEM_MAKE_CASE_CSTR(CLASS)                      \
-  else if (st.type_ == CLASS::NodeType) {               \
-    return CLASS::make(static_cast<const CLASS*>(&st)); \
-  }
-
-  if (st.type_ == detail::ScheduleTreeType::None) {
-    LOG(FATAL) << "Hit Error node!";
-  }
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeBand)
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeContext)
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeDomain)
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeExtension)
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeFilter)
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeMapping)
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeSequence)
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeSet)
-  ELEM_MAKE_CASE_CSTR(ScheduleTreeThreadSpecificMarker)
-
-#undef ELEM_MAKE_CASE_CSTR
-
-  LOG(FATAL) << "NYI: ScheduleTree from type: " << static_cast<int>(st.type_);
-  return nullptr;
-}
 } // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -163,7 +138,7 @@ ScheduleTree::ScheduleTree(const ScheduleTree& st)
 }
 
 ScheduleTreeUPtr ScheduleTree::makeScheduleTree(const ScheduleTree& tree) {
-  return makeElem(tree);
+  return tree.clone();
 }
 
 ScheduleTree* ScheduleTree::child(const vector<size_t>& positions) {

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -139,7 +139,7 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   }
   ELEM_MAKE_CASE(ScheduleTreeBand)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeContext)
-  ELEM_MAKE_CASE(ScheduleTreeDomain)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeDomain)
   ELEM_MAKE_CASE(ScheduleTreeExtension)
   ELEM_MAKE_CASE(ScheduleTreeFilter)
   ELEM_MAKE_CASE(ScheduleTreeMapping)

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -255,9 +255,7 @@ std::unique_ptr<ScheduleTree> ScheduleTree::makeContext(
 std::unique_ptr<ScheduleTree> ScheduleTree::makeFilter(
     isl::union_set filter,
     std::vector<ScheduleTreeUPtr>&& children) {
-  auto res = std::unique_ptr<ScheduleTree>(new ScheduleTreeFilter(filter));
-  res->appendChildren(std::move(children));
-  return res;
+  return ScheduleTreeFilter::make(filter, std::move(children));
 }
 
 std::unique_ptr<ScheduleTree> ScheduleTree::makeMappingUnsafe(

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -144,7 +144,7 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   ELEM_MAKE_CASE_CSTR(ScheduleTreeFilter)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeMapping)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeSequence)
-  ELEM_MAKE_CASE(ScheduleTreeSet)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeSet)
   ELEM_MAKE_CASE(ScheduleTreeThreadSpecificMarker)
 
 #undef ELEM_MAKE_CASE_CSTR

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -143,7 +143,7 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   ELEM_MAKE_CASE_CSTR(ScheduleTreeExtension)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeFilter)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeMapping)
-  ELEM_MAKE_CASE(ScheduleTreeSequence)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeSequence)
   ELEM_MAKE_CASE(ScheduleTreeSet)
   ELEM_MAKE_CASE(ScheduleTreeThreadSpecificMarker)
 

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -251,9 +251,7 @@ std::unique_ptr<ScheduleTree> ScheduleTree::makeDomain(
 std::unique_ptr<ScheduleTree> ScheduleTree::makeContext(
     isl::set context,
     std::vector<ScheduleTreeUPtr>&& children) {
-  auto res = std::unique_ptr<ScheduleTree>(new ScheduleTreeContext(context));
-  res->appendChildren(std::move(children));
-  return res;
+  return ScheduleTreeContext::make(context, std::move(children));
 }
 
 std::unique_ptr<ScheduleTree> ScheduleTree::makeFilter(

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -284,10 +284,7 @@ std::unique_ptr<ScheduleTree> ScheduleTree::makeExtension(
 std::unique_ptr<ScheduleTree> ScheduleTree::makeThreadSpecificMarker(
     isl::ctx ctx,
     std::vector<ScheduleTreeUPtr>&& children) {
-  auto res =
-      std::unique_ptr<ScheduleTree>(new ScheduleTreeThreadSpecificMarker(ctx));
-  res->appendChildren(std::move(children));
-  return res;
+  return ScheduleTreeThreadSpecificMarker::make(ctx, std::move(children));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -137,7 +137,7 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   if (st.type_ == detail::ScheduleTreeType::None) {
     LOG(FATAL) << "Hit Error node!";
   }
-  ELEM_MAKE_CASE(ScheduleTreeBand)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeBand)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeContext)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeDomain)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeExtension)

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -124,11 +124,6 @@ vector<ScheduleTree*> ancestorsInSubTree(
 }
 
 static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
-#define ELEM_MAKE_CASE(CLASS)                                                \
-  else if (st.type_ == CLASS::NodeType) {                                    \
-    return std::unique_ptr<CLASS>(new CLASS(static_cast<const CLASS&>(st))); \
-  }
-
 #define ELEM_MAKE_CASE_CSTR(CLASS)                      \
   else if (st.type_ == CLASS::NodeType) {               \
     return CLASS::make(static_cast<const CLASS*>(&st)); \
@@ -145,10 +140,9 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   ELEM_MAKE_CASE_CSTR(ScheduleTreeMapping)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeSequence)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeSet)
-  ELEM_MAKE_CASE(ScheduleTreeThreadSpecificMarker)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeThreadSpecificMarker)
 
 #undef ELEM_MAKE_CASE_CSTR
-#undef ELEM_MAKE_CASE
 
   LOG(FATAL) << "NYI: ScheduleTree from type: " << static_cast<int>(st.type_);
   return nullptr;

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -243,9 +243,7 @@ ScheduleTreeUPtr ScheduleTree::makeEmptyBand(const ScheduleTree* root) {
 std::unique_ptr<ScheduleTree> ScheduleTree::makeDomain(
     isl::union_set domain,
     std::vector<ScheduleTreeUPtr>&& children) {
-  auto res = std::unique_ptr<ScheduleTree>(new ScheduleTreeDomain(domain));
-  res->appendChildren(std::move(children));
-  return res;
+  return ScheduleTreeDomain::make(domain, std::move(children));
 }
 
 std::unique_ptr<ScheduleTree> ScheduleTree::makeContext(

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -283,10 +283,7 @@ std::unique_ptr<ScheduleTree> ScheduleTree::makeMappingUnsafe(
 std::unique_ptr<ScheduleTree> ScheduleTree::makeExtension(
     isl::union_map extension,
     std::vector<ScheduleTreeUPtr>&& children) {
-  auto res =
-      std::unique_ptr<ScheduleTree>(new ScheduleTreeExtension(extension));
-  res->appendChildren(std::move(children));
-  return res;
+  return ScheduleTreeExtension::make(extension, std::move(children));
 }
 
 std::unique_ptr<ScheduleTree> ScheduleTree::makeThreadSpecificMarker(

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -226,8 +226,10 @@ size_t ScheduleTree::scheduleDepth(const ScheduleTree* relativeRoot) const {
 std::unique_ptr<ScheduleTree> ScheduleTree::makeBand(
     isl::multi_union_pw_aff mupa,
     std::vector<ScheduleTreeUPtr>&& children) {
-  auto res = ScheduleTreeBand::make(mupa);
-  res->appendChildren(std::move(children));
+  std::vector<bool> coincident(mupa.size(), false);
+  std::vector<bool> unroll(mupa.size(), false);
+  auto res = ScheduleTreeBand::make(
+      mupa, false, coincident, unroll, std::move(children));
   return res;
 }
 

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -141,7 +141,7 @@ static std::unique_ptr<ScheduleTree> makeElem(const ScheduleTree& st) {
   ELEM_MAKE_CASE_CSTR(ScheduleTreeContext)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeDomain)
   ELEM_MAKE_CASE_CSTR(ScheduleTreeExtension)
-  ELEM_MAKE_CASE(ScheduleTreeFilter)
+  ELEM_MAKE_CASE_CSTR(ScheduleTreeFilter)
   ELEM_MAKE_CASE(ScheduleTreeMapping)
   ELEM_MAKE_CASE(ScheduleTreeSequence)
   ELEM_MAKE_CASE(ScheduleTreeSet)

--- a/tc/core/polyhedral/schedule_tree.h
+++ b/tc/core/polyhedral/schedule_tree.h
@@ -401,11 +401,11 @@ struct ScheduleTree {
         "Arguments must be rvalue references to ScheduleTreeUPtr");
 
     auto ctx = arg->ctx_;
-    auto res = new T(ctx);
-    flattenSequenceOrSet(res);
+    auto res = T::make(ctx);
+    flattenSequenceOrSet(res.get());
     res->appendChildren(
         vectorFromArgs(std::forward<Arg>(arg), std::forward<Args>(args)...));
-    return ScheduleTreeUPtr(res);
+    return res;
   }
 
   // Make a (deep) copy of "tree".

--- a/tc/core/polyhedral/schedule_tree.h
+++ b/tc/core/polyhedral/schedule_tree.h
@@ -465,6 +465,10 @@ struct ScheduleTree {
   // Note that this function does _not_ output the child trees.
   virtual std::ostream& write(std::ostream& os) const = 0;
 
+  // Clone the current node.
+  // Note that this function does _not_ clone the child trees.
+  virtual ScheduleTreeUPtr clone() const = 0;
+
   //
   // Data members
   //

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -64,6 +64,14 @@ std::unique_ptr<ScheduleTreeDomain> ScheduleTreeDomain::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeDomain> ScheduleTreeDomain::make(
+    const ScheduleTreeDomain* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeDomain>(new ScheduleTreeDomain(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeExtension> ScheduleTreeExtension::make(
     isl::union_map extension,
     std::vector<ScheduleTreeUPtr>&& children) {

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -158,6 +158,15 @@ std::unique_ptr<ScheduleTreeSequence> ScheduleTreeSequence::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeSequence> ScheduleTreeSequence::make(
+    const ScheduleTreeSequence* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res =
+      std::unique_ptr<ScheduleTreeSequence>(new ScheduleTreeSequence(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeSet> ScheduleTreeSet::make(
     isl::ctx ctx,
     std::vector<ScheduleTreeUPtr>&& children) {

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -186,6 +186,16 @@ isl::multi_union_pw_aff ScheduleTreeBand::memberRange(size_t first, size_t n)
   return isl::multi_union_pw_aff(space, list);
 }
 
+std::unique_ptr<ScheduleTreeThreadSpecificMarker>
+ScheduleTreeThreadSpecificMarker::make(
+    isl::ctx ctx,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeThreadSpecificMarker>(
+      new ScheduleTreeThreadSpecificMarker(ctx));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 bool ScheduleTreeBand::operator==(const ScheduleTreeBand& other) const {
   if (permutable_ != other.permutable_) {
     return false;

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -46,6 +46,15 @@ std::unique_ptr<ScheduleTreeContext> ScheduleTreeContext::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeContext> ScheduleTreeContext::make(
+    const ScheduleTreeContext* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res =
+      std::unique_ptr<ScheduleTreeContext>(new ScheduleTreeContext(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeDomain> ScheduleTreeDomain::make(
     isl::union_set domain,
     std::vector<ScheduleTreeUPtr>&& children) {

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -271,6 +271,16 @@ ScheduleTreeThreadSpecificMarker::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeThreadSpecificMarker>
+ScheduleTreeThreadSpecificMarker::make(
+    const ScheduleTreeThreadSpecificMarker* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeThreadSpecificMarker>(
+      new ScheduleTreeThreadSpecificMarker(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 bool ScheduleTreeBand::operator==(const ScheduleTreeBand& other) const {
   if (permutable_ != other.permutable_) {
     return false;

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -37,6 +37,15 @@ namespace tc {
 namespace polyhedral {
 namespace detail {
 
+std::unique_ptr<ScheduleTreeContext> ScheduleTreeContext::make(
+    isl::set context,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res =
+      std::unique_ptr<ScheduleTreeContext>(new ScheduleTreeContext(context));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::fromMultiUnionPwAff(
     isl::multi_union_pw_aff mupa) {
   isl::ctx ctx(mupa.get_ctx());

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -99,6 +99,14 @@ std::unique_ptr<ScheduleTreeFilter> ScheduleTreeFilter::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeFilter> ScheduleTreeFilter::make(
+    const ScheduleTreeFilter* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeFilter>(new ScheduleTreeFilter(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeMapping> ScheduleTreeMapping::make(
     isl::ctx ctx,
     const ScheduleTreeMapping::Mapping& mapping,

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -106,6 +106,15 @@ ScheduleTreeMapping::ScheduleTreeMapping(
   }
 }
 
+std::unique_ptr<ScheduleTreeSequence> ScheduleTreeSequence::make(
+    isl::ctx ctx,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res =
+      std::unique_ptr<ScheduleTreeSequence>(new ScheduleTreeSequence(ctx));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::fromMultiUnionPwAff(
     isl::multi_union_pw_aff mupa) {
   isl::ctx ctx(mupa.get_ctx());

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -117,6 +117,15 @@ std::unique_ptr<ScheduleTreeMapping> ScheduleTreeMapping::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeMapping> ScheduleTreeMapping::make(
+    const ScheduleTreeMapping* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res =
+      std::unique_ptr<ScheduleTreeMapping>(new ScheduleTreeMapping(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 ScheduleTreeMapping::ScheduleTreeMapping(
     isl::ctx ctx,
     const ScheduleTreeMapping::Mapping& mapping)

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -124,13 +124,20 @@ std::unique_ptr<ScheduleTreeSet> ScheduleTreeSet::make(
 }
 
 std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::make(
-    isl::multi_union_pw_aff mupa) {
+    isl::multi_union_pw_aff mupa,
+    bool permutable,
+    std::vector<bool> coincident,
+    std::vector<bool> unroll,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  TC_CHECK_EQ(static_cast<size_t>(mupa.size()), coincident.size());
+  TC_CHECK_EQ(static_cast<size_t>(mupa.size()), unroll.size());
   isl::ctx ctx(mupa.get_ctx());
   std::unique_ptr<ScheduleTreeBand> band(new ScheduleTreeBand(ctx));
+  band->permutable_ = permutable;
   band->mupa_ = mupa.floor();
-  size_t n = band->mupa_.size();
-  band->coincident_ = vector<bool>(n, false);
-  band->unroll_ = vector<bool>(n, false);
+  band->coincident_ = coincident;
+  band->unroll_ = unroll;
+  band->appendChildren(std::move(children));
   return band;
 }
 

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -73,6 +73,16 @@ std::unique_ptr<ScheduleTreeFilter> ScheduleTreeFilter::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeMapping> ScheduleTreeMapping::make(
+    isl::ctx ctx,
+    const ScheduleTreeMapping::Mapping& mapping,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeMapping>(
+      new ScheduleTreeMapping(ctx, mapping));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 ScheduleTreeMapping::ScheduleTreeMapping(
     isl::ctx ctx,
     const ScheduleTreeMapping::Mapping& mapping)

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -115,6 +115,14 @@ std::unique_ptr<ScheduleTreeSequence> ScheduleTreeSequence::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeSet> ScheduleTreeSet::make(
+    isl::ctx ctx,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeSet>(new ScheduleTreeSet(ctx));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::fromMultiUnionPwAff(
     isl::multi_union_pw_aff mupa) {
   isl::ctx ctx(mupa.get_ctx());

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -175,6 +175,14 @@ std::unique_ptr<ScheduleTreeSet> ScheduleTreeSet::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeSet> ScheduleTreeSet::make(
+    const ScheduleTreeSet* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeSet>(new ScheduleTreeSet(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::make(
     isl::multi_union_pw_aff mupa,
     bool permutable,

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -64,6 +64,15 @@ std::unique_ptr<ScheduleTreeExtension> ScheduleTreeExtension::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeFilter> ScheduleTreeFilter::make(
+    isl::union_set filter,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res =
+      std::unique_ptr<ScheduleTreeFilter>(new ScheduleTreeFilter(filter));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::fromMultiUnionPwAff(
     isl::multi_union_pw_aff mupa) {
   isl::ctx ctx(mupa.get_ctx());

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -201,6 +201,14 @@ std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::make(
   return band;
 }
 
+std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::make(
+    const ScheduleTreeBand* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeBand>(new ScheduleTreeBand(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 // Return the number of scheduling dimensions in the band
 size_t ScheduleTreeBand::nMember() const {
   size_t res = mupa_.size();

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -46,6 +46,15 @@ std::unique_ptr<ScheduleTreeContext> ScheduleTreeContext::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeDomain> ScheduleTreeDomain::make(
+    isl::union_set domain,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res =
+      std::unique_ptr<ScheduleTreeDomain>(new ScheduleTreeDomain(domain));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::fromMultiUnionPwAff(
     isl::multi_union_pw_aff mupa) {
   isl::ctx ctx(mupa.get_ctx());

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -55,6 +55,15 @@ std::unique_ptr<ScheduleTreeDomain> ScheduleTreeDomain::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeExtension> ScheduleTreeExtension::make(
+    isl::union_map extension,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res = std::unique_ptr<ScheduleTreeExtension>(
+      new ScheduleTreeExtension(extension));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::fromMultiUnionPwAff(
     isl::multi_union_pw_aff mupa) {
   isl::ctx ctx(mupa.get_ctx());

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -81,6 +81,15 @@ std::unique_ptr<ScheduleTreeExtension> ScheduleTreeExtension::make(
   return res;
 }
 
+std::unique_ptr<ScheduleTreeExtension> ScheduleTreeExtension::make(
+    const ScheduleTreeExtension* tree,
+    std::vector<ScheduleTreeUPtr>&& children) {
+  auto res =
+      std::unique_ptr<ScheduleTreeExtension>(new ScheduleTreeExtension(*tree));
+  res->appendChildren(std::move(children));
+  return res;
+}
+
 std::unique_ptr<ScheduleTreeFilter> ScheduleTreeFilter::make(
     isl::union_set filter,
     std::vector<ScheduleTreeUPtr>&& children) {

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -123,7 +123,7 @@ std::unique_ptr<ScheduleTreeSet> ScheduleTreeSet::make(
   return res;
 }
 
-std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::fromMultiUnionPwAff(
+std::unique_ptr<ScheduleTreeBand> ScheduleTreeBand::make(
     isl::multi_union_pw_aff mupa) {
   isl::ctx ctx(mupa.get_ctx());
   std::unique_ptr<ScheduleTreeBand> band(new ScheduleTreeBand(ctx));

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -297,11 +297,15 @@ struct ScheduleTreeBand : public ScheduleTree {
  * underneath the innermost band member mapped to threads.
  */
 struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
+ public:
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::ThreadSpecificMarker;
 
+ private:
   explicit ScheduleTreeThreadSpecificMarker(isl::ctx ctx)
       : ScheduleTree(ctx, {}, NodeType) {}
+
+ public:
   virtual ~ScheduleTreeThreadSpecificMarker() override {}
 
   bool operator==(const ScheduleTreeThreadSpecificMarker& other) const {
@@ -310,6 +314,10 @@ struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
   bool operator!=(const ScheduleTreeThreadSpecificMarker& other) const {
     return !(*this == other);
   }
+
+  static std::unique_ptr<ScheduleTreeThreadSpecificMarker> make(
+      isl::ctx ctx,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
 };

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -121,20 +121,28 @@ struct ScheduleTreeExtension : public ScheduleTree {
 };
 
 struct ScheduleTreeFilter : public ScheduleTree {
+ public:
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Filter;
 
+ private:
   ScheduleTreeFilter() = delete;
-  ScheduleTreeFilter(const ScheduleTreeFilter& eb)
-      : ScheduleTree(eb), filter_(eb.filter_) {}
   explicit ScheduleTreeFilter(isl::union_set s)
       : ScheduleTree(s.get_ctx(), {}, NodeType), filter_(s) {}
+
+ public:
+  ScheduleTreeFilter(const ScheduleTreeFilter& eb)
+      : ScheduleTree(eb), filter_(eb.filter_) {}
   virtual ~ScheduleTreeFilter() override {}
 
   bool operator==(const ScheduleTreeFilter& other) const;
   bool operator!=(const ScheduleTreeFilter& other) const {
     return !(*this == other);
   }
+
+  static std::unique_ptr<ScheduleTreeFilter> make(
+      isl::union_set filter,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
 

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -72,14 +72,17 @@ struct ScheduleTreeDomain : public ScheduleTree {
   ScheduleTreeDomain() = delete;
   explicit ScheduleTreeDomain(isl::union_set us)
       : ScheduleTree(us.get_ctx(), {}, NodeType), domain_(us) {}
-
- public:
   ScheduleTreeDomain(const ScheduleTreeDomain& eb)
       : ScheduleTree(eb), domain_(eb.domain_) {}
+
+ public:
   virtual ~ScheduleTreeDomain() override {}
 
   static std::unique_ptr<ScheduleTreeDomain> make(
       isl::union_set domain,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeDomain> make(
+      const ScheduleTreeDomain* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   bool operator==(const ScheduleTreeDomain& other) const;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -162,26 +162,7 @@ struct ScheduleTreeMapping : public ScheduleTree {
   ScheduleTreeMapping() = delete;
   ScheduleTreeMapping(const ScheduleTreeMapping& eb)
       : ScheduleTree(eb), mapping(eb.mapping), filter_(eb.filter_) {}
-  ScheduleTreeMapping(isl::ctx ctx, const Mapping& mapping)
-      : ScheduleTree(ctx, {}, NodeType),
-        mapping(mapping),
-        filter_(isl::union_set()) {
-    TC_CHECK_GT(mapping.size(), 0u) << "empty mapping filter";
-
-    auto domain = mapping.cbegin()->second.domain();
-    for (auto& kvp : mapping) {
-      TC_CHECK(domain.is_equal(kvp.second.domain()));
-    }
-    filter_ = domain.universe();
-    for (auto& kvp : mapping) {
-      auto upa = kvp.second;
-      auto id = kvp.first;
-      // Create mapping filter by equating the
-      // parameter mappedIds[i] to the "i"-th affine function.
-      upa = upa.sub(isl::union_pw_aff::param_on_domain(domain.universe(), id));
-      filter_ = filter_.intersect(upa.zero_union_set());
-    }
-  }
+  ScheduleTreeMapping(isl::ctx ctx, const Mapping& mapping);
   virtual ~ScheduleTreeMapping() override {}
 
   bool operator==(const ScheduleTreeMapping& other) const;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -238,9 +238,9 @@ struct ScheduleTreeSet : public ScheduleTree {
 
  private:
   explicit ScheduleTreeSet(isl::ctx ctx) : ScheduleTree(ctx, {}, NodeType) {}
+  ScheduleTreeSet(const ScheduleTreeSet& eb) : ScheduleTree(eb) {}
 
  public:
-  ScheduleTreeSet(const ScheduleTreeSet& eb) : ScheduleTree(eb) {}
   virtual ~ScheduleTreeSet() override {}
 
   bool operator==(const ScheduleTreeSet& other) const;
@@ -250,6 +250,9 @@ struct ScheduleTreeSet : public ScheduleTree {
 
   static std::unique_ptr<ScheduleTreeSet> make(
       isl::ctx ctx,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeSet> make(
+      const ScheduleTreeSet* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -31,15 +31,23 @@ namespace polyhedral {
 namespace detail {
 
 struct ScheduleTreeContext : public ScheduleTree {
+ public:
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Context;
 
+ private:
   ScheduleTreeContext() = delete;
-  ScheduleTreeContext(const ScheduleTreeContext& eb)
-      : ScheduleTree(eb), context_(eb.context_) {}
   explicit ScheduleTreeContext(isl::set s)
       : ScheduleTree(s.get_ctx(), {}, NodeType), context_(s) {}
+
+ public:
+  ScheduleTreeContext(const ScheduleTreeContext& eb)
+      : ScheduleTree(eb), context_(eb.context_) {}
   virtual ~ScheduleTreeContext() override {}
+
+  static std::unique_ptr<ScheduleTreeContext> make(
+      isl::set context,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   bool operator==(const ScheduleTreeContext& other) const;
   bool operator!=(const ScheduleTreeContext& other) const {

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -33,69 +33,89 @@ namespace detail {
 struct ScheduleTreeContext : public ScheduleTree {
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Context;
-  isl::set context_;
+
   ScheduleTreeContext() = delete;
   ScheduleTreeContext(const ScheduleTreeContext& eb)
       : ScheduleTree(eb), context_(eb.context_) {}
   explicit ScheduleTreeContext(isl::set s)
       : ScheduleTree(s.get_ctx(), {}, NodeType), context_(s) {}
   virtual ~ScheduleTreeContext() override {}
+
   bool operator==(const ScheduleTreeContext& other) const;
   bool operator!=(const ScheduleTreeContext& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
+
+ public:
+  isl::set context_;
 };
 
 struct ScheduleTreeDomain : public ScheduleTree {
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Domain;
-  isl::union_set domain_;
+
   ScheduleTreeDomain() = delete;
   ScheduleTreeDomain(const ScheduleTreeDomain& eb)
       : ScheduleTree(eb), domain_(eb.domain_) {}
   explicit ScheduleTreeDomain(isl::union_set us)
       : ScheduleTree(us.get_ctx(), {}, NodeType), domain_(us) {}
   virtual ~ScheduleTreeDomain() override {}
+
   bool operator==(const ScheduleTreeDomain& other) const;
   bool operator!=(const ScheduleTreeDomain& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
+
+ public:
+  isl::union_set domain_;
 };
 
 struct ScheduleTreeExtension : public ScheduleTree {
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Extension;
-  isl::union_map extension_;
+
   ScheduleTreeExtension() = delete;
   ScheduleTreeExtension(const ScheduleTreeExtension& eb)
       : ScheduleTree(eb), extension_(eb.extension_) {}
   explicit ScheduleTreeExtension(isl::union_map m)
       : ScheduleTree(m.get_ctx(), {}, NodeType), extension_(m) {}
   virtual ~ScheduleTreeExtension() override {}
+
   bool operator==(const ScheduleTreeExtension& other) const;
   bool operator!=(const ScheduleTreeExtension& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
+
+ public:
+  isl::union_map extension_;
 };
 
 struct ScheduleTreeFilter : public ScheduleTree {
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Filter;
-  isl::union_set filter_;
+
   ScheduleTreeFilter() = delete;
   ScheduleTreeFilter(const ScheduleTreeFilter& eb)
       : ScheduleTree(eb), filter_(eb.filter_) {}
   explicit ScheduleTreeFilter(isl::union_set s)
       : ScheduleTree(s.get_ctx(), {}, NodeType), filter_(s) {}
   virtual ~ScheduleTreeFilter() override {}
+
   bool operator==(const ScheduleTreeFilter& other) const;
   bool operator!=(const ScheduleTreeFilter& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
+
+ public:
+  isl::union_set filter_;
 };
 
 struct ScheduleTreeMapping : public ScheduleTree {
@@ -103,8 +123,10 @@ struct ScheduleTreeMapping : public ScheduleTree {
       mapping::MappingId,
       isl::union_pw_aff,
       typename mapping::MappingId::Hash>;
+
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Mapping;
+
   ScheduleTreeMapping() = delete;
   ScheduleTreeMapping(const ScheduleTreeMapping& eb)
       : ScheduleTree(eb), mapping(eb.mapping), filter_(eb.filter_) {}
@@ -129,12 +151,15 @@ struct ScheduleTreeMapping : public ScheduleTree {
     }
   }
   virtual ~ScheduleTreeMapping() override {}
+
   bool operator==(const ScheduleTreeMapping& other) const;
   bool operator!=(const ScheduleTreeMapping& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
 
+ public:
   // Mapping from identifiers to affine functions on domain elements.
   const Mapping mapping;
   // Assignment of the affine functions to the identifiers as parameters.
@@ -144,27 +169,33 @@ struct ScheduleTreeMapping : public ScheduleTree {
 struct ScheduleTreeSequence : public ScheduleTree {
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Sequence;
+
   explicit ScheduleTreeSequence(isl::ctx ctx)
       : ScheduleTree(ctx, {}, NodeType) {}
   ScheduleTreeSequence(const ScheduleTreeSequence& eb) : ScheduleTree(eb) {}
   virtual ~ScheduleTreeSequence() override {}
+
   bool operator==(const ScheduleTreeSequence& other) const;
   bool operator!=(const ScheduleTreeSequence& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
 };
 
 struct ScheduleTreeSet : public ScheduleTree {
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Set;
+
   explicit ScheduleTreeSet(isl::ctx ctx) : ScheduleTree(ctx, {}, NodeType) {}
   ScheduleTreeSet(const ScheduleTreeSet& eb) : ScheduleTree(eb) {}
   virtual ~ScheduleTreeSet() override {}
+
   bool operator==(const ScheduleTreeSet& other) const;
   bool operator!=(const ScheduleTreeSet& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
 };
 
@@ -183,10 +214,12 @@ struct ScheduleTreeBand : public ScheduleTree {
         coincident_(eb.coincident_),
         unroll_(eb.unroll_) {}
   virtual ~ScheduleTreeBand() override {}
+
   bool operator==(const ScheduleTreeBand& other) const;
   bool operator!=(const ScheduleTreeBand& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
 
   // First replace "mupa" by its greatest integer part to ensure that the
@@ -229,15 +262,18 @@ struct ScheduleTreeBand : public ScheduleTree {
 struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::ThreadSpecificMarker;
+
   explicit ScheduleTreeThreadSpecificMarker(isl::ctx ctx)
       : ScheduleTree(ctx, {}, NodeType) {}
   virtual ~ScheduleTreeThreadSpecificMarker() override {}
+
   bool operator==(const ScheduleTreeThreadSpecificMarker& other) const {
     return true;
   }
   bool operator!=(const ScheduleTreeThreadSpecificMarker& other) const {
     return !(*this == other);
   }
+
   virtual std::ostream& write(std::ostream& os) const override;
 };
 

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -189,11 +189,15 @@ struct ScheduleTreeMapping : public ScheduleTree {
 };
 
 struct ScheduleTreeSequence : public ScheduleTree {
+ public:
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Sequence;
 
+ private:
   explicit ScheduleTreeSequence(isl::ctx ctx)
       : ScheduleTree(ctx, {}, NodeType) {}
+
+ public:
   ScheduleTreeSequence(const ScheduleTreeSequence& eb) : ScheduleTree(eb) {}
   virtual ~ScheduleTreeSequence() override {}
 
@@ -201,6 +205,10 @@ struct ScheduleTreeSequence : public ScheduleTree {
   bool operator!=(const ScheduleTreeSequence& other) const {
     return !(*this == other);
   }
+
+  static std::unique_ptr<ScheduleTreeSequence> make(
+      isl::ctx ctx,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
 };

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -261,17 +261,17 @@ struct ScheduleTreeSet : public ScheduleTree {
 struct ScheduleTreeBand : public ScheduleTree {
  private:
   explicit ScheduleTreeBand(isl::ctx ctx) : ScheduleTree(ctx, {}, NodeType) {}
-
- public:
-  static constexpr detail::ScheduleTreeType NodeType =
-      detail::ScheduleTreeType::Band;
-
   ScheduleTreeBand(const ScheduleTreeBand& eb)
       : ScheduleTree(eb),
         permutable_(eb.permutable_),
         mupa_(eb.mupa_),
         coincident_(eb.coincident_),
         unroll_(eb.unroll_) {}
+
+ public:
+  static constexpr detail::ScheduleTreeType NodeType =
+      detail::ScheduleTreeType::Band;
+
   virtual ~ScheduleTreeBand() override {}
 
   bool operator==(const ScheduleTreeBand& other) const;
@@ -289,6 +289,9 @@ struct ScheduleTreeBand : public ScheduleTree {
       bool permutable,
       std::vector<bool> coincident,
       std::vector<bool> unroll,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeBand> make(
+      const ScheduleTreeBand* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   // Return the number of scheduling dimensions in the band

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -61,15 +61,23 @@ struct ScheduleTreeContext : public ScheduleTree {
 };
 
 struct ScheduleTreeDomain : public ScheduleTree {
+ public:
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Domain;
 
+ private:
   ScheduleTreeDomain() = delete;
-  ScheduleTreeDomain(const ScheduleTreeDomain& eb)
-      : ScheduleTree(eb), domain_(eb.domain_) {}
   explicit ScheduleTreeDomain(isl::union_set us)
       : ScheduleTree(us.get_ctx(), {}, NodeType), domain_(us) {}
+
+ public:
+  ScheduleTreeDomain(const ScheduleTreeDomain& eb)
+      : ScheduleTree(eb), domain_(eb.domain_) {}
   virtual ~ScheduleTreeDomain() override {}
+
+  static std::unique_ptr<ScheduleTreeDomain> make(
+      isl::union_set domain,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   bool operator==(const ScheduleTreeDomain& other) const;
   bool operator!=(const ScheduleTreeDomain& other) const {

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -264,8 +264,7 @@ struct ScheduleTreeBand : public ScheduleTree {
   // schedule is always integral.
   // The band is not marked permutable, the dimensions are not marked
   // coincident and are not marked for unrolling.
-  static std::unique_ptr<ScheduleTreeBand> fromMultiUnionPwAff(
-      isl::multi_union_pw_aff mupa);
+  static std::unique_ptr<ScheduleTreeBand> make(isl::multi_union_pw_aff mupa);
 
   // Return the number of scheduling dimensions in the band
   size_t nMember() const;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -214,10 +214,14 @@ struct ScheduleTreeSequence : public ScheduleTree {
 };
 
 struct ScheduleTreeSet : public ScheduleTree {
+ public:
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Set;
 
+ private:
   explicit ScheduleTreeSet(isl::ctx ctx) : ScheduleTree(ctx, {}, NodeType) {}
+
+ public:
   ScheduleTreeSet(const ScheduleTreeSet& eb) : ScheduleTree(eb) {}
   virtual ~ScheduleTreeSet() override {}
 
@@ -225,6 +229,10 @@ struct ScheduleTreeSet : public ScheduleTree {
   bool operator!=(const ScheduleTreeSet& other) const {
     return !(*this == other);
   }
+
+  static std::unique_ptr<ScheduleTreeSet> make(
+      isl::ctx ctx,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
 };

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -151,6 +151,7 @@ struct ScheduleTreeFilter : public ScheduleTree {
 };
 
 struct ScheduleTreeMapping : public ScheduleTree {
+ public:
   using Mapping = std::unordered_map<
       mapping::MappingId,
       isl::union_pw_aff,
@@ -159,16 +160,24 @@ struct ScheduleTreeMapping : public ScheduleTree {
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Mapping;
 
+ private:
   ScheduleTreeMapping() = delete;
+  ScheduleTreeMapping(isl::ctx ctx, const Mapping& mapping);
+
+ public:
   ScheduleTreeMapping(const ScheduleTreeMapping& eb)
       : ScheduleTree(eb), mapping(eb.mapping), filter_(eb.filter_) {}
-  ScheduleTreeMapping(isl::ctx ctx, const Mapping& mapping);
   virtual ~ScheduleTreeMapping() override {}
 
   bool operator==(const ScheduleTreeMapping& other) const;
   bool operator!=(const ScheduleTreeMapping& other) const {
     return !(*this == other);
   }
+
+  static std::unique_ptr<ScheduleTreeMapping> make(
+      isl::ctx ctx,
+      const Mapping& mapping,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
 

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -58,6 +58,9 @@ struct ScheduleTreeContext : public ScheduleTree {
   }
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 
  public:
   isl::set context_;
@@ -91,6 +94,9 @@ struct ScheduleTreeDomain : public ScheduleTree {
   }
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 
  public:
   isl::union_set domain_;
@@ -124,6 +130,9 @@ struct ScheduleTreeExtension : public ScheduleTree {
   }
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 
  public:
   isl::union_map extension_;
@@ -157,6 +166,9 @@ struct ScheduleTreeFilter : public ScheduleTree {
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 
  public:
   isl::union_set filter_;
@@ -195,6 +207,9 @@ struct ScheduleTreeMapping : public ScheduleTree {
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 
  public:
   // Mapping from identifiers to affine functions on domain elements.
@@ -229,6 +244,9 @@ struct ScheduleTreeSequence : public ScheduleTree {
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 };
 
 struct ScheduleTreeSet : public ScheduleTree {
@@ -256,6 +274,9 @@ struct ScheduleTreeSet : public ScheduleTree {
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 };
 
 struct ScheduleTreeBand : public ScheduleTree {
@@ -280,6 +301,9 @@ struct ScheduleTreeBand : public ScheduleTree {
   }
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 
   // Make a schedule node band from partial schedule.
   // Replace "mupa" by its greatest integer part to ensure that the
@@ -353,6 +377,9 @@ struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;
+  virtual ScheduleTreeUPtr clone() const override {
+    return make(this);
+  }
 };
 
 bool elemEquals(

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -91,15 +91,23 @@ struct ScheduleTreeDomain : public ScheduleTree {
 };
 
 struct ScheduleTreeExtension : public ScheduleTree {
+ public:
   static constexpr detail::ScheduleTreeType NodeType =
       detail::ScheduleTreeType::Extension;
 
+ private:
   ScheduleTreeExtension() = delete;
-  ScheduleTreeExtension(const ScheduleTreeExtension& eb)
-      : ScheduleTree(eb), extension_(eb.extension_) {}
   explicit ScheduleTreeExtension(isl::union_map m)
       : ScheduleTree(m.get_ctx(), {}, NodeType), extension_(m) {}
+
+ public:
+  ScheduleTreeExtension(const ScheduleTreeExtension& eb)
+      : ScheduleTree(eb), extension_(eb.extension_) {}
   virtual ~ScheduleTreeExtension() override {}
+
+  static std::unique_ptr<ScheduleTreeExtension> make(
+      isl::union_map extension,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   bool operator==(const ScheduleTreeExtension& other) const;
   bool operator!=(const ScheduleTreeExtension& other) const {

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -105,14 +105,17 @@ struct ScheduleTreeExtension : public ScheduleTree {
   ScheduleTreeExtension() = delete;
   explicit ScheduleTreeExtension(isl::union_map m)
       : ScheduleTree(m.get_ctx(), {}, NodeType), extension_(m) {}
-
- public:
   ScheduleTreeExtension(const ScheduleTreeExtension& eb)
       : ScheduleTree(eb), extension_(eb.extension_) {}
+
+ public:
   virtual ~ScheduleTreeExtension() override {}
 
   static std::unique_ptr<ScheduleTreeExtension> make(
       isl::union_map extension,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeExtension> make(
+      const ScheduleTreeExtension* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   bool operator==(const ScheduleTreeExtension& other) const;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -332,6 +332,8 @@ struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
  private:
   explicit ScheduleTreeThreadSpecificMarker(isl::ctx ctx)
       : ScheduleTree(ctx, {}, NodeType) {}
+  ScheduleTreeThreadSpecificMarker(const ScheduleTreeThreadSpecificMarker& tree)
+      : ScheduleTree(tree) {}
 
  public:
   virtual ~ScheduleTreeThreadSpecificMarker() override {}
@@ -345,6 +347,9 @@ struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
 
   static std::unique_ptr<ScheduleTreeThreadSpecificMarker> make(
       isl::ctx ctx,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeThreadSpecificMarker> make(
+      const ScheduleTreeThreadSpecificMarker* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -260,11 +260,15 @@ struct ScheduleTreeBand : public ScheduleTree {
 
   virtual std::ostream& write(std::ostream& os) const override;
 
-  // First replace "mupa" by its greatest integer part to ensure that the
+  // Make a schedule node band from partial schedule.
+  // Replace "mupa" by its greatest integer part to ensure that the
   // schedule is always integral.
-  // The band is not marked permutable, the dimensions are not marked
-  // coincident and are not marked for unrolling.
-  static std::unique_ptr<ScheduleTreeBand> make(isl::multi_union_pw_aff mupa);
+  static std::unique_ptr<ScheduleTreeBand> make(
+      isl::multi_union_pw_aff mupa,
+      bool permutable,
+      std::vector<bool> coincident,
+      std::vector<bool> unroll,
+      std::vector<ScheduleTreeUPtr>&& children = {});
 
   // Return the number of scheduling dimensions in the band
   size_t nMember() const;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -138,10 +138,10 @@ struct ScheduleTreeFilter : public ScheduleTree {
   ScheduleTreeFilter() = delete;
   explicit ScheduleTreeFilter(isl::union_set s)
       : ScheduleTree(s.get_ctx(), {}, NodeType), filter_(s) {}
-
- public:
   ScheduleTreeFilter(const ScheduleTreeFilter& eb)
       : ScheduleTree(eb), filter_(eb.filter_) {}
+
+ public:
   virtual ~ScheduleTreeFilter() override {}
 
   bool operator==(const ScheduleTreeFilter& other) const;
@@ -151,6 +151,9 @@ struct ScheduleTreeFilter : public ScheduleTree {
 
   static std::unique_ptr<ScheduleTreeFilter> make(
       isl::union_set filter,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeFilter> make(
+      const ScheduleTreeFilter* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -175,10 +175,10 @@ struct ScheduleTreeMapping : public ScheduleTree {
  private:
   ScheduleTreeMapping() = delete;
   ScheduleTreeMapping(isl::ctx ctx, const Mapping& mapping);
-
- public:
   ScheduleTreeMapping(const ScheduleTreeMapping& eb)
       : ScheduleTree(eb), mapping(eb.mapping), filter_(eb.filter_) {}
+
+ public:
   virtual ~ScheduleTreeMapping() override {}
 
   bool operator==(const ScheduleTreeMapping& other) const;
@@ -189,6 +189,9 @@ struct ScheduleTreeMapping : public ScheduleTree {
   static std::unique_ptr<ScheduleTreeMapping> make(
       isl::ctx ctx,
       const Mapping& mapping,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeMapping> make(
+      const ScheduleTreeMapping* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -211,9 +211,9 @@ struct ScheduleTreeSequence : public ScheduleTree {
  private:
   explicit ScheduleTreeSequence(isl::ctx ctx)
       : ScheduleTree(ctx, {}, NodeType) {}
+  ScheduleTreeSequence(const ScheduleTreeSequence& eb) : ScheduleTree(eb) {}
 
  public:
-  ScheduleTreeSequence(const ScheduleTreeSequence& eb) : ScheduleTree(eb) {}
   virtual ~ScheduleTreeSequence() override {}
 
   bool operator==(const ScheduleTreeSequence& other) const;
@@ -223,6 +223,9 @@ struct ScheduleTreeSequence : public ScheduleTree {
 
   static std::unique_ptr<ScheduleTreeSequence> make(
       isl::ctx ctx,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeSequence> make(
+      const ScheduleTreeSequence* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   virtual std::ostream& write(std::ostream& os) const override;

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -39,14 +39,17 @@ struct ScheduleTreeContext : public ScheduleTree {
   ScheduleTreeContext() = delete;
   explicit ScheduleTreeContext(isl::set s)
       : ScheduleTree(s.get_ctx(), {}, NodeType), context_(s) {}
-
- public:
   ScheduleTreeContext(const ScheduleTreeContext& eb)
       : ScheduleTree(eb), context_(eb.context_) {}
+
+ public:
   virtual ~ScheduleTreeContext() override {}
 
   static std::unique_ptr<ScheduleTreeContext> make(
       isl::set context,
+      std::vector<ScheduleTreeUPtr>&& children = {});
+  static std::unique_ptr<ScheduleTreeContext> make(
+      const ScheduleTreeContext* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
   bool operator==(const ScheduleTreeContext& other) const;


### PR DESCRIPTION
To enforce the memory model, schedule tree nodes should not be constructed on stack but only wrapped in unique pointers.  Make the (non-copy) constructors of the ScheduleTree* classes private and provide ScheduleTree*::make functions that return unique pointers.

@skimo-openhub @nicolasvasilache do you prefer separate commits for each class or one commit with all classes?  Changes are _mostly_ identical.