### PR TITLE
Compiler options

### DIFF
--- a/tc/aten/aten_compiler-inl.h
+++ b/tc/aten/aten_compiler-inl.h
@@ -32,10 +32,11 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
     const std::string& tc,
     const std::string& entryPoint,
     const std::vector<at::Tensor>& inputs,
-    const typename Backend::MappingOptionsType& options) {
+    const typename Backend::MappingOptionsType& options,
+    const CompilerOptions& compilerOptions) {
   auto inputDLTensors = makeDLConstTensors(inputs);
   return tc::compile<Backend>(
-      tc, entryPoint, extractRawPtrs(inputDLTensors), options);
+      tc, entryPoint, extractRawPtrs(inputDLTensors), options, compilerOptions);
 }
 
 template <typename Executor>

--- a/tc/aten/aten_compiler.h
+++ b/tc/aten/aten_compiler.h
@@ -22,6 +22,7 @@
 #include "tc/aten/aten.h"
 #include "tc/core/tensor.h"
 #include "tc/core/utils/time.h"
+#include "tc/utils/compiler_options.h"
 
 namespace tc {
 namespace aten {

--- a/tc/aten/aten_compiler.h
+++ b/tc/aten/aten_compiler.h
@@ -58,7 +58,8 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
     const std::string& tc,
     const std::string& entryPoint,
     const std::vector<at::Tensor>& inputs,
-    const typename Backend::MappingOptionsType& options);
+    const typename Backend::MappingOptionsType& options,
+    const CompilerOptions& compilerOptions = CompilerOptions());
 
 /// Given an executor resulting from compiling a TC, run the TC and fill the
 /// outputs vector with the results. The output vector must have as many

--- a/tc/autotuner/autotuner-inl.h
+++ b/tc/autotuner/autotuner-inl.h
@@ -29,6 +29,7 @@
 #include "tc/core/tensor.h"
 #include "tc/core/utils/math.h"
 #include "tc/lang/canonicalize.h"
