### PR TITLE
TuningHarness<Backend>::runOneIteration: use TC_CHECK_GT instead of CHECK_GT

### DIFF
--- a/tc/autotuner/autotuner-inl.h
+++ b/tc/autotuner/autotuner-inl.h
@@ -302,7 +302,7 @@ void TuningHarness<Backend>::runOneIteration(
         makeTensorInfoVector(outputs_.begin()->second),
         Backend::backendString(),
         1);
-    CHECK_GT(vBest.size(), 0);
+    TC_CHECK_GT(vBest.size(), 0u);
     infoPrinter << vBest[0];
     LOG_LINE_BY_LINE(INFO, ssInfo);
   }


### PR DESCRIPTION
Commit 71c013c47 (Remove best options fro autotuner and always recover
from cache, Mon Jul 23 05:09:48 2018 -0700) introduced a call
to CHECK_GT instead of the more usual TC_CHECK_GT, without
a motivation for deviating from this norm.
Use TC_CHECK_GT instead and make sure no warnings get generated
(needed for both TC_CHECK_GT and CHECK_GT).