### PR TITLE
Remove Python tests from installation documentation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -140,12 +140,6 @@ Run Python smoke checks:
        python -c 'import torch'
        python -c 'import tensor_comprehensions'
 
-Run Python tests:
-
-    .. code-block:: bash
-
-       python ./test_python/test_tc.py -v
-
 At this point, if things work as expected you can venture installing as
 follows (it is always a good idea to record installed files for easy removal):
 


### PR DESCRIPTION
The file `test_python/test_tc.py` was removed in commit 516ce74, but is still
mentioned in the documentation describing the installation procedure. This patch
removes the respective section from the documentation.