### PR TITLE
schedule_print.cc: drop dead code

### DIFF
--- a/tc/core/polyhedral/schedule_print.cc
+++ b/tc/core/polyhedral/schedule_print.cc
@@ -87,26 +87,6 @@ ostream_joiner make_ostream_joiner(std::ostream& os, const char* delimiter) {
 
 } // namespace
 
-std::ostream& operator<<(std::ostream& os, isl::ast_loop_type lt) {
-  WS w;
-  os << "type(";
-  if (lt == isl::ast_loop_type::error) {
-    os << "error";
-  } else if (lt == isl::ast_loop_type::_default) {
-    os << "default";
-  } else if (lt == isl::ast_loop_type::atomic) {
-    os << "atomic";
-  } else if (lt == isl::ast_loop_type::unroll) {
-    os << "unroll";
-  } else if (lt == isl::ast_loop_type::separate) {
-    os << "separate";
-  } else {
-    LOG(FATAL) << "NYI: print type: " << static_cast<int>(lt);
-  }
-  os << ")";
-  return os;
-}
-
 std::ostream& operator<<(std::ostream& os, detail::ScheduleTreeType nt) {
   WS w;
   os << w.tab() << "type(";

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -246,7 +246,6 @@ bool elemEquals(
     const ScheduleTree* e2,
     detail::ScheduleTreeType type);
 
-std::ostream& operator<<(std::ostream& os, isl::ast_loop_type lt);
 std::ostream& operator<<(std::ostream& os, detail::ScheduleTreeType nt);
 std::ostream& operator<<(
     std::ostream& os,


### PR DESCRIPTION
Some prehistoric representation of TC schedule trees
used to needlessly keep track of an isl::ast_loop_type field.
The printing function was left in by mistake when this field was removed.