+#include "tc/utils/compiler_options.h"
 
 namespace tc {
 namespace autotune {
@@ -74,6 +75,9 @@ void TuningHarness<Backend>::stopAfterCurrentIteration() {
 template <typename Backend>
 template <typename SearchStrategy>
 void TuningHarness<Backend>::doCompile(SearchStrategy& searchStrategy) {
+  CompilerOptions supressWarningsOptions;
+  supressWarningsOptions.emitWarnings = false;
+
   // Atomically fetch and add the next job until there are no jobs left
   while (true) {
     auto current = currentCompilationJob_.fetch_add(1);
@@ -93,7 +97,7 @@ void TuningHarness<Backend>::doCompile(SearchStrategy& searchStrategy) {
           LOG_LINE_BY_LINE(INFO, ssInfo);
         }
         pExecutor = tc::detail::compile<Backend>(
-            tcTree_, inputs_.begin()->second, options);
+            tcTree_, inputs_.begin()->second, options, supressWarningsOptions);
         LOG_IF(INFO, FLAGS_debug_tuner) << "[COMPILE] Done compilation";
       } catch (const std::exception& e) {
         LOG(WARNING) << "[TUNER][COMPILE] failed compilation: " << e.what();

--- a/tc/autotuner/autotuner-inl.h
+++ b/tc/autotuner/autotuner-inl.h
@@ -92,8 +92,8 @@ void TuningHarness<Backend>::doCompile(SearchStrategy& searchStrategy) {
           LOG(INFO) << "[COMPILE] Start compilation @:" << current;
           LOG_LINE_BY_LINE(INFO, ssInfo);
         }
-        pExecutor =
-            tc::compile<Backend>(tcTree_, inputs_.begin()->second, options);
+        pExecutor = tc::detail::compile<Backend>(
+            tcTree_, inputs_.begin()->second, options);
         LOG_IF(INFO, FLAGS_debug_tuner) << "[COMPILE] Done compilation";
       } catch (const std::exception& e) {
         LOG(WARNING) << "[TUNER][COMPILE] failed compilation: " << e.what();

--- a/tc/core/compiler-inl.h
+++ b/tc/core/compiler-inl.h
@@ -55,8 +55,8 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
 
   auto inputsInfo = makeTensorInfoVector(inputs);
   auto outputsInfo = detail::inferOutputTensorInfo(tcDefinition, inputs);
-  auto halideComponents =
-      tc2halide::translate(isl::with_exceptions::globalIslCtx(), tcDefinition);
+  auto halideComponents = tc2halide::translate(
+      isl::with_exceptions::globalIslCtx(), tcDefinition, CompilerOptions());
   detail::checkInputsCompliant(halideComponents, inputs);
 
   auto tcName = lang::Def(tcDefinition).name().name();

--- a/tc/core/compiler-inl.h
+++ b/tc/core/compiler-inl.h
@@ -41,9 +41,10 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
   auto parsedTcs = detail::parse(tc);
   TC_CHECK_EQ(parsedTcs.count(entryPoint), 1u)
       << "attempting to access undefined function " << entryPoint;
-  return compile<Backend>(parsedTcs[entryPoint], inputs, options);
+  return detail::compile<Backend>(parsedTcs[entryPoint], inputs, options);
 }
 
+namespace detail {
 template <typename Backend>
 std::unique_ptr<typename Backend::ExecutorType> compile(
     lang::TreeRef tcDefinition,
@@ -69,4 +70,5 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
       new typename Backend::ExecutorType(
           inputsInfo, outputsInfo, halideComponents, compilationResult));
 }
+} // namespace detail
 } // namespace tc

--- a/tc/core/compiler.cc
+++ b/tc/core/compiler.cc
@@ -24,16 +24,19 @@
 #include "tc/core/halide_utils.h"
 #include "tc/core/tensor.h"
 #include "tc/lang/canonicalize.h"
+#include "tc/utils/compiler_options.h"
 
 namespace tc {
 std::vector<TensorInfo> inferOutputTensorInfo(
     const std::string& tc,
     const std::string& entryPoint,
-    const std::vector<const DLConstTensor*> inputs) {
+    const std::vector<const DLConstTensor*> inputs,
+    const CompilerOptions& compilerOptions) {
   auto parsedTcs = detail::parse(tc);
   TC_CHECK_EQ(parsedTcs.count(entryPoint), 1u)
       << "attempting to access undefined function " << entryPoint;
-  return tc::detail::inferOutputTensorInfo(parsedTcs[entryPoint], inputs);
+  return tc::detail::inferOutputTensorInfo(
+      parsedTcs[entryPoint], inputs, compilerOptions);
 }
 
 namespace detail {
@@ -101,12 +104,11 @@ void checkInputsCompliant(
 
 std::vector<TensorInfo> inferOutputTensorInfo(
     lang::TreeRef tcDefinition,
-    const std::vector<const DLConstTensor*> inputs) {
+    const std::vector<const DLConstTensor*> inputs,
+    const CompilerOptions& compilerOptions) {
   return tc::inferOutputTensorInfo(
       tc2halide::translate(
-          isl::with_exceptions::globalIslCtx(),
-          tcDefinition,
-          CompilerOptions()),
+          isl::with_exceptions::globalIslCtx(), tcDefinition, compilerOptions),
       inputs);
 }
 

--- a/tc/core/compiler.cc
+++ b/tc/core/compiler.cc
@@ -103,7 +103,10 @@ std::vector<TensorInfo> inferOutputTensorInfo(
     lang::TreeRef tcDefinition,
     const std::vector<const DLConstTensor*> inputs) {
   return tc::inferOutputTensorInfo(
-      tc2halide::translate(isl::with_exceptions::globalIslCtx(), tcDefinition),
+      tc2halide::translate(
+          isl::with_exceptions::globalIslCtx(),
+          tcDefinition,
+          CompilerOptions()),
       inputs);
 }
 

--- a/tc/core/compiler.h
+++ b/tc/core/compiler.h
@@ -22,6 +22,7 @@
 #include "tc/core/mapping_options.h"
 #include "tc/core/tensor.h"
 #include "tc/lang/tree.h"
+#include "tc/utils/compiler_options.h"
 
 /**
  * This provides a simple functional-style C++ API with multi-backend
@@ -62,8 +63,9 @@ namespace tc {
 /// "entryPoint", this function compiles a new TcExecutor for the specified
 /// Backend. For now, contiguous output sizes are inferred given input sizes.
 /// If you need another kernel for another entryPoint or other inputs or
-//  other options then just compile another TcExecutor; because atm we fully
-/// JIT specialize on all sizes.
+/// other options then just compile another TcExecutor; because atm we fully
+/// JIT specialize on all sizes.  General compilation options (warnings, debug
+/// info) are provided in "compilerOptions".
 /// \returns a new TcExecutor on which the run method can be called to run
 /// entryPoint
 template <typename Backend>
@@ -72,7 +74,8 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
     const std::string& entryPoint,
     const std::vector<const DLConstTensor*>& inputs,
     /* TODO: in the future also pass outputs for stride and alignment info */
-    const typename Backend::MappingOptionsType& options);
+    const typename Backend::MappingOptionsType& options,
+    const CompilerOptions& compilerOptions = CompilerOptions());
 
 /// Given a TC representation as a TC + TC function name entryPoint and a list
 /// of input tensors that match the definition in the TC function definition
@@ -85,7 +88,8 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
 std::vector<TensorInfo> inferOutputTensorInfo(
     const std::string& tc,
     const std::string& entryPoint,
-    const std::vector<const DLConstTensor*> inputs);
+    const std::vector<const DLConstTensor*> inputs,
+    const CompilerOptions& compilerOptions = CompilerOptions());
 
 namespace detail {
 /// Given a TC representation, this parses the TC functions into a map of
@@ -105,7 +109,8 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
     lang::TreeRef tcDefinition,
     const std::vector<const DLConstTensor*>& inputs,
     /* TODO: in the future also pass outputs for stride and alignment info */
-    const typename Backend::MappingOptionsType& options);
+    const typename Backend::MappingOptionsType& options,
+    const CompilerOptions& compilerOptions = CompilerOptions());
 
 /// Given a TC representation as a TreeRef and a list of input tensors that
 /// match the definition in the TC function definition (in positional order),
