### PR TITLE
accessSubscriptsAreUnrolledLoops: use isl::space::add_unnamed_tuple_ui

### DIFF
--- a/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
+++ b/tc/core/polyhedral/cuda/memory_promotion_heuristic.cc
@@ -329,8 +329,8 @@ bool accessSubscriptsAreUnrolledLoops(
       }
     }
 
-    auto space = isl::space(leaf->ctx_, 0, unrolledDims.size())
-                     .align_params(subdomain.get_space());
+    auto space =
+        subdomain.get_space().add_unnamed_tuple_ui(unrolledDims.size());
     auto unrolledDimsMupa = isl::multi_union_pw_aff(space, unrolledDims);
 
     // It is possible that no loops are unrolled, in which case


### PR DESCRIPTION
Using isl::space::add_unnamed_tuple_ui is a more natural way
of achieving the effect of the original code (which was written
before isl::space::add_unnamed_tuple_ui was made available).