### PR TITLE
Add a primitive CPU mapper

### DIFF
--- a/tc/core/CMakeLists.txt
+++ b/tc/core/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(
 
   polyhedral/codegen_llvm.cc
   polyhedral/llvm_jit.cc
+  polyhedral/cpu/mapped_scop.cc
 )
 target_include_directories(tc_core_cpu PUBLIC ${LLVM_INCLUDE_DIRS})
 target_link_libraries(

--- a/tc/core/polyhedral/codegen_llvm.cc
+++ b/tc/core/polyhedral/codegen_llvm.cc
@@ -57,9 +57,6 @@ using IteratorMapType = std::unordered_map<std::string, isl::ast_expr>;
 using IteratorMapsType =
     std::unordered_map<isl::id, IteratorMapType, isl::IslIdIslHash>;
 
-using IteratorLLVMValueMapType =
-    std::unordered_map<isl::id, llvm::Value*, isl::IslIdIslHash>;
-
 using StmtSubscriptExprMapType =
     std::unordered_map<isl::id, std::vector<isl::ast_expr>, isl::IslIdIslHash>;
 
@@ -458,8 +455,6 @@ class LLVMCodegen {
   }
 
   llvm::BasicBlock* emitFor(isl::ast_node_for node) {
-    IteratorLLVMValueMapType iterPHIs;
-
     auto* incoming = halide_cg.get_builder().GetInsertBlock();
     auto* function = incoming->getParent();
     auto* headerBB = llvm::BasicBlock::Create(llvmCtx, "loop_header", function);

--- a/tc/core/polyhedral/codegen_llvm.cc
+++ b/tc/core/polyhedral/codegen_llvm.cc
@@ -88,7 +88,8 @@ std::vector<int64_t> getTensorSizesWithoutLeadingDim(
   for (int d = 1; d < dims; ++d) {
     Halide::Expr extent = t.parameter().extent_constraint(d);
     TC_CHECK(extent.defined())
-        << "Undefined extent on input/output tensor. Forward bounds inference should have set these\n";
+        << "Undefined extent on input/output tensor. "
+        << "Forward bounds inference should have set these\n";
     sizes.push_back(getTensorSize(context, extent));
   }
   return sizes;

--- a/tc/core/polyhedral/cpu/mapped_scop.cc
+++ b/tc/core/polyhedral/cpu/mapped_scop.cc
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tc/core/polyhedral/cpu/mapped_scop.h"
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_set>
+
+#include "tc/core/check.h"
+#include "tc/core/flags.h"
+#include "tc/core/functional.h"
+#include "tc/core/polyhedral/codegen_llvm.h"
+#include "tc/core/polyhedral/exceptions.h"
+#include "tc/core/polyhedral/llvm_jit.h"
+#include "tc/core/polyhedral/schedule_transforms.h"
+#include "tc/core/polyhedral/schedule_utils.h"
+#include "tc/core/polyhedral/scop.h"
+
+#include <glog/logging.h>
+
+namespace tc {
+namespace polyhedral {
+
+std::unique_ptr<Jit> MappedScop::codegen(
+    const std::string& specializedName) const {
+  std::unique_ptr<Jit> jit(new Jit());
+  jit->codegenScop(specializedName, *scop_);
+  return jit;
+}
+
+std::unique_ptr<MappedScop> MappedScop::makeSequential(
+    std::unique_ptr<Scop>&& scopUPtr,
+    const CpuMappingOptions& cpuOptions) {
+  using namespace polyhedral::detail;
+
+  const auto& generic = cpuOptions.generic;
+  auto mappedScop = std::unique_ptr<MappedScop>(
+      new MappedScop(std::move(scopUPtr), generic.proto.unroll()));
+  auto& scop = mappedScop->scop_;
+
+  // 1a. Optionally specialize before scheduling...
+  if (generic.proto.fix_parameters_before_scheduling()) {
+    scop->specializeToContext();
+  }
+
+  // 2. Schedule
+  scop = Scop::makeScheduled(*scop, generic.outerScheduleOptions);
+
+  // 3. Tile
+  TC_CHECK_LT(0u, generic.tiling.size())
+      << "Must pass tile vector with >= 1 tile sizes";
+  auto outerBand = scop->tileOuterBand(generic.tiling);
+
+  // 4. Optionally reschedule if point loops need a different strategy than
+  // tile loops
+  if (generic.outerScheduleOptions != generic.intraTileScheduleOptions) {
+    scop->reschedule(outerBand->child({0}), generic.intraTileScheduleOptions);
+    LOG_IF(INFO, FLAGS_debug_tc_mapper)
+        << "After intra-tile rescheduling:" << std::endl
+        << *mappedScop->schedule();
+  }
+
+  // 1b. ...or after rescheduling
+  if (!generic.proto.fix_parameters_before_scheduling()) {
+    scop->specializeToContext();
+  }
+
+  LOG_IF(INFO, FLAGS_debug_tc_mapper)
+      << "After sequential strategy:" << std::endl
+      << *mappedScop->schedule();
+
+  return mappedScop;
+}
+
+} // namespace polyhedral
+} // namespace tc

--- a/tc/core/polyhedral/cpu/mapped_scop.h
+++ b/tc/core/polyhedral/cpu/mapped_scop.h
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "tc/core/cpu/cpu_mapping_options.h"
+#include "tc/core/polyhedral/llvm_jit.h"
+#include "tc/core/polyhedral/scop.h"
+#include "tc/core/tensor.h"
+#include "tc/external/isl.h"
+
+namespace tc {
+namespace polyhedral {
+
+class MappedScop {
+ private:
+  MappedScop(std::unique_ptr<Scop>&& scop, uint64_t unroll_)
+      : scop_(std::move(scop)), unroll(unroll_) {}
+
+ public:
+  static std::unique_ptr<MappedScop> makeSequential(
+      std::unique_ptr<Scop>&& scopUPtr,
+      const CpuMappingOptions& mappingOptions);
+
+  // Fix the values of the specified parameters in the context
+  // to the corresponding specified values.
+  template <typename T>
+  void fixParameters(const std::unordered_map<std::string, T>& sizes) {
+    scop_->fixParameters(sizes);
+  }
+
+  // Generate code at the current state of transformation provided a
+  // name for the generated function.
+  std::unique_ptr<Jit> codegen(const std::string& specializedName) const;
+
+  // Accessors..
+  // Const accessor to schedule of underlying Scop.
+  inline const detail::ScheduleTree* schedule() const {
+    return scop_->scheduleRoot();
+  }
+  // Reference to underlying scop, no ownership transfer intended.
+  inline const Scop& scop() const {
+    return *scop_;
+  }
+  inline Scop& scop() {
+    return *scop_;
+  }
+
+ private:
+  std::unique_ptr<Scop> scop_;
+
+ public:
+  const uint64_t unroll;
+};
+} // namespace polyhedral
+} // namespace tc

--- a/tc/core/polyhedral/llvm_jit.cc
+++ b/tc/core/polyhedral/llvm_jit.cc
@@ -34,41 +34,6 @@
 
 using namespace llvm;
 
-// Parse through ldconfig to find the path of a particular
-// shared library. This is an unfortunate way to have to
-// find it, but I couldn't immediately find something in
-// imported libraries that would resolve this for us.
-std::string find_library_path(std::string library) {
-  std::string command = "ldconfig -p | grep " + library + " | grep x86-64";
-
-  FILE* fpipe = popen(command.c_str(), "r");
-
-  if (fpipe == nullptr) {
-    throw std::runtime_error("Failed to popen()");
-  }
-
-  std::string output;
-  char buffer[512];
-
-  while (1) {
-    int charactersRead = fread(buffer, 1, sizeof(buffer), fpipe);
-    if (charactersRead == 0)
-      break;
-    output += std::string(buffer, charactersRead);
-  }
-  pclose(fpipe);
-
-  auto idx = output.rfind("=> ");
-  if (idx == std::string::npos) {
-    throw std::runtime_error("Failed locate library: " + library);
-  }
-  output = output.substr(idx + 3);
-  if (output.length() > 0 && output[output.length() - 1] == '\n') {
-    output = output.substr(0, output.length() - 1);
-  }
-  return output;
-}
-
 namespace tc {
 
 #if LLVM_VERSION_MAJOR <= 6
@@ -77,15 +42,7 @@ Jit::Jit()
     : TM_(EngineBuilder().selectTarget()),
       DL_(TM_->createDataLayout()),
       objectLayer_([]() { return std::make_shared<SectionMemoryManager>(); }),
-      compileLayer_(objectLayer_, orc::SimpleCompiler(*TM_)) {
-  std::string err;
-
-  auto path = find_library_path("libcilkrts.so");
-  sys::DynamicLibrary::LoadLibraryPermanently(path.c_str(), &err);
-  if (err != "") {
-    throw std::runtime_error("Failed to find cilkrts: " + err);
-  }
-}
+      compileLayer_(objectLayer_, orc::SimpleCompiler(*TM_)) {}
 
 void Jit::addModule(std::shared_ptr<Module> M) {
   M->setTargetTriple(TM_->getTargetTriple().str());

--- a/test/test_mapper_llvm.cc
+++ b/test/test_mapper_llvm.cc
@@ -50,14 +50,20 @@ def fun(float(N, M) A, float(N, M) B) -> (C) {
 
   Jit jit;
   jit.codegenScop("kernel_anon", *scop);
-  auto fptr =
-      (void (*)(float*, float*, float*))jit.getSymbolAddress("kernel_anon");
+  auto fptr = reinterpret_cast<void (*)(float*, float*, float*, int, int)>(
+      jit.getSymbolAddress("kernel_anon"));
 
   at::Tensor A = at::CPU(at::kFloat).rand({N, M});
   at::Tensor B = at::CPU(at::kFloat).rand({N, M});
   at::Tensor C = at::CPU(at::kFloat).rand({N, M});
   at::Tensor Cc = A + B;
-  fptr(A.data<float>(), B.data<float>(), C.data<float>());
+  auto orderedParameters = scop->getParameterValues();
+  fptr(
+      A.data<float>(),
+      B.data<float>(),
+      C.data<float>(),
+      orderedParameters[0],
+      orderedParameters[1]);
 
   checkRtol(Cc - C, {A, B}, N * M);
 }
@@ -96,8 +102,19 @@ TEST(LLVMCodegen, MultiStmt) {
 
   Jit jit;
   jit.codegenScop("kernel_anon", *scop);
-  auto fptr = (void (*)(float*, float*, float*, float*, float*, float*, float*))
-                  jit.getSymbolAddress("kernel_anon");
+  auto fptr = reinterpret_cast<void (*)(
+      float*,
+      float*,
+      float*,
+      float*,
+      float*,
+      float*,
+      float*,
+      int,
+      int,
+      int,
+      int)>(jit.getSymbolAddress("kernel_anon"));
+  auto orderedParameters = scop->getParameterValues();
   fptr(
       A.data<float>(),
       B.data<float>(),
@@ -105,7 +122,11 @@ TEST(LLVMCodegen, MultiStmt) {
       D.data<float>(),
       O1.data<float>(),
       O2.data<float>(),
-      O3.data<float>());
+      O3.data<float>(),
+      orderedParameters[0],
+      orderedParameters[1],
+      orderedParameters[2],
+      orderedParameters[3]);
 
   for (int c0 = 0; c0 < N; c0 += 1) {
     for (int c1 = 0; c1 < M; c1 += 1) {
@@ -157,8 +178,17 @@ def batch_matmul(float(B, N, M) X, float(B, M, K) Y) -> (Z) {
   Jit jit;
   jit.codegenScop("batch_matmul", *scop);
   auto fptr =
-      (void (*)(float*, float*, float*))jit.getSymbolAddress("batch_matmul");
-  fptr(X.data<float>(), Y.data<float>(), Oc.data<float>());
+      reinterpret_cast<void (*)(float*, float*, float*, int, int, int, int)>(
+          jit.getSymbolAddress("batch_matmul"));
+  auto orderedParameters = scop->getParameterValues();
+  fptr(
+      X.data<float>(),
+      Y.data<float>(),
+      Oc.data<float>(),
+      orderedParameters[0],
+      orderedParameters[1],
+      orderedParameters[2],
+      orderedParameters[3]);
   checkRtol(O - Oc, {Y, X}, M, 3e-7);
 }
 
@@ -197,18 +227,37 @@ def convolution(float(N,C,H,W) I, float(O,C,KH,KW) W1, float(O) B) -> (tmp, O1)
 
   Jit jit;
   jit.codegenScop("convolution", *scop);
-  auto fptr =
-      (void (*)(float*, float*, float*, float*, float*))jit.getSymbolAddress(
-          "convolution");
+  auto fptr = reinterpret_cast<void (*)(
+      float*,
+      float*,
+      float*,
+      float*,
+      float*,
+      int,
+      int,
+      int,
+      int,
+      int,
+      int,
+      int)>(jit.getSymbolAddress("convolution"));
   at::Tensor tmp = at::CPU(at::kFloat).zeros_like(expected);
   at::Tensor output = at::CPU(at::kFloat).zeros_like(expected);
 
+  auto orderedParameters = scop->getParameterValues();
   fptr(
       I.data<float>(),
       W1.data<float>(),
       B.data<float>(),
       tmp.data<float>(),
-      output.data<float>());
+      output.data<float>(),
+      orderedParameters[0],
+      orderedParameters[1],
+      orderedParameters[2],
+      orderedParameters[3],
+      orderedParameters[4],
+      orderedParameters[5],
+      orderedParameters[6]);
+
   TC_CHECK_EQ(output.ndimension(), 4);
   checkRtol(output - expected, {I, W1, B}, C * KH * KW, 1e-6);
 }
@@ -228,7 +277,8 @@ def concat(float(M, N) A, float(M, N) B) -> (O1) {
 
   Jit jit;
   jit.codegenScop("concat", *scop);
-  auto fptr = (void (*)(float*, float*, float*))jit.getSymbolAddress("concat");
+  auto fptr = reinterpret_cast<void (*)(float*, float*, float*, int, int)>(
+      jit.getSymbolAddress("concat"));
 
   at::Tensor A = at::CPU(at::kFloat).rand({M, N});
   at::Tensor B = at::CPU(at::kFloat).rand({M, N});
@@ -241,7 +291,14 @@ def concat(float(M, N) A, float(M, N) B) -> (O1) {
       O1c[n][1][m] = B[m][n];
     }
   }
-  fptr(A.data<float>(), B.data<float>(), O1.data<float>());
+
+  auto orderedParameters = scop->getParameterValues();
+  fptr(
+      A.data<float>(),
+      B.data<float>(),
+      O1.data<float>(),
+      orderedParameters[0],
+      orderedParameters[1]);
   checkRtol(O1c - O1, {A, B}, N * M);
 }
 


### PR DESCRIPTION
This PR adds a primitive CPU mapper that only performs tiling and rescheduling.
On the path to adding this, many issues surfaced with codegen_llvm.
This PR cleans them up and simplifies a lot of the custom logic in favor of just using HalideIR -> LLVMIR.

Tests in `test_mapper_llvm` are updated to use the primitive CPU path.
Tapir is retired for now until we get a solid single thread mapper.