@@ -116,7 +121,8 @@ std::unique_ptr<typename Backend::ExecutorType> compile(
 /// performing output shape validation.
 std::vector<TensorInfo> inferOutputTensorInfo(
     lang::TreeRef tcDefinition,
-    const std::vector<const DLConstTensor*> inputs);
+    const std::vector<const DLConstTensor*> inputs,
+    const CompilerOptions& compilerOptions = CompilerOptions());
 
 } // namespace detail
 } // namespace tc

--- a/tc/core/polyhedral/scop.cc
+++ b/tc/core/polyhedral/scop.cc
@@ -34,6 +34,7 @@
 #include "tc/core/polyhedral/schedule_utils.h"
 #include "tc/core/scope_guard.h"
 #include "tc/core/tc2halide.h"
+#include "tc/utils/compiler_options.h"
 
 using namespace std;
 
@@ -69,12 +70,18 @@ ScopUPtr Scop::makeScop(
   return scop;
 }
 
-ScopUPtr Scop::makeScop(isl::ctx ctx, const string& tc) {
-  return makeScop(ctx, tc2halide::translate(ctx, tc));
+ScopUPtr Scop::makeScop(
+    isl::ctx ctx,
+    const string& tc,
+    const CompilerOptions& compilerOptions) {
+  return makeScop(ctx, tc2halide::translate(ctx, tc, compilerOptions));
 }
 
-ScopUPtr Scop::makeScop(isl::ctx ctx, const lang::TreeRef& treeRef) {
-  return makeScop(ctx, tc2halide::translate(ctx, treeRef));
+ScopUPtr Scop::makeScop(
+    isl::ctx ctx,
+    const lang::TreeRef& treeRef,
+    const CompilerOptions& compilerOptions) {
+  return makeScop(ctx, tc2halide::translate(ctx, treeRef, compilerOptions));
 }
 
 isl::union_set& Scop::domainRef() {

--- a/tc/core/polyhedral/scop.h
+++ b/tc/core/polyhedral/scop.h
@@ -32,6 +32,7 @@
 #include "tc/core/tc2halide.h"
 #include "tc/core/tensor.h"
 #include "tc/external/isl.h"
+#include "tc/utils/compiler_options.h"
 
 namespace tc {
 namespace polyhedral {
@@ -56,11 +57,15 @@ struct Scop {
   // Halide IR is constructed and made a member by setting halideComponents.
   // These operations are grouped and scheduled in a halide::Stmt which becomes
   // the unit from which the scop is constructed.
-  static std::unique_ptr<Scop> makeScop(isl::ctx ctx, const std::string& tc);
+  static std::unique_ptr<Scop> makeScop(
+      isl::ctx ctx,
+      const std::string& tc,
+      const CompilerOptions& compilerOptions = CompilerOptions());
 
   static std::unique_ptr<Scop> makeScop(
       isl::ctx ctx,
-      const lang::TreeRef& treeRef);
+      const lang::TreeRef& treeRef,
+      const CompilerOptions& compilerOptions = CompilerOptions());
 
   // Clone a Scop
   static std::unique_ptr<Scop> makeScop(const Scop& scop) {

--- a/tc/core/tc2halide.cc
+++ b/tc/core/tc2halide.cc
@@ -915,7 +915,8 @@ HalideComponents translate(
     const tc::CompilerOptions& compilerOptions = tc::CompilerOptions()) {
   LOG_IF(INFO, tc::FLAGS_debug_halide) << treeRef;
   return translateDef(
-      lang::Def(lang::Sema().checkFunction(treeRef)), compilerOptions);
+      lang::Def(lang::Sema(compilerOptions).checkFunction(treeRef)),
+      compilerOptions);
 }
 
 // NOTE: there is no guarantee here that the tc string has only one def. It

--- a/tc/core/tc2halide.h
+++ b/tc/core/tc2halide.h
@@ -20,6 +20,7 @@
 #include "tc/external/isl.h"
 #include "tc/lang/tree.h"
 #include "tc/lang/tree_views.h"
+#include "tc/utils/compiler_options.h"
 
 namespace tc2halide {
 
@@ -44,15 +45,19 @@ struct HalideComponents {
 Halide::Internal::Call::ConstString kReductionUpdate = "ReductionUpdate";
 
 // Translate a TC parse tree into equivalent Halide imperative IR with
-// a naive schedule.
+// a naive schedule.  Additional options, such as how to treat warnings, are
+// passed in as "compilerOptions".
 HalideComponents translate(
     isl::ctx ctx,
     const lang::TreeRef& treeRef,
-    bool throwWarnings = false);
+    const tc::CompilerOptions& compilerOptions);
 
 // Translate TC source into equivalent Halide imperative IR with a
-// naive schedule.
-HalideComponents
-translate(isl::ctx ctx, const std::string& tc, bool throwWarnings = false);
+// naive schedule.  Additional options, such as how to treat warnings, are
+// passed in as "compilerOptions".
+HalideComponents translate(
+    isl::ctx ctx,
+    const std::string& tc,
+    const tc::CompilerOptions& compilerOptions);
 
 } // namespace tc2halide

--- a/tc/lang/error_report.h
+++ b/tc/lang/error_report.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "tc/lang/tree.h"
+#include "tc/utils/compiler_options.h"
 
 namespace lang {
 
@@ -42,8 +43,12 @@ struct ErrorReport : public std::exception {
   mutable std::string the_message;
 };
 
-inline void warn(const ErrorReport& err) {
-  std::cerr << "WARNING: " << err.what();
+inline void warn(
+    const ErrorReport& err,
+    const tc::CompilerOptions& compilerOptions = tc::CompilerOptions()) {
+  if (compilerOptions.emitWarnings) {
+    std::cerr << "WARNING: " << err.what();
+  }
 }
 
 template <typename T>

--- a/tc/lang/sema.h
+++ b/tc/lang/sema.h
@@ -170,8 +170,6 @@ static inline TreeRef match_types(TreeRef a, TreeRef b) {
 /// variable objects.
 /// - checks that input variables are readonly.
 struct Sema {
-  std::unordered_map<TreeRef, TreeRef> expr_to_type;
-
   TreeRef typeOfExpr(TreeRef ref) {
     if (expr_to_type.count(ref) == 0) {
       throw ErrorReport(ref)
@@ -706,6 +704,8 @@ struct Sema {
   // if you write to an input, using it in a range expression is no longer
   // allowed
   std::unordered_set<std::string> live_input_names;
+
+  std::unordered_map<TreeRef, TreeRef> expr_to_type;
 
   std::unordered_set<std::string> inputParameters;
   std::unordered_set<std::string> nonTemporaries;

--- a/tc/lang/sema.h
+++ b/tc/lang/sema.h
@@ -21,6 +21,7 @@
 #include "tc/lang/error_report.h"
 #include "tc/lang/tree.h"
 #include "tc/lang/tree_views.h"
+#include "tc/utils/compiler_options.h"
 
 namespace lang {
 
@@ -170,6 +171,10 @@ static inline TreeRef match_types(TreeRef a, TreeRef b) {
 /// variable objects.
 /// - checks that input variables are readonly.
 struct Sema {
+  explicit Sema(
+      const tc::CompilerOptions& compilerOptions = tc::CompilerOptions())
+      : compilerOptions(compilerOptions) {}
+
   TreeRef typeOfExpr(TreeRef ref) {
     if (expr_to_type.count(ref) == 0) {
       throw ErrorReport(ref)
@@ -556,7 +561,7 @@ struct Sema {
           << " is not pre-initialized before calling the TC function,"
           << " consider using the !-suffixed reduction operator " << tk
           << "! instead of " << tk;
-      warn(err);
+      warn(err, compilerOptions);
     }
 
     auto type = TensorType::create(
@@ -709,5 +714,8 @@ struct Sema {
 
   std::unordered_set<std::string> inputParameters;
   std::unordered_set<std::string> nonTemporaries;
+
+  // TC compilation flow options.
+  tc::CompilerOptions compilerOptions;
 };
 } // namespace lang

--- a/tc/utils/compiler_options.h
+++ b/tc/utils/compiler_options.h
@@ -32,6 +32,8 @@ class CompilerOptions {
 
   /// Print syntactic warnings.
   bool emitWarnings = true;
+  /// Treat warnings in TC to Halide conversion as exceptions.
+  bool throwWarnings = false;
 };
 
 } // namespace tc

--- a/tc/utils/compiler_options.h
+++ b/tc/utils/compiler_options.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace tc {
+
+/// Container class for TC compiler options.
+/// Unlike MappingOptions, these do not affect the behavior of the polyhedral
+/// mapper but the general flow of the TC compilation, for example whether
+/// syntax warnings should be generated when parsing TC definitions.
+///
+/// This class intends to replace the uses of flags (aka global variables)
+/// scattered around the codebae.
+class CompilerOptions {
+ public:
+  /// Explicitly-default constructor.  All member variables must have a default
+  /// assigned value.
+  CompilerOptions() = default;
+
+  /// Print syntactic warnings.
+  bool emitWarnings = true;
+};
+
+} // namespace tc

--- a/test/test_core.cc
+++ b/test/test_core.cc
@@ -32,6 +32,7 @@
 #include "tc/lang/error_report.h"
 #include "tc/library/copy.h"
 #include "tc/library/matmul.h"
+#include "tc/utils/compiler_options.h"
 
 using namespace std;
 
@@ -60,8 +61,8 @@ dtype {
 struct GenericHalideCoreTest : public ::testing::Test {
   void CheckC(const std::string& tc, const std::vector<std::string>& expected) {
     auto curPos = std::string::npos;
-    auto halide =
-        tc2halide::translate(isl::with_exceptions::globalIslCtx(), tc);
+    auto halide = tc2halide::translate(
+        isl::with_exceptions::globalIslCtx(), tc, CompilerOptions());
     auto res = tc::halideCodegenC(halide.stmt);
     for (const auto& e : expected) {
       auto newPos = res.find(e);
@@ -243,8 +244,8 @@ struct TC2Isl : public ::testing::Test {
     DLConstTensorUPtr in = makeDLConstTensor(ti);
 
     // Must reuse the same ctx or memleaks ensue!
-    tc2halide::HalideComponents comps =
-        tc2halide::translate(isl::with_exceptions::globalIslCtx(), tc);
+    tc2halide::HalideComponents comps = tc2halide::translate(
+        isl::with_exceptions::globalIslCtx(), tc, CompilerOptions());
     auto scop =
         polyhedral::Scop::makeScop(isl::with_exceptions::globalIslCtx(), comps);
     polyhedral::detail::validateSchedule(scop->scheduleRoot());

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -50,7 +50,7 @@ struct PolyhedralMapperTest : public ::testing::Test {
   std::unique_ptr<Scop> Prepare(std::string tc) {
     auto ctx = isl::with_exceptions::globalIslCtx();
     // Build the SCoP corresponding to the Tc
-    return Scop::makeScop(ctx, tc);
+    return Scop::makeScop(ctx, tc, CompilerOptions());
   }
 
   std::unique_ptr<Scop> PrepareAndJoinBands(std::string tc) {

--- a/test/test_cuda_mapper_memory_promotion.cc
+++ b/test/test_cuda_mapper_memory_promotion.cc
@@ -46,7 +46,7 @@ class TestMapper : public ::testing::Test {
       const CudaMappingOptions& mappingOptions,
       std::unordered_map<std::string, size_t> problemSizes) {
     auto ctx = isl::with_exceptions::globalIslCtx();
-    auto scop = Scop::makeScop(ctx, tc);
+    auto scop = Scop::makeScop(ctx, tc, CompilerOptions());
     scop = Scop::makeSpecializedScop(*scop, problemSizes);
     scop->specializeToContext();
     return MappedScop::makeWithOuterBlockInnerThreadStrategy(

--- a/test/test_inference.cc
+++ b/test/test_inference.cc
@@ -22,11 +22,14 @@
 
 using namespace std;
 using namespace lang;
+using tc::CompilerOptions;
 
 struct InferenceTest : public ::testing::Test {
   void Check(const string& tc, const string& expected) {
-    auto halideComponents =
-        tc2halide::translate(isl::with_exceptions::globalIslCtx(), tc, true);
+    CompilerOptions compilerOptions;
+    compilerOptions.throwWarnings = true;
+    auto halideComponents = tc2halide::translate(
+        isl::with_exceptions::globalIslCtx(), tc, compilerOptions);
 
     stringstream ss;
     // Ordered map for repro

--- a/test/test_tc2halide.cc
+++ b/test/test_tc2halide.cc
@@ -32,8 +32,8 @@ using namespace std;
 struct TC2Isl : public ::testing::Test {
   void SetUp() {}
   void Check(const string& tc) {
-    auto halide =
-        tc2halide::translate(isl::with_exceptions::globalIslCtx(), tc);
+    auto halide = tc2halide::translate(
+        isl::with_exceptions::globalIslCtx(), tc, CompilerOptions());
     auto scop = polyhedral::Scop::makeScop(
         isl::with_exceptions::globalIslCtx(), halide);
     auto scheduleHalide = scop->scheduleRoot();


### PR DESCRIPTION
    This class intends to collect TC flow options in a single object that
    can be passed around, instead of (re)setting flags.  The latter are
    essentially global variables that may or may not be initialized from
    command-line arguments.  Start populating the CompilerOptions class with
    the new "emitWarnings" option that would otherwise become a flag.  In
    future, the use of flags must be restricted to files that produce
    binaries, e.g., those containing the main() function and having explicit
    access to command-line arguments.

    CompilerOptions is located in the new "tc/utils" directory as it needs
    to be accessed by both tc_lang and tc_core libraries.  Because it's
    header-only, there is not need to build it into a separate library and
    link.  In future, other TC-generic headers, for example tc/core/check.h,
    should move to tc/utils as well.

Closes #541 
Closes #456 