### PR TITLE
ScheduleTree: replace comparison operators with named functions

### DIFF
--- a/tc/core/polyhedral/schedule_isl_conversion.cc
+++ b/tc/core/polyhedral/schedule_isl_conversion.cc
@@ -311,7 +311,7 @@ std::unique_ptr<ScheduleTree> fromIslSchedule(isl::schedule schedule) {
 // Note that the children of set and sequence nodes are always filters, so
 // they cannot be replaced by empty trees.
 bool validateSchedule(const ScheduleTree* st) {
-  return *st == *fromIslSchedule(toIslSchedule(st));
+  return st->treeEquals(fromIslSchedule(toIslSchedule(st)).get());
 }
 
 bool validateSchedule(isl::schedule sc) {

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -344,7 +344,7 @@ bool ScheduleTree::operator==(const ScheduleTree& other) const {
   if (children_.size() != other.children_.size()) {
     return false;
   }
-  if (!elemEquals(this, &other, type_)) {
+  if (!this->nodeEquals(&other)) {
     return false;
   }
   TC_CHECK(!other.as<ScheduleTreeSet>())

--- a/tc/core/polyhedral/schedule_tree.cc
+++ b/tc/core/polyhedral/schedule_tree.cc
@@ -336,21 +336,17 @@ vector<const ScheduleTree*> ScheduleTree::collectDFSPreorder(
   return functional::Filter(filterType, collectDFSPreorder(tree));
 }
 
-bool ScheduleTree::operator==(const ScheduleTree& other) const {
-  // ctx_ cmp ?
-  if (type_ != other.type_) {
+bool ScheduleTree::treeEquals(const ScheduleTree* other) const {
+  if (!nodeEquals(other)) {
     return false;
   }
-  if (children_.size() != other.children_.size()) {
+  if (numChildren() != other->numChildren()) {
     return false;
   }
-  if (!this->nodeEquals(&other)) {
-    return false;
-  }
-  TC_CHECK(!other.as<ScheduleTreeSet>())
+  TC_CHECK(!other->as<ScheduleTreeSet>())
       << "NYI: ScheduleTreeType::Set comparison";
-  for (size_t i = 0; i < children_.size(); ++i) {
-    if (*children_[i] != *other.children_[i]) {
+  for (size_t i = 0, e = numChildren(); i < e; ++i) {
+    if (!child({i})->treeEquals(other->child({i}))) {
       return false;
     }
   }

--- a/tc/core/polyhedral/schedule_tree.h
+++ b/tc/core/polyhedral/schedule_tree.h
@@ -469,6 +469,11 @@ struct ScheduleTree {
   // Note that this function does _not_ clone the child trees.
   virtual ScheduleTreeUPtr clone() const = 0;
 
+  // Compare the current node to the "other" node.
+  // Note that this function does _not_ compare the child trees,
+  // use treeEquals() instead to compare entire trees.
+  virtual bool nodeEquals(const ScheduleTree* other) const = 0;
+
   //
   // Data members
   //

--- a/tc/core/polyhedral/schedule_tree.h
+++ b/tc/core/polyhedral/schedule_tree.h
@@ -156,11 +156,6 @@ struct ScheduleTree {
  public:
   virtual ~ScheduleTree();
 
-  bool operator==(const ScheduleTree& other) const;
-  bool operator!=(const ScheduleTree& other) const {
-    return !(*this == other);
-  }
-
   // Swap a tree with with the given tree.
   void swapChild(size_t pos, ScheduleTreeUPtr& swappee) {
     TC_CHECK_GE(pos, 0u) << "position out of children bounds";
@@ -473,6 +468,10 @@ struct ScheduleTree {
   // Note that this function does _not_ compare the child trees,
   // use treeEquals() instead to compare entire trees.
   virtual bool nodeEquals(const ScheduleTree* other) const = 0;
+
+  // Comapre the subtree rooted at the current node to the subtree
+  // rooted at "other".
+  bool treeEquals(const ScheduleTree* other) const;
 
   //
   // Data members

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -364,8 +364,18 @@ bool ScheduleTreeFilter::operator==(const ScheduleTreeFilter& other) const {
 }
 
 bool ScheduleTreeMapping::operator==(const ScheduleTreeMapping& other) const {
-  auto res = filter_.is_equal(other.filter_);
-  return res;
+  if (mapping.size() != other.mapping.size()) {
+    return false;
+  }
+  for (const auto& kvp : mapping) {
+    if (other.mapping.count(kvp.first) == 0) {
+      return false;
+    }
+    if (!other.mapping.at(kvp.first).plain_is_equal(kvp.second)) {
+      return false;
+    }
+  }
+  return filter_.is_equal(other.filter_);
 }
 
 bool ScheduleTreeSequence::operator==(const ScheduleTreeSequence& other) const {

--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -385,36 +385,6 @@ bool ScheduleTreeSequence::operator==(const ScheduleTreeSequence& other) const {
 bool ScheduleTreeSet::operator==(const ScheduleTreeSet& other) const {
   return true;
 }
-
-bool elemEquals(
-    const ScheduleTree* e1,
-    const ScheduleTree* e2,
-    detail::ScheduleTreeType type) {
-#define ELEM_EQUALS_CASE(CLASS)                                              \
-  else if (type == CLASS::NodeType) {                                        \
-    return *static_cast<const CLASS*>(e1) == *static_cast<const CLASS*>(e2); \
-  }
-
-  if (type == detail::ScheduleTreeType::None) {
-    LOG(FATAL) << "Hit Error node!";
-  }
-  ELEM_EQUALS_CASE(ScheduleTreeBand)
-  ELEM_EQUALS_CASE(ScheduleTreeContext)
-  ELEM_EQUALS_CASE(ScheduleTreeDomain)
-  ELEM_EQUALS_CASE(ScheduleTreeExtension)
-  ELEM_EQUALS_CASE(ScheduleTreeFilter)
-  ELEM_EQUALS_CASE(ScheduleTreeMapping)
-  ELEM_EQUALS_CASE(ScheduleTreeSequence)
-  ELEM_EQUALS_CASE(ScheduleTreeSet)
-  else {
-    LOG(FATAL) << "NYI: ScheduleTree::operator== for type: "
-               << static_cast<int>(type);
-  }
-
-#undef ELEM_EQUALS_CASE
-
-  return false;
-}
 } // namespace detail
 } // namespace polyhedral
 } // namespace tc

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -61,6 +61,10 @@ struct ScheduleTreeContext : public ScheduleTree {
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherContext = other->as<ScheduleTreeContext>();
+    return otherContext && *this == *otherContext;
+  }
 
  public:
   isl::set context_;
@@ -96,6 +100,10 @@ struct ScheduleTreeDomain : public ScheduleTree {
   virtual std::ostream& write(std::ostream& os) const override;
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
+  }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherDomain = other->as<ScheduleTreeDomain>();
+    return otherDomain && *this == *otherDomain;
   }
 
  public:
@@ -133,6 +141,10 @@ struct ScheduleTreeExtension : public ScheduleTree {
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherExtension = other->as<ScheduleTreeExtension>();
+    return otherExtension && *this == *otherExtension;
+  }
 
  public:
   isl::union_map extension_;
@@ -168,6 +180,10 @@ struct ScheduleTreeFilter : public ScheduleTree {
   virtual std::ostream& write(std::ostream& os) const override;
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
+  }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherFilter = other->as<ScheduleTreeFilter>();
+    return otherFilter && *this == *otherFilter;
   }
 
  public:
@@ -210,6 +226,10 @@ struct ScheduleTreeMapping : public ScheduleTree {
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherMapping = other->as<ScheduleTreeMapping>();
+    return otherMapping && *this == *otherMapping;
+  }
 
  public:
   // Mapping from identifiers to affine functions on domain elements.
@@ -247,6 +267,10 @@ struct ScheduleTreeSequence : public ScheduleTree {
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherSequence = other->as<ScheduleTreeSequence>();
+    return otherSequence && *this == *otherSequence;
+  }
 };
 
 struct ScheduleTreeSet : public ScheduleTree {
@@ -277,6 +301,10 @@ struct ScheduleTreeSet : public ScheduleTree {
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherSet = other->as<ScheduleTreeSet>();
+    return otherSet && *this == *otherSet;
+  }
 };
 
 struct ScheduleTreeBand : public ScheduleTree {
@@ -303,6 +331,10 @@ struct ScheduleTreeBand : public ScheduleTree {
   virtual std::ostream& write(std::ostream& os) const override;
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
+  }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherBand = other->as<ScheduleTreeBand>();
+    return otherBand && *this == *otherBand;
   }
 
   // Make a schedule node band from partial schedule.
@@ -379,6 +411,10 @@ struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
   virtual std::ostream& write(std::ostream& os) const override;
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
+  }
+  virtual bool nodeEquals(const ScheduleTree* other) const override {
+    auto otherMarker = other->as<ScheduleTreeThreadSpecificMarker>();
+    return otherMarker && *this == *otherMarker;
   }
 };
 

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -418,11 +418,6 @@ struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
   }
 };
 
-bool elemEquals(
-    const ScheduleTree* e1,
-    const ScheduleTree* e2,
-    detail::ScheduleTreeType type);
-
 std::ostream& operator<<(std::ostream& os, detail::ScheduleTreeType nt);
 std::ostream& operator<<(
     std::ostream& os,

--- a/tc/core/polyhedral/schedule_tree_elem.h
+++ b/tc/core/polyhedral/schedule_tree_elem.h
@@ -52,19 +52,15 @@ struct ScheduleTreeContext : public ScheduleTree {
       const ScheduleTreeContext* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
-  bool operator==(const ScheduleTreeContext& other) const;
-  bool operator!=(const ScheduleTreeContext& other) const {
-    return !(*this == other);
-  }
-
   virtual std::ostream& write(std::ostream& os) const override;
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherContext = other->as<ScheduleTreeContext>();
-    return otherContext && *this == *otherContext;
+    return otherContext && nodeEquals(otherContext);
   }
+  bool nodeEquals(const ScheduleTreeContext* otherContext) const;
 
  public:
   isl::set context_;
@@ -92,19 +88,15 @@ struct ScheduleTreeDomain : public ScheduleTree {
       const ScheduleTreeDomain* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
-  bool operator==(const ScheduleTreeDomain& other) const;
-  bool operator!=(const ScheduleTreeDomain& other) const {
-    return !(*this == other);
-  }
-
   virtual std::ostream& write(std::ostream& os) const override;
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherDomain = other->as<ScheduleTreeDomain>();
-    return otherDomain && *this == *otherDomain;
+    return otherDomain && nodeEquals(otherDomain);
   }
+  bool nodeEquals(const ScheduleTreeDomain* otherDomain) const;
 
  public:
   isl::union_set domain_;
@@ -132,19 +124,15 @@ struct ScheduleTreeExtension : public ScheduleTree {
       const ScheduleTreeExtension* tree,
       std::vector<ScheduleTreeUPtr>&& children = {});
 
-  bool operator==(const ScheduleTreeExtension& other) const;
-  bool operator!=(const ScheduleTreeExtension& other) const {
-    return !(*this == other);
-  }
-
   virtual std::ostream& write(std::ostream& os) const override;
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherExtension = other->as<ScheduleTreeExtension>();
-    return otherExtension && *this == *otherExtension;
+    return otherExtension && nodeEquals(otherExtension);
   }
+  bool nodeEquals(const ScheduleTreeExtension* otherExtension) const;
 
  public:
   isl::union_map extension_;
@@ -165,11 +153,6 @@ struct ScheduleTreeFilter : public ScheduleTree {
  public:
   virtual ~ScheduleTreeFilter() override {}
 
-  bool operator==(const ScheduleTreeFilter& other) const;
-  bool operator!=(const ScheduleTreeFilter& other) const {
-    return !(*this == other);
-  }
-
   static std::unique_ptr<ScheduleTreeFilter> make(
       isl::union_set filter,
       std::vector<ScheduleTreeUPtr>&& children = {});
@@ -183,8 +166,9 @@ struct ScheduleTreeFilter : public ScheduleTree {
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherFilter = other->as<ScheduleTreeFilter>();
-    return otherFilter && *this == *otherFilter;
+    return otherFilter && nodeEquals(otherFilter);
   }
+  bool nodeEquals(const ScheduleTreeFilter* otherFilter) const;
 
  public:
   isl::union_set filter_;
@@ -209,11 +193,6 @@ struct ScheduleTreeMapping : public ScheduleTree {
  public:
   virtual ~ScheduleTreeMapping() override {}
 
-  bool operator==(const ScheduleTreeMapping& other) const;
-  bool operator!=(const ScheduleTreeMapping& other) const {
-    return !(*this == other);
-  }
-
   static std::unique_ptr<ScheduleTreeMapping> make(
       isl::ctx ctx,
       const Mapping& mapping,
@@ -228,8 +207,9 @@ struct ScheduleTreeMapping : public ScheduleTree {
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherMapping = other->as<ScheduleTreeMapping>();
-    return otherMapping && *this == *otherMapping;
+    return otherMapping && nodeEquals(otherMapping);
   }
+  bool nodeEquals(const ScheduleTreeMapping* otherMapping) const;
 
  public:
   // Mapping from identifiers to affine functions on domain elements.
@@ -251,11 +231,6 @@ struct ScheduleTreeSequence : public ScheduleTree {
  public:
   virtual ~ScheduleTreeSequence() override {}
 
-  bool operator==(const ScheduleTreeSequence& other) const;
-  bool operator!=(const ScheduleTreeSequence& other) const {
-    return !(*this == other);
-  }
-
   static std::unique_ptr<ScheduleTreeSequence> make(
       isl::ctx ctx,
       std::vector<ScheduleTreeUPtr>&& children = {});
@@ -269,8 +244,9 @@ struct ScheduleTreeSequence : public ScheduleTree {
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherSequence = other->as<ScheduleTreeSequence>();
-    return otherSequence && *this == *otherSequence;
+    return otherSequence && nodeEquals(otherSequence);
   }
+  bool nodeEquals(const ScheduleTreeSequence* otherSequence) const;
 };
 
 struct ScheduleTreeSet : public ScheduleTree {
@@ -285,11 +261,6 @@ struct ScheduleTreeSet : public ScheduleTree {
  public:
   virtual ~ScheduleTreeSet() override {}
 
-  bool operator==(const ScheduleTreeSet& other) const;
-  bool operator!=(const ScheduleTreeSet& other) const {
-    return !(*this == other);
-  }
-
   static std::unique_ptr<ScheduleTreeSet> make(
       isl::ctx ctx,
       std::vector<ScheduleTreeUPtr>&& children = {});
@@ -303,8 +274,9 @@ struct ScheduleTreeSet : public ScheduleTree {
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherSet = other->as<ScheduleTreeSet>();
-    return otherSet && *this == *otherSet;
+    return otherSet && nodeEquals(otherSet);
   }
+  bool nodeEquals(const ScheduleTreeSet* otherSet) const;
 };
 
 struct ScheduleTreeBand : public ScheduleTree {
@@ -323,19 +295,15 @@ struct ScheduleTreeBand : public ScheduleTree {
 
   virtual ~ScheduleTreeBand() override {}
 
-  bool operator==(const ScheduleTreeBand& other) const;
-  bool operator!=(const ScheduleTreeBand& other) const {
-    return !(*this == other);
-  }
-
   virtual std::ostream& write(std::ostream& os) const override;
   virtual ScheduleTreeUPtr clone() const override {
     return make(this);
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherBand = other->as<ScheduleTreeBand>();
-    return otherBand && *this == *otherBand;
+    return otherBand && nodeEquals(otherBand);
   }
+  bool nodeEquals(const ScheduleTreeBand* other) const;
 
   // Make a schedule node band from partial schedule.
   // Replace "mupa" by its greatest integer part to ensure that the
@@ -394,13 +362,6 @@ struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
  public:
   virtual ~ScheduleTreeThreadSpecificMarker() override {}
 
-  bool operator==(const ScheduleTreeThreadSpecificMarker& other) const {
-    return true;
-  }
-  bool operator!=(const ScheduleTreeThreadSpecificMarker& other) const {
-    return !(*this == other);
-  }
-
   static std::unique_ptr<ScheduleTreeThreadSpecificMarker> make(
       isl::ctx ctx,
       std::vector<ScheduleTreeUPtr>&& children = {});
@@ -414,8 +375,9 @@ struct ScheduleTreeThreadSpecificMarker : public ScheduleTree {
   }
   virtual bool nodeEquals(const ScheduleTree* other) const override {
     auto otherMarker = other->as<ScheduleTreeThreadSpecificMarker>();
-    return otherMarker && *this == *otherMarker;
+    return otherMarker && nodeEquals(otherMarker);
   }
+  bool nodeEquals(const ScheduleTreeThreadSpecificMarker* other) const;
 };
 
 std::ostream& operator<<(std::ostream& os, detail::ScheduleTreeType nt);

--- a/test/test_cuda_mapper.cc
+++ b/test/test_cuda_mapper.cc
@@ -144,8 +144,9 @@ struct PolyhedralMapperTest : public ::testing::Test {
       islNode = islNode.as<isl::schedule_node_band>().tile(mv);
       auto scheduleISL = fromIslSchedule(islNode.get_schedule().reset_user());
 
-      ASSERT_TRUE(*scheduleISL == *scheduleISLPP) << *scheduleISL << "\nVS\n"
-                                                  << *scheduleISLPP;
+      ASSERT_TRUE(scheduleISL->treeEquals(scheduleISLPP.get()))
+          << *scheduleISL << "\nVS\n"
+          << *scheduleISLPP;
     }
   }
 


### PR DESCRIPTION
Proceeding with ScheduleTree evolution plan (#553)

This PR replaces overloaded comparison operators with two functions, `nodeEquals` and `treeEquals`.  The main motivation for this change: after grafting ScheduleTreeElem* onto ScheduleTree in the inheritance structure we ended up with `operator==` comparing **subtrees** if called on ScheduleTree and **nodes** if called on instances of other classes.  I argue that the behavior of default comparison operator is _unintutitive_ for tree-like structure.  Therefore, introducing explicitly-named comparison functions that make the intention clear is an improvement.

As an additional benefit, regular member functions can be declared virtual, unlike operators.  With this approach, each subclass needs to override _one_ abstract function that does node-to-node comparison while subtree comparison is handed automatically.  Previously, it would have been necessary to also modify the clunky macro-based logic in one of the comparison operators.