### PR TITLE
ScheduleTreeMapping::ScheduleTreeMapping: drop redundant initialization

### DIFF
--- a/tc/core/polyhedral/schedule_tree_elem.cc
+++ b/tc/core/polyhedral/schedule_tree_elem.cc
@@ -129,9 +129,7 @@ std::unique_ptr<ScheduleTreeMapping> ScheduleTreeMapping::make(
 ScheduleTreeMapping::ScheduleTreeMapping(
     isl::ctx ctx,
     const ScheduleTreeMapping::Mapping& mapping)
-    : ScheduleTree(ctx, {}, NodeType),
-      mapping(mapping),
-      filter_(isl::union_set()) {
+    : ScheduleTree(ctx, {}, NodeType), mapping(mapping) {
   TC_CHECK_GT(mapping.size(), 0u) << "empty mapping filter";
 
   auto domain = mapping.cbegin()->second.domain();


### PR DESCRIPTION
The filter_ field was being explicitly initialized to its default value,
which is confusing, especially since the body of the constructor
performs a proper initialization of this field.