### PR TITLE
do not call domain() on a set space

### DIFF
--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -253,7 +253,7 @@ void ScheduleTreeBand::drop(size_t pos, size_t n) {
 isl::multi_union_pw_aff ScheduleTreeBand::memberRange(size_t first, size_t n)
     const {
   auto list = mupa_.get_union_pw_aff_list();
-  auto space = mupa_.get_space().domain().add_unnamed_tuple_ui(n);
+  auto space = mupa_.get_space().params().add_unnamed_tuple_ui(n);
   auto end = first + n;
   TC_CHECK_LE(end, nMember());
   list = list.drop(end, nMember() - end);

--- a/tc/core/polyhedral/unroll.cc
+++ b/tc/core/polyhedral/unroll.cc
@@ -94,7 +94,7 @@ isl::val boundInstancesAndMarkUnroll(
   auto n = band->nMember();
 
   auto list = partial.get_union_pw_aff_list();
-  auto space = partial.get_space().domain();
+  auto space = partial.get_space().params();
   for (int i = n - 1; i >= 0; --i) {
     auto member = partial.get_union_pw_aff(i);
     auto outerMap = prefix;


### PR DESCRIPTION
Some more issues detected by the templated isl